### PR TITLE
:bug: Fix crash in ErrorApp

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -371,10 +371,22 @@ class FinampErrorApp extends StatelessWidget {
         GlobalCupertinoLocalizations.delegate,
       ],
       supportedLocales: AppLocalizations.supportedLocales,
-      home: Scaffold(
-        body: Center(
-          child: Text(
-              AppLocalizations.of(context)!.startupError(error.toString())),
+      home: ErrorScreen(error: error),
+    );
+  }
+}
+
+class ErrorScreen extends StatelessWidget {
+  const ErrorScreen({super.key, this.error});
+
+  final dynamic error;
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      body: Center(
+        child: Text(
+          AppLocalizations.of(context)!.startupError(error.toString()),
         ),
       ),
     );


### PR DESCRIPTION
Currently, the error app crashes due to `AppLocalization.of(context)` returning `null`.
This is apparently [a bug in Flutter](https://stackoverflow.com/a/72754385/2475176), and worked around by adding another widget wrapping the Scaffold.