### PR TITLE
Add to playlist in playlist

### DIFF
--- a/lib/components/AlbumScreen/song_list_tile.dart
+++ b/lib/components/AlbumScreen/song_list_tile.dart
@@ -229,6 +229,16 @@ class _SongListTileState extends State<SongListTile> {
                 title: Text(AppLocalizations.of(context)!.replaceQueue),
               ),
             ),
+            if (widget.isInPlaylist)
+              PopupMenuItem<SongListTileMenuItems>(
+                enabled: !isOffline,
+                value: SongListTileMenuItems.addToPlaylist,
+                child: ListTile(
+                  leading: const Icon(Icons.playlist_add),
+                  title: Text(AppLocalizations.of(context)!.addToPlaylistTitle),
+                  enabled: !isOffline,
+                ),
+              ),
             widget.isInPlaylist
                 ? PopupMenuItem<SongListTileMenuItems>(
                     enabled: !isOffline,


### PR DESCRIPTION
This simple PR adds the function to add items to a playlist inside of a playlist.
Currently you have to search for the song itself to add it to a playlist.
Now you can add the song to a different playlist directly in the playlist view