### PR TITLE
Only show StopForegroundSelector on Android

### DIFF
--- a/lib/components/AudioServiceSettingsScreen/stop_foreground_selector.dart
+++ b/lib/components/AudioServiceSettingsScreen/stop_foreground_selector.dart
@@ -1,3 +1,5 @@
+import 'dart:io' show Platform;
+
 import 'package:flutter/material.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:hive/hive.dart';
@@ -10,6 +12,11 @@ class StopForegroundSelector extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    if (!Platform.isAndroid) {
+      // This setting is only available on Android
+      return const SizedBox.shrink();
+    }
+
     return ValueListenableBuilder<Box<FinampSettings>>(
       valueListenable: FinampSettingsHelper.finampSettingsListener,
       builder: (_, box, __) {

--- a/lib/components/AudioServiceSettingsScreen/stop_foreground_selector.dart
+++ b/lib/components/AudioServiceSettingsScreen/stop_foreground_selector.dart
@@ -1,5 +1,3 @@
-import 'dart:io' show Platform;
-
 import 'package:flutter/material.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:hive/hive.dart';
@@ -12,11 +10,6 @@ class StopForegroundSelector extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    if (!Platform.isAndroid) {
-      // This setting is only available on Android
-      return const SizedBox.shrink();
-    }
-
     return ValueListenableBuilder<Box<FinampSettings>>(
       valueListenable: FinampSettingsHelper.finampSettingsListener,
       builder: (_, box, __) {

--- a/lib/screens/audio_service_settings_screen.dart
+++ b/lib/screens/audio_service_settings_screen.dart
@@ -1,3 +1,5 @@
+import 'dart:io';
+
 import 'package:flutter/material.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 
@@ -17,9 +19,9 @@ class AudioServiceSettingsScreen extends StatelessWidget {
       ),
       body: Scrollbar(
         child: ListView(
-          children: const [
-            StopForegroundSelector(),
-            SongShuffleItemCountEditor(),
+          children: [
+            if (Platform.isAndroid) const StopForegroundSelector(),
+            const SongShuffleItemCountEditor(),
           ],
         ),
       ),


### PR DESCRIPTION
As this setting is only used for Android, there's no need to display it on other platforms.