### PR TITLE
Fix missing album images in queue list

### DIFF
--- a/lib/components/PlayerScreen/queue_list.dart
+++ b/lib/components/PlayerScreen/queue_list.dart
@@ -76,10 +76,10 @@ class _QueueListState extends State<QueueList> {
                   },
                   child: ListTile(
                     leading: AlbumImage(
-                      item: _queue?[actualIndex].extras?["ItemJson"] == null
+                      item: _queue?[actualIndex].extras?["itemJson"] == null
                           ? null
                           : BaseItemDto.fromJson(
-                              _queue?[actualIndex].extras?["ItemJson"]),
+                              _queue?[actualIndex].extras?["itemJson"]),
                     ),
                     title: Text(
                         snapshot.data!.queue?[actualIndex].title ??


### PR DESCRIPTION
Probably some regression happened at some point.

![obraz](https://user-images.githubusercontent.com/46846000/185771188-b444e45a-5363-4928-8c6c-2591306c29c8.png)
