### PR TITLE
Sync downloads

### DIFF
--- a/lib/components/DownloadsScreen/sync_downloaded_playlists.dart
+++ b/lib/components/DownloadsScreen/sync_downloaded_playlists.dart
@@ -25,19 +25,23 @@ class _SyncDownloadedPlaylistsButtonState
     _syncLogger.info("Syncing downloaded playlists");
     List<DownloadedParent> parents = downloadsHelper.downloadedParents.toList();
     List<DownloadedSong> songs = downloadsHelper.downloadedItems.toList();
+
     for (DownloadedParent parent in parents) {
-      List<BaseItemDto> children = parent.downloadedChildren.values.toList();
+      Set<String> children =
+          parent.downloadedChildren.values.map((e) => e.id).toSet();
       DownloadedSong firstSong = songs.first;
       List<BaseItemDto>? items = await _jellyfinApiData.getItems(
           isGenres: false, parentItem: parent.item);
+
       if (items == null) continue;
+
       for (BaseItemDto item in items) {
         _syncLogger.info(item.id.toString());
-        List<BaseItemDto> found =
-            children.where((element) => element.id == item.id).toList();
-        _syncLogger.info(found.toString());
-        if (found.isEmpty) {
+        bool isInChildren = children.contains(item.id);
+
+        if (isInChildren) {
           _syncLogger.info("Need sync download of ${item.id}");
+
           await downloadsHelper.addDownloads(
             items: [item],
             parent: parent.item,

--- a/lib/components/DownloadsScreen/sync_downloaded_playlists.dart
+++ b/lib/components/DownloadsScreen/sync_downloaded_playlists.dart
@@ -1,0 +1,58 @@
+import 'package:finamp/models/finamp_models.dart';
+import 'package:finamp/models/jellyfin_models.dart';
+import 'package:finamp/services/downloads_helper.dart';
+import 'package:finamp/services/jellyfin_api_helper.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_downloader/flutter_downloader.dart';
+import 'package:get_it/get_it.dart';
+import 'package:logging/logging.dart';
+
+class SyncDownloadedPlaylistsButton extends StatefulWidget {
+  const SyncDownloadedPlaylistsButton({super.key});
+
+  @override
+  State<SyncDownloadedPlaylistsButton> createState() =>
+      _SyncDownloadedPlaylistsButtonState();
+}
+
+class _SyncDownloadedPlaylistsButtonState
+    extends State<SyncDownloadedPlaylistsButton> {
+  final _syncLogger = Logger("SyncDownloadedPlaylistsButton");
+  DownloadsHelper downloadsHelper = GetIt.instance<DownloadsHelper>();
+  final _jellyfinApiData = GetIt.instance<JellyfinApiHelper>();
+
+  void syncPlaylists() async {
+    _syncLogger.info("Syncing downloaded playlists");
+    List<DownloadedParent> parents = downloadsHelper.downloadedParents.toList();
+    List<DownloadedSong> songs = downloadsHelper.downloadedItems.toList();
+    for (DownloadedParent parent in parents) {
+      List<BaseItemDto> children = parent.downloadedChildren.values.toList();
+      DownloadedSong firstSong = songs.first;
+      List<BaseItemDto>? items = await _jellyfinApiData.getItems(
+          isGenres: false, parentItem: parent.item);
+      if (items == null) continue;
+      for (BaseItemDto item in items) {
+        _syncLogger.info(item.id.toString());
+        List<BaseItemDto> found =
+            children.where((element) => element.id == item.id).toList();
+        _syncLogger.info(found.toString());
+        if (found.isEmpty) {
+          _syncLogger.info("Need sync download of ${item.id}");
+          await downloadsHelper.addDownloads(
+            items: [item],
+            parent: parent.item,
+            useHumanReadableNames: firstSong.useHumanReadableNames,
+            downloadLocation: firstSong.downloadLocation!,
+            viewId: firstSong.viewId,
+          );
+        }
+      }
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return IconButton(
+        onPressed: () => syncPlaylists(), icon: const Icon(Icons.sync));
+  }
+}

--- a/lib/screens/downloads_screen.dart
+++ b/lib/screens/downloads_screen.dart
@@ -5,6 +5,7 @@ import '../components/DownloadsScreen/downloads_overview.dart';
 import '../components/DownloadsScreen/downloaded_albums_list.dart';
 import '../components/DownloadsScreen/download_error_screen_button.dart';
 import '../components/DownloadsScreen/download_missing_images_button.dart';
+import '../components/DownloadsScreen/sync_downloaded_playlists.dart';
 
 class DownloadsScreen extends StatelessWidget {
   const DownloadsScreen({Key? key}) : super(key: key);
@@ -17,6 +18,7 @@ class DownloadsScreen extends StatelessWidget {
       appBar: AppBar(
         title: Text(AppLocalizations.of(context)!.downloads),
         actions: const [
+          SyncDownloadedPlaylistsButton(),
           DownloadMissingImagesButton(),
           DownloadErrorScreenButton()
         ],

--- a/lib/services/downloads_helper.dart
+++ b/lib/services/downloads_helper.dart
@@ -853,6 +853,7 @@ class DownloadsHelper {
           {List<String>? keys}) =>
       _downloadedItemsBox.listenable(keys: keys);
 
+
   /// Converts a dart list to a string with the correct SQL syntax
   String _dartListToSqlList(List dartList) {
     try {


### PR DESCRIPTION

@jmshrv This adds a new button to sync the current downloads.
Example: 
You download a playlist via finamp.
You add a track to this playlist via jellyfin.
Current situation: you have to delete the playlist and download it again.
With the new button: It checks for not downloaded files and downloads them too.