### PR TITLE
Rework player progress reporting

### DIFF
--- a/lib/services/music_player_background_task.dart
+++ b/lib/services/music_player_background_task.dart
@@ -376,25 +376,27 @@ class MusicPlayerBackgroundTask extends BaseAudioHandler {
     required bool includeNowPlayingQueue,
     bool isStopEvent = false,
   }) {
-    if (_queueAudioSource.length == 0 && item == null) {
-      // This function relies on _queue having items, so we return null if it's
-      // empty to avoid more errors.
-      return null;
+    if (item == null) {
+      final currentIndex = _player.currentIndex;
+      if (_queueAudioSource.length == 0 || currentIndex == 0) {
+        // This function relies on _queue having items,
+        // so we return null if it's empty or no index is played
+        // and no custom item was passed to avoid more errors.
+        return null;
+      }
+      item = _getQueueItem(currentIndex!);
     }
 
     try {
       return PlaybackProgressInfo(
-        itemId: item?.extras?["itemJson"]["Id"] ??
-            _getQueueItem(_player.currentIndex ?? 0).extras!["itemJson"]["Id"],
+        itemId: item.extras!["itemJson"]["Id"],
         isPaused: !_player.playing,
         isMuted: _player.volume == 0,
         positionTicks: isStopEvent
-            ? (item?.duration?.inMicroseconds ?? 0) * 10
+            ? (item.duration?.inMicroseconds ?? 0) * 10
             : _player.position.inMicroseconds * 10,
         repeatMode: _jellyfinRepeatMode(_player.loopMode),
-        playMethod: item?.extras!["shouldTranscode"] ??
-                _getQueueItem(_player.currentIndex ?? 0)
-                    .extras!["shouldTranscode"]
+        playMethod: item.extras!["shouldTranscode"] ?? false
             ? "Transcode"
             : "DirectPlay",
         // We don't send the queue since it seems useless and it can cause

--- a/lib/services/music_player_background_task.dart
+++ b/lib/services/music_player_background_task.dart
@@ -454,7 +454,7 @@ class MusicPlayerBackgroundTask extends BaseAudioHandler {
     return generatePlaybackProgressInfo(
       item,
       isPaused: !state.playing,
-      // TODO: get volume from state?
+      // always consider as unmuted
       isMuted: false,
       playerPosition: state.position,
       repeatMode: _jellyfinRepeatModeFromRepeatMode(state.repeatMode),

--- a/lib/services/music_player_background_task.dart
+++ b/lib/services/music_player_background_task.dart
@@ -345,7 +345,7 @@ class MusicPlayerBackgroundTask extends BaseAudioHandler {
   }
 
   /// Report track changes to the Jellyfin Server if the user is not offline.
-  onTrackChanged(
+  Future<void> onTrackChanged(
     MediaItem currentItem,
     PlaybackState currentState,
     MediaItem? previousItem,
@@ -357,7 +357,11 @@ class MusicPlayerBackgroundTask extends BaseAudioHandler {
 
     final jellyfinApiHelper = GetIt.instance<JellyfinApiHelper>();
 
-    if (previousItem != null && previousState != null) {
+    if (previousItem != null &&
+        previousState != null &&
+        // don't submit stop events for idle tracks (at position 0 and not playing)
+        (previousState.playing ||
+            previousState.updatePosition != Duration.zero)) {
       final playbackData = generatePlaybackProgressInfoFromState(
         previousItem,
         previousState,

--- a/lib/services/music_player_background_task.dart
+++ b/lib/services/music_player_background_task.dart
@@ -358,13 +358,20 @@ class MusicPlayerBackgroundTask extends BaseAudioHandler {
     final jellyfinApiHelper = GetIt.instance<JellyfinApiHelper>();
 
     if (previousItem != null && previousState != null) {
-      final playbackData = generatePlaybackProgressInfoFromState(
-        previousItem,
-        previousState,
-      );
+      const maxStateReportAge = Duration(seconds: 15);
+      final stateAge = DateTime.now().difference(previousState.updateTime);
 
-      if (playbackData != null) {
-        await jellyfinApiHelper.stopPlaybackProgress(playbackData);
+      // Only report stop events if the respective playback state isn't out of date.
+      // This catches duplicate events when the user switches from a stopped track.
+      if (stateAge < maxStateReportAge) {
+        final playbackData = generatePlaybackProgressInfoFromState(
+          previousItem,
+          previousState,
+        );
+
+        if (playbackData != null) {
+          await jellyfinApiHelper.stopPlaybackProgress(playbackData);
+        }
       }
     }
 


### PR DESCRIPTION
Still need to test this thoroughly and fix one added TODO before this is ready for a full review. Wanted to get this out early nonetheless.

On to the basic ideas behind this change: currently, the player reports playback stop events **after** the track index changes, with no easy way to know the previous state.
For that, it subscribes to `_player.currentIndexStream`, which simply maps the (distinct) index from `_player.playbackEventStream`. So, my idea was to drop this index stream completely, and instead handle the changes in the `_player.playbackEventStream` manually by comparing the new and previous index. This comes with the advantage that of knowing the complete previous *state* as well in that handler.

I also heavily rewrote `generatePlaybackProgressInfo` and split it into three functions.
The original function still handles the reporting, but now receives all attributes as parameters. No default handling, no reading information from the player anymore.

The two new functions handle the following cases:
- the default case where we simply want to publish the current playback progress (e.g., a presently running track progressed a certain duration), where all data is resolved directly from the player.
- the playback start/stop case, where we can provide the specific media item and playback state that was valid for this item.