### PR TITLE
Use last known playback position for ProgressState while paused

### DIFF
--- a/lib/services/progress_state_stream.dart
+++ b/lib/services/progress_state_stream.dart
@@ -19,7 +19,7 @@ Stream<ProgressState> get progressStateStream {
   return Rx.combineLatest3<MediaItem?, PlaybackState, Duration, ProgressState>(
       audioHandler.mediaItem,
       audioHandler.playbackState,
-      AudioService.position,
+      AudioService.position.startWith(audioHandler.playbackState.value.position),
       (mediaItem, playbackState, position) =>
           ProgressState(mediaItem, playbackState, position));
 }


### PR DESCRIPTION
If you pause playback and open player screen or go to album/artist, causing fresh NowPlayingBar to be created, the ProgressState won't emit anything since AudioService.position doesn't emit position unless playback is in progress. This causes the player to have 00:00 position & duration and grayed out slider, and NPB doesn't appear at all (because snapshot.hasData is false).

This PR reuses last known playback position from audioHandler until AudioService emits new position after unpausing, fixing both issues.