### PR TITLE
add a "Use Vorbis" switch

### DIFF
--- a/lib/components/TranscodingSettingsScreen/VorbisSwitch.dart
+++ b/lib/components/TranscodingSettingsScreen/VorbisSwitch.dart
@@ -1,0 +1,34 @@
+import 'package:flutter/material.dart';
+import 'package:hive/hive.dart';
+
+import '../../services/FinampSettingsHelper.dart';
+import '../../models/FinampModels.dart';
+
+class VorbisSwitch extends StatelessWidget {
+  const VorbisSwitch({Key? key}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return ValueListenableBuilder<Box<FinampSettings>>(
+      valueListenable: FinampSettingsHelper.finampSettingsListener,
+      builder: (context, box, child) {
+        bool? useVorbis = box.get("FinampSettings")?.useVorbis;
+
+        return SwitchListTile(
+          title: const Text("Use Vorbis Codec"),
+          subtitle: const Text(
+              "If enabled, music streams will be transcoded to Vorbis and not AAC by the server."),
+          value: useVorbis ?? false,
+          onChanged: useVorbis == null
+              ? null
+              : (value) {
+                  FinampSettings finampSettingsTemp =
+                      box.get("FinampSettings")!;
+                  finampSettingsTemp.useVorbis = value;
+                  box.put("FinampSettings", finampSettingsTemp);
+                },
+        );
+      },
+    );
+  }
+}

--- a/lib/models/FinampModels.dart
+++ b/lib/models/FinampModels.dart
@@ -68,6 +68,7 @@ class FinampSettings {
         _contentGridViewCrossAxisCountLandscape,
     this.showTextOnGridView = _showTextOnGridView,
     this.sleepTimerSeconds = _sleepTimerSeconds,
+    this.useVorbis = false,
   });
 
   @HiveField(0)
@@ -122,6 +123,11 @@ class FinampSettings {
   /// doesn't come with an adapter for it by default.
   @HiveField(14, defaultValue: _sleepTimerSeconds)
   int sleepTimerSeconds;
+
+  /// Whether or not to request Vorbis as the transcoding codec.
+  /// If false, AAC will be used.
+  @HiveField(15)
+  bool useVorbis;
 
   static Future<FinampSettings> create() async {
     Directory internalSongDir = await getInternalSongDir();

--- a/lib/models/FinampModels.dart
+++ b/lib/models/FinampModels.dart
@@ -44,6 +44,7 @@ const _contentGridViewCrossAxisCountPortrait = 2;
 const _contentGridViewCrossAxisCountLandscape = 3;
 const _showTextOnGridView = true;
 const _sleepTimerSeconds = 1800; // 30 Minutes
+const _useVorbis = false;
 
 @HiveType(typeId: 28)
 class FinampSettings {
@@ -68,7 +69,7 @@ class FinampSettings {
         _contentGridViewCrossAxisCountLandscape,
     this.showTextOnGridView = _showTextOnGridView,
     this.sleepTimerSeconds = _sleepTimerSeconds,
-    this.useVorbis = false,
+    this.useVorbis = _useVorbis,
   });
 
   @HiveField(0)
@@ -126,7 +127,7 @@ class FinampSettings {
 
   /// Whether or not to request Vorbis as the transcoding codec.
   /// If false, AAC will be used.
-  @HiveField(15)
+  @HiveField(15, defaultValue: _useVorbis)
   bool useVorbis;
 
   static Future<FinampSettings> create() async {

--- a/lib/models/FinampModels.g.dart
+++ b/lib/models/FinampModels.g.dart
@@ -178,13 +178,14 @@ class FinampSettingsAdapter extends TypeAdapter<FinampSettings> {
           fields[12] == null ? 3 : fields[12] as int,
       showTextOnGridView: fields[13] == null ? true : fields[13] as bool,
       sleepTimerSeconds: fields[14] == null ? 1800 : fields[14] as int,
+      useVorbis: fields[15] == null ? false : fields[15] as bool,
     );
   }
 
   @override
   void write(BinaryWriter writer, FinampSettings obj) {
     writer
-      ..writeByte(15)
+      ..writeByte(16)
       ..writeByte(0)
       ..write(obj.isOffline)
       ..writeByte(1)
@@ -214,7 +215,9 @@ class FinampSettingsAdapter extends TypeAdapter<FinampSettings> {
       ..writeByte(13)
       ..write(obj.showTextOnGridView)
       ..writeByte(14)
-      ..write(obj.sleepTimerSeconds);
+      ..write(obj.sleepTimerSeconds)
+      ..writeByte(15)
+      ..write(obj.useVorbis);
   }
 
   @override

--- a/lib/screens/TranscodingSettingsScreen.dart
+++ b/lib/screens/TranscodingSettingsScreen.dart
@@ -1,3 +1,5 @@
+import 'dart:io';
+
 import 'package:flutter/material.dart';
 
 import '../components/TranscodingSettingsScreen/TranscodeSwitch.dart';
@@ -18,7 +20,7 @@ class TranscodingSettingsScreen extends StatelessWidget {
           children: [
             const TranscodeSwitch(),
             const BitrateSelector(),
-            const VorbisSwitch(),
+            if (!(Platform.isIOS || Platform.isMacOS)) const VorbisSwitch(),
           ],
         ),
       ),

--- a/lib/screens/TranscodingSettingsScreen.dart
+++ b/lib/screens/TranscodingSettingsScreen.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 
 import '../components/TranscodingSettingsScreen/TranscodeSwitch.dart';
 import '../components/TranscodingSettingsScreen/BitrateSelector.dart';
+import '../components/TranscodingSettingsScreen/VorbisSwitch.dart';
 
 class TranscodingSettingsScreen extends StatelessWidget {
   const TranscodingSettingsScreen({Key? key}) : super(key: key);
@@ -17,14 +18,7 @@ class TranscodingSettingsScreen extends StatelessWidget {
           children: [
             const TranscodeSwitch(),
             const BitrateSelector(),
-            Padding(
-              padding: const EdgeInsets.all(8.0),
-              child: Text(
-                "Jellyfin uses AAC for transcoding.",
-                style: Theme.of(context).textTheme.caption,
-                textAlign: TextAlign.center,
-              ),
-            ),
+            const VorbisSwitch(),
           ],
         ),
       ),

--- a/lib/services/AudioServiceHelper.dart
+++ b/lib/services/AudioServiceHelper.dart
@@ -234,6 +234,7 @@ class AudioServiceHelper {
         "shouldTranscode": FinampSettingsHelper.finampSettings.shouldTranscode,
         "downloadedSongJson": (await _getDownloadedSong(item.id))?.toJson(),
         "isOffline": FinampSettingsHelper.finampSettings.isOffline,
+        "useVorbis": FinampSettingsHelper.finampSettings.useVorbis,
         // TODO: Maybe add transcoding bitrate here?
       },
       rating: Rating.newHeartRating(item.userData?.isFavorite ?? false),

--- a/lib/services/MusicPlayerBackgroundTask.dart
+++ b/lib/services/MusicPlayerBackgroundTask.dart
@@ -524,7 +524,7 @@ class MusicPlayerBackgroundTask extends BaseAudioHandler {
         "MaxStreamingBitrate": mediaItem.extras!["shouldTranscode"]
             ? FinampSettingsHelper.finampSettings.transcodeBitrate.toString()
             : "999999999",
-        "AudioCodec": mediaItem.extras!["useVorbis"] ? "libvorbis" : "aac",
+        "AudioCodec": mediaItem.extras!["useVorbis"] ? "vorbis" : "aac",
         "TranscodingContainer": "ts",
         "TranscodingProtocol":
             mediaItem.extras!["shouldTranscode"] ? "hls" : "http",

--- a/lib/services/MusicPlayerBackgroundTask.dart
+++ b/lib/services/MusicPlayerBackgroundTask.dart
@@ -473,7 +473,8 @@ class MusicPlayerBackgroundTask extends BaseAudioHandler {
         return Future.error(
             "Offline mode enabled but downloaded song not found.");
       } else {
-        if (mediaItem.extras!["shouldTranscode"] == true) {
+        if (mediaItem.extras!["shouldTranscode"] == true &&
+            mediaItem.extras!["useVorbis"] == false) {
           return HlsAudioSource(await _songUri(mediaItem));
         } else {
           return AudioSource.uri(await _songUri(mediaItem));
@@ -527,7 +528,7 @@ class MusicPlayerBackgroundTask extends BaseAudioHandler {
         "AudioCodec": mediaItem.extras!["useVorbis"] ? "vorbis" : "aac",
         "TranscodingContainer": "ts",
         "TranscodingProtocol":
-            mediaItem.extras!["shouldTranscode"] ? "hls" : "http",
+            mediaItem.extras!["shouldTranscode"] ? (mediaItem.extras!["useVorbis"] ? "http" : "hls") : "http",
         "ApiKey": _jellyfinApiData.currentUser!.accessToken,
       },
     );

--- a/lib/services/MusicPlayerBackgroundTask.dart
+++ b/lib/services/MusicPlayerBackgroundTask.dart
@@ -524,7 +524,9 @@ class MusicPlayerBackgroundTask extends BaseAudioHandler {
         "MaxStreamingBitrate": mediaItem.extras!["shouldTranscode"]
             ? FinampSettingsHelper.finampSettings.transcodeBitrate.toString()
             : "999999999",
-        "AudioCodec": "aac",
+        "AudioCodec": mediaItem.extras!["useVorbis"]
+            ? "vorbis"
+            : "aac",
         "TranscodingContainer": "ts",
         "TranscodingProtocol":
             mediaItem.extras!["shouldTranscode"] ? "hls" : "http",

--- a/lib/services/MusicPlayerBackgroundTask.dart
+++ b/lib/services/MusicPlayerBackgroundTask.dart
@@ -524,9 +524,7 @@ class MusicPlayerBackgroundTask extends BaseAudioHandler {
         "MaxStreamingBitrate": mediaItem.extras!["shouldTranscode"]
             ? FinampSettingsHelper.finampSettings.transcodeBitrate.toString()
             : "999999999",
-        "AudioCodec": mediaItem.extras!["useVorbis"]
-            ? "vorbis"
-            : "aac",
+        "AudioCodec": mediaItem.extras!["useVorbis"] ? "libvorbis" : "aac",
         "TranscodingContainer": "ts",
         "TranscodingProtocol":
             mediaItem.extras!["shouldTranscode"] ? "hls" : "http",


### PR DESCRIPTION
AAC is currently hard-coded as the codec used for transcoding. In
low-bandwidth environments, where transcoding is usually a must, AAC
performs very badly though, especially the built-in FFmpeg AAC encoder.
qaac and maybe FDK AAC are a bit better, but due to codec limitations,
even those high-performance codecs are outperformed by Vorbis on low
bitrates (also using those would require more patching in Jellyfin, and
using non-free software, so that wouldn't really work).
Vorbis is a free (as in freedom) audio format, and the libvorbis codec
implementation is also free (also as in freedom). Jellyfin supports
using it out-of-the-box.
While opus would've been a better choice, I and some friends currently
have some trouble getting it to work properly on the Jellyfin server
side of things, so I figured many other users do as well, which is why
Opus, even if it performs even better, hasn't been chosen.
A switch has been added into the Transcoding Settings Menu that toggles
between the widely-supported AAC and the higher-quality Vorbis. Settings
are stored in the Hive Database (I do not have Dart and Flutter
installed, so 1) this is untested and 2) the FinampModels.g.dart hasn't
been re-generated yet).