### PR TITLE
Fix shuffle always starts on first song(issues:#61) and remove redund…

### DIFF
--- a/lib/components/AlbumScreen/album_screen_content_flexible_space_bar.dart
+++ b/lib/components/AlbumScreen/album_screen_content_flexible_space_bar.dart
@@ -1,3 +1,5 @@
+import 'dart:math';
+
 import 'package:flutter/material.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:get_it/get_it.dart';
@@ -70,6 +72,7 @@ class AlbumScreenContentFlexibleSpaceBar extends StatelessWidget {
                             audioServiceHelper.replaceQueueWithItem(
                           itemList: items,
                           shuffle: true,
+                          initialIndex: Random().nextInt(items.length),
                         ),
                         icon: const Icon(Icons.shuffle),
                         label: Text(

--- a/lib/services/audio_service_helper.dart
+++ b/lib/services/audio_service_helper.dart
@@ -40,14 +40,14 @@ class AudioServiceHelper {
         }
       }
 
-      if (!shuffle) {
-        // Give the audio service our next initial index so that playback starts
-        // at that index. We don't do this if shuffling because it causes the
-        // queue to always start at the start (although you could argue that we
-        // still should if initialIndex is not 0, but that doesn't happen
-        // anywhere in this app so oh well).
-        _audioHandler.setNextInitialIndex(initialIndex);
-      }
+      // if (!shuffle) {
+      //   // Give the audio service our next initial index so that playback starts
+      //   // at that index. We don't do this if shuffling because it causes the
+      //   // queue to always start at the start (although you could argue that we
+      //   // still should if initialIndex is not 0, but that doesn't happen
+      //   // anywhere in this app so oh well).
+      _audioHandler.setNextInitialIndex(initialIndex);
+      // }
 
       await _audioHandler.updateQueue(queue);
 

--- a/lib/services/music_player_background_task.dart
+++ b/lib/services/music_player_background_task.dart
@@ -312,7 +312,6 @@ class MusicPlayerBackgroundTask extends BaseAudioHandler {
     try {
       switch (shuffleMode) {
         case AudioServiceShuffleMode.all:
-          await _player.shuffle();
           await _player.setShuffleModeEnabled(true);
           shuffleNextQueue = true;
           break;


### PR DESCRIPTION
Try to fix #61

We pick a random item and put it first, instead of putting the first one first every time. And In order to make initialIndex take effect in updateQueue → _player.setAudioSource, I removed the if judgment in the replaceQueueWithItem method.

I remove _player.shuffle() when setShuffleMode(AudioServiceShuffleMode.all). It's redundant. I see the just_audio src code. When we invoke setAudioSource() method and proload is true, just_audio will call _load() method. AudioSource will be shuffled here. And platform.load() will send audioSourceMessage, initialPosition, initialIndex to native layer program.Actually audioSourceMessage contains shuffleOrder information. You can see [just_audio-0.9.32/android/src/main/java/com/ryanheise/just_audio/AudioPlayer.java
](https://github.com/ryanheise/just_audio/blob/097e04d2ad8f5481dee172f4283a0c8dc7178bf1/just_audio/android/src/main/java/com/ryanheise/just_audio/AudioPlayer.java#LL619C4-L625C21) at case concatenating part.

I see when I click block(or named stop) button on bottom bar. The current music always autochanged to album/playlist first item. Is this this app feature, or a bug?

```
Future<Duration?> _load(AudioPlayerPlatform platform, AudioSource source,
      {_InitialSeekValues? initialSeekValues}) async {

   ...

    try {
      await source._setup(this);
      checkInterruption();
      source._shuffle(initialIndex: initialSeekValues?.index ?? 0);
      _broadcastSequence();
      _durationFuture = platform
          .load(LoadRequest(
            audioSourceMessage: source._toMessage(),
            initialPosition: initialSeekValues?.position,
            initialIndex: initialSeekValues?.index,
          ))
          .then((response) => response.duration);
      
   ...

```

