### PR TITLE
:eyes: Download original images instead of always converting them to png

### DIFF
--- a/lib/services/downloads_helper.dart
+++ b/lib/services/downloads_helper.dart
@@ -880,13 +880,14 @@ class DownloadsHelper {
 
     final imageUrl = _jellyfinApiData.getImageUrl(
       item: item,
-      quality: 100,
-      format: "png",
+      // Download original file
+      quality: null,
+      format: null,
     );
     final tokenHeader = _jellyfinApiData.getTokenHeader();
     final relativePath =
         path_helper.relative(downloadDir.path, from: downloadLocation.path);
-    final fileName = "${item.imageId}.png";
+    final fileName = item.imageId;
 
     final imageDownloadId = await FlutterDownloader.enqueue(
       url: imageUrl.toString(),

--- a/lib/services/jellyfin_api_helper.dart
+++ b/lib/services/jellyfin_api_helper.dart
@@ -445,8 +445,8 @@ class JellyfinApiHelper {
     required BaseItemDto item,
     int? maxWidth,
     int? maxHeight,
-    int quality = 90,
-    String format = "jpg",
+    int? quality = 90,
+    String? format = "jpg",
   }) {
     if (item.imageId == null) {
       return null;
@@ -466,8 +466,8 @@ class JellyfinApiHelper {
         scheme: parsedBaseUrl.scheme,
         pathSegments: builtPath,
         queryParameters: {
-          "format": format,
-          "quality": quality.toString(),
+          if (format != null) "format": format,
+          if (quality != null) "quality": quality.toString(),
           if (maxWidth != null) "MaxWidth": maxWidth.toString(),
           if (maxHeight != null) "MaxHeight": maxHeight.toString(),
         });


### PR DESCRIPTION
Reasoning: for some cover arts, storing PNGs takes up a lot of space (up to 20 MB per image as I've seen) but due to the conversion, there is still a noticeable quality loss like artifacting or patterns from the conversion. Just downloading and storing the original file is thus preferable.