### PR TITLE
:bug: Fix playback stop events using an incorrect position

### DIFF
--- a/lib/services/music_player_background_task.dart
+++ b/lib/services/music_player_background_task.dart
@@ -100,6 +100,7 @@ class MusicPlayerBackgroundTask extends BaseAudioHandler {
           final playbackData = generatePlaybackProgressInfo(
             item: _previousItem,
             includeNowPlayingQueue: true,
+            isStopEvent: true,
           );
 
           if (playbackData != null) {
@@ -373,6 +374,7 @@ class MusicPlayerBackgroundTask extends BaseAudioHandler {
   PlaybackProgressInfo? generatePlaybackProgressInfo({
     MediaItem? item,
     required bool includeNowPlayingQueue,
+    bool isStopEvent = false,
   }) {
     if (_queueAudioSource.length == 0 && item == null) {
       // This function relies on _queue having items, so we return null if it's
@@ -386,7 +388,9 @@ class MusicPlayerBackgroundTask extends BaseAudioHandler {
             _getQueueItem(_player.currentIndex ?? 0).extras!["itemJson"]["Id"],
         isPaused: !_player.playing,
         isMuted: _player.volume == 0,
-        positionTicks: _player.position.inMicroseconds * 10,
+        positionTicks: isStopEvent
+            ? (item?.duration?.inMicroseconds ?? 0) * 10
+            : _player.position.inMicroseconds * 10,
         repeatMode: _jellyfinRepeatMode(_player.loopMode),
         playMethod: item?.extras!["shouldTranscode"] ??
                 _getQueueItem(_player.currentIndex ?? 0)


### PR DESCRIPTION
As outlined in [my recent comment](https://github.com/UnicornsOnLSD/finamp/issues/87#issuecomment-1064319704) in #87, stop events submitted to the server seem to use the playback progress of the following song that's already playing, which causes scrobbling plugins to drop the listen.

Simply using the song's duration for the stop event works around the issue. Unfortunately, this isn't without problems either, since it'll probably submit a complete listen when skipping or changing a track. Due to my limited experience with the app's architecture, I'm not sure how to fix that.

This PR mainly serves as a first attempt, hoping you or others can develop a better solution.

Note that [the other stop event](https://github.com/Maxr1998/finamp/blob/ea1582e28379b8a9661da080f9affa62e35bd229/lib/services/MusicPlayerBackgroundTask.dart#L143) in the playback task was deliberately not changed, since the issue shouldn't occur here and no played item is supplied in that method.