### PR TITLE
Improved skipToPrevious() functionality

### DIFF
--- a/lib/services/music_player_background_task.dart
+++ b/lib/services/music_player_background_task.dart
@@ -271,7 +271,11 @@ class MusicPlayerBackgroundTask extends BaseAudioHandler {
   @override
   Future<void> skipToPrevious() async {
     try {
-      await _player.seekToPrevious();
+      if (!_player.hasPrevious || _player.position.inSeconds >= 5) {
+        await _player.seek(Duration.zero, index: _player.currentIndex);
+      } else {
+        await _player.seek(Duration.zero, index: _player.previousIndex);
+      }
     } catch (e) {
       _audioServiceBackgroundTaskLogger.severe(e);
       return Future.error(e);


### PR DESCRIPTION
Almost every other music app allows the previous button to restart the song when the current song plays for at least 5 seconds or so. Wanted to implement that functionality into this app as well. Also allowed the previous button to always restart the current song if its the first song in the queue instead of doing nothing.
First time doing a PR, hope everything looks okay :)