### PR TITLE
Sort artist albums by PremiereDate instead of ProductionYear

### DIFF
--- a/lib/components/MusicScreen/music_screen_tab_view.dart
+++ b/lib/components/MusicScreen/music_screen_tab_view.dart
@@ -90,7 +90,7 @@ class _MusicScreenTabViewState extends State<MusicScreenTabView>
                 : widget.parentItem == null
                     ? "SortName"
                     : widget.parentItem?.type == "MusicArtist"
-                        ? "ProductionYear"
+                        ? "PremiereDate"
                         : "SortName"),
         sortOrder:
             widget.sortOrder?.toString() ?? SortOrder.ascending.toString(),


### PR DESCRIPTION
If an artist has multiple albums in one year, albums may not necessarily follow the release order. Sorting by PremiereDate instead fixes that. If no PremiereDate is set on the item, the server will automatically fall back to ProductionYear.