### PR TITLE
Trim searchTerm before searching

### DIFF
--- a/lib/components/MusicScreen/music_screen_tab_view.dart
+++ b/lib/components/MusicScreen/music_screen_tab_view.dart
@@ -94,7 +94,7 @@ class _MusicScreenTabViewState extends State<MusicScreenTabView>
                         : "SortName"),
         sortOrder:
             widget.sortOrder?.toString() ?? SortOrder.ascending.toString(),
-        searchTerm: widget.searchTerm,
+        searchTerm: widget.searchTerm?.trim(),
         // If this is the genres tab, tell getItems to get genres.
         isGenres: widget.tabContentType == TabContentType.genres,
         filters: widget.isFavourite ? "IsFavorite" : null,


### PR DESCRIPTION
When using the keyboard's autocomplete/suggestions while searching, a space is usually appended to the search term. Because this could influence the returned search results, it makes sense to trim the search term before sending it to the server.