### PR TITLE
Add Play Next & Add to Queue for songs and albums.

### DIFF
--- a/lib/components/AlbumScreen/song_list_tile.dart
+++ b/lib/components/AlbumScreen/song_list_tile.dart
@@ -239,20 +239,22 @@ class _SongListTileState extends State<SongListTile> {
             screenSize.height - details.globalPosition.dy,
           ),
           items: [
-            PopupMenuItem<SongListTileMenuItems>(
-              value: SongListTileMenuItems.addToQueue,
-              child: ListTile(
-                leading: const Icon(Icons.queue_music),
-                title: Text(AppLocalizations.of(context)!.addToQueue),
+            if (_audioServiceHelper.hasQueueItems()) ...[
+              PopupMenuItem<SongListTileMenuItems>(
+                value: SongListTileMenuItems.addToQueue,
+                child: ListTile(
+                  leading: const Icon(Icons.queue_music),
+                  title: Text(AppLocalizations.of(context)!.addToQueue),
+                ),
               ),
-            ),
-            PopupMenuItem<SongListTileMenuItems>(
-              value: SongListTileMenuItems.playNext,
-              child: ListTile(
-                leading: const Icon(Icons.queue_music),
-                title: Text(AppLocalizations.of(context)!.playNext),
+              PopupMenuItem<SongListTileMenuItems>(
+                value: SongListTileMenuItems.playNext,
+                child: ListTile(
+                  leading: const Icon(Icons.queue_music),
+                  title: Text(AppLocalizations.of(context)!.playNext),
+                ),
               ),
-            ),
+            ],
             PopupMenuItem<SongListTileMenuItems>(
               value: SongListTileMenuItems.replaceQueueWithItem,
               child: ListTile(

--- a/lib/components/AlbumScreen/song_list_tile.dart
+++ b/lib/components/AlbumScreen/song_list_tile.dart
@@ -20,6 +20,7 @@ import 'downloaded_indicator.dart';
 
 enum SongListTileMenuItems {
   addToQueue,
+  playNext,
   replaceQueueWithItem,
   addToPlaylist,
   removeFromPlaylist,
@@ -246,6 +247,13 @@ class _SongListTileState extends State<SongListTile> {
               ),
             ),
             PopupMenuItem<SongListTileMenuItems>(
+              value: SongListTileMenuItems.playNext,
+              child: ListTile(
+                leading: const Icon(Icons.queue_music),
+                title: Text(AppLocalizations.of(context)!.playNext),
+              ),
+            ),
+            PopupMenuItem<SongListTileMenuItems>(
               value: SongListTileMenuItems.replaceQueueWithItem,
               child: ListTile(
                 leading: const Icon(Icons.play_circle),
@@ -324,12 +332,22 @@ class _SongListTileState extends State<SongListTile> {
 
         switch (selection) {
           case SongListTileMenuItems.addToQueue:
-            await _audioServiceHelper.addQueueItem(widget.item);
+            await _audioServiceHelper.addQueueItems([widget.item]);
 
             if (!mounted) return;
 
             ScaffoldMessenger.of(context).showSnackBar(SnackBar(
               content: Text(AppLocalizations.of(context)!.addedToQueue),
+            ));
+            break;
+
+          case SongListTileMenuItems.playNext:
+            await _audioServiceHelper.insertQueueItemsNext([widget.item]);
+
+            if (!mounted) return;
+
+            ScaffoldMessenger.of(context).showSnackBar(SnackBar(
+              content: Text(AppLocalizations.of(context)!.insertedIntoQueue),
             ));
             break;
 
@@ -451,7 +469,7 @@ class _SongListTileState extends State<SongListTile> {
                 ),
               ),
               confirmDismiss: (direction) async {
-                await _audioServiceHelper.addQueueItem(widget.item);
+                await _audioServiceHelper.addQueueItems([widget.item]);
 
                 if (!mounted) return false;
 

--- a/lib/components/MusicScreen/album_item.dart
+++ b/lib/components/MusicScreen/album_item.dart
@@ -169,7 +169,11 @@ class _AlbumItemState extends State<AlbumItem> {
           switch (selection) {
             case _AlbumListTileMenuItems.addToQueue:
               final children = await jellyfinApiHelper.getItems(
-                  parentItem: widget.album, isGenres: false);
+                parentItem: widget.album,
+                sortBy: "ParentIndexNumber,IndexNumber,SortName",
+                includeItemTypes: "Audio",
+                isGenres: false,
+              );
               await _audioServiceHelper.addQueueItems(children!);
 
               if (!mounted) return;
@@ -181,7 +185,11 @@ class _AlbumItemState extends State<AlbumItem> {
 
             case _AlbumListTileMenuItems.playNext:
               final children = await jellyfinApiHelper.getItems(
-                  parentItem: widget.album, isGenres: false);
+                parentItem: widget.album,
+                sortBy: "ParentIndexNumber,IndexNumber,SortName",
+                includeItemTypes: "Audio",
+                isGenres: false,
+              );
               await _audioServiceHelper.insertQueueItemsNext(children!);
 
               if (!mounted) return;

--- a/lib/components/MusicScreen/album_item.dart
+++ b/lib/components/MusicScreen/album_item.dart
@@ -98,11 +98,7 @@ class _AlbumItemState extends State<AlbumItem> {
         onLongPressStart: (details) async {
           Feedback.forLongPress(context);
 
-          if (FinampSettingsHelper.finampSettings.isOffline) {
-            // If offline, don't show the context menu since the only options here
-            // are for online.
-            return;
-          }
+          final isOffline = FinampSettingsHelper.finampSettings.isOffline;
 
           final jellyfinApiHelper = GetIt.instance<JellyfinApiHelper>();
 
@@ -115,48 +111,58 @@ class _AlbumItemState extends State<AlbumItem> {
               screenSize.height - details.globalPosition.dy,
             ),
             items: [
-              PopupMenuItem<_AlbumListTileMenuItems>(
-                value: _AlbumListTileMenuItems.addToQueue,
-                child: ListTile(
-                  leading: const Icon(Icons.queue_music),
-                  title: Text(AppLocalizations.of(context)!.addToQueue),
+              if (_audioServiceHelper.hasQueueItems()) ...[
+                PopupMenuItem<_AlbumListTileMenuItems>(
+                  value: _AlbumListTileMenuItems.addToQueue,
+                  child: ListTile(
+                    leading: const Icon(Icons.queue_music),
+                    title: Text(AppLocalizations.of(context)!.addToQueue),
+                  ),
                 ),
-              ),
-              PopupMenuItem<_AlbumListTileMenuItems>(
-                value: _AlbumListTileMenuItems.playNext,
-                child: ListTile(
-                  leading: const Icon(Icons.queue_music),
-                  title: Text(AppLocalizations.of(context)!.playNext),
+                PopupMenuItem<_AlbumListTileMenuItems>(
+                  value: _AlbumListTileMenuItems.playNext,
+                  child: ListTile(
+                    leading: const Icon(Icons.queue_music),
+                    title: Text(AppLocalizations.of(context)!.playNext),
+                  ),
                 ),
-              ),
+              ],
               mutableAlbum.userData!.isFavorite
                   ? PopupMenuItem<_AlbumListTileMenuItems>(
+                      enabled: !isOffline,
                       value: _AlbumListTileMenuItems.removeFavourite,
                       child: ListTile(
+                        enabled: !isOffline,
                         leading: const Icon(Icons.favorite_border),
                         title:
                             Text(AppLocalizations.of(context)!.removeFavourite),
                       ),
                     )
                   : PopupMenuItem<_AlbumListTileMenuItems>(
+                      enabled: !isOffline,
                       value: _AlbumListTileMenuItems.addFavourite,
                       child: ListTile(
+                        enabled: !isOffline,
                         leading: const Icon(Icons.favorite),
                         title: Text(AppLocalizations.of(context)!.addFavourite),
                       ),
                     ),
               jellyfinApiHelper.selectedMixAlbumIds.contains(mutableAlbum.id)
                   ? PopupMenuItem<_AlbumListTileMenuItems>(
+                      enabled: !isOffline,
                       value: _AlbumListTileMenuItems.removeFromMixList,
                       child: ListTile(
+                        enabled: !isOffline,
                         leading: const Icon(Icons.explore_off),
                         title:
                             Text(AppLocalizations.of(context)!.removeFromMix),
                       ),
                     )
                   : PopupMenuItem<_AlbumListTileMenuItems>(
+                      enabled: !isOffline,
                       value: _AlbumListTileMenuItems.addToMixList,
                       child: ListTile(
+                        enabled: !isOffline,
                         leading: const Icon(Icons.explore),
                         title: Text(AppLocalizations.of(context)!.addToMix),
                       ),

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -417,7 +417,13 @@
   "queue": "Queue",
   "@queue": {},
   "addToQueue": "Add to Queue",
-  "@addToQueue": {},
+  "@addToQueue": {
+    "description": "Popup menu item title for adding an item to the end of the play queue."
+  },
+  "playNext": "Play Next",
+  "@playNext": {
+    "description": "Popup menu item title for inserting an item into the play queue after the currently-playing item."
+  },
   "replaceQueue": "Replace Queue",
   "@replaceQueue": {},
   "instantMix": "Instant Mix",
@@ -429,7 +435,13 @@
   "addFavourite": "Add Favourite",
   "@addFavourite": {},
   "addedToQueue": "Added to queue.",
-  "@addedToQueue": {},
+  "@addedToQueue": {
+    "description": "Snackbar message that shows when the user successfully adds items to the end of the play queue."
+  },
+  "insertedIntoQueue": "Inserted into queue.",
+  "@insertedIntoQueue": {
+    "description": "Snackbar message that shows when the user successfully inserts items into the play queue at a location that is not necessarily the end."
+  },
   "queueReplaced": "Queue replaced.",
   "@queueReplaced": {},
   "removedFromPlaylist": "Removed from playlist.",

--- a/lib/services/audio_service_helper.dart
+++ b/lib/services/audio_service_helper.dart
@@ -64,6 +64,10 @@ class AudioServiceHelper {
     }
   }
 
+  bool hasQueueItems() {
+    return (_audioHandler.queue.valueOrNull?.length ?? 0) != 0;
+  }
+
   @Deprecated("Use addQueueItems instead")
   Future<void> addQueueItem(BaseItemDto item) async {
     await addQueueItems([item]);

--- a/lib/services/music_player_background_task.dart
+++ b/lib/services/music_player_background_task.dart
@@ -218,16 +218,10 @@ class MusicPlayerBackgroundTask extends BaseAudioHandler {
 
   Future<void> insertQueueItemsNext(List<MediaItem> mediaItems) async {
     try {
-      int? idx = _player.nextIndex;
-      if (idx == null) {
-        idx = _player.currentIndex;
-        if (idx != null) ++idx;
-      }
-      idx ??= 0;
-
       final sources =
           await Future.wait(mediaItems.map((i) => _mediaItemToAudioSource(i)));
-      await _queueAudioSource.insertAll(idx, sources);
+      await _queueAudioSource.insertAll(
+          (_player.currentIndex ?? -1) + 1, sources);
       queue.add(_queueFromSource());
     } catch (e) {
       _audioServiceBackgroundTaskLogger.severe(e);

--- a/lib/services/music_player_background_task.dart
+++ b/lib/services/music_player_background_task.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 import 'dart:io';
+import 'dart:math';
 
 import 'package:android_id/android_id.dart';
 import 'package:audio_service/audio_service.dart';
@@ -14,6 +15,66 @@ import '../models/jellyfin_models.dart';
 import 'finamp_settings_helper.dart';
 import 'finamp_user_helper.dart';
 import 'jellyfin_api_helper.dart';
+
+// Largely copied from just_audio's DefaultShuffleOrder, but with a mildly
+// stupid hack to insert() to make Play Next work
+class FinampShuffleOrder extends ShuffleOrder {
+  final Random _random;
+  @override
+  final indices = <int>[];
+
+  FinampShuffleOrder({Random? random}) : _random = random ?? Random();
+
+  @override
+  void shuffle({int? initialIndex}) {
+    assert(initialIndex == null || indices.contains(initialIndex));
+    if (indices.length <= 1) return;
+    indices.shuffle(_random);
+    if (initialIndex == null) return;
+
+    const initialPos = 0;
+    final swapPos = indices.indexOf(initialIndex);
+    // Swap the indices at initialPos and swapPos.
+    final swapIndex = indices[initialPos];
+    indices[initialPos] = initialIndex;
+    indices[swapPos] = swapIndex;
+  }
+
+  @override
+  void insert(int index, int count) {
+    // Offset indices after insertion point.
+    for (var i = 0; i < indices.length; i++) {
+      if (indices[i] >= index) {
+        indices[i] += count;
+      }
+    }
+
+    final newIndices = List.generate(count, (i) => index + i);
+    // This is the only modification from DefaultShuffleOrder: Only shuffle
+    // inserted indices amongst themselves, but keep them contiguous
+    newIndices.shuffle(_random);
+    indices.insertAll(index, newIndices);
+  }
+
+  @override
+  void removeRange(int start, int end) {
+    final count = end - start;
+    // Remove old indices.
+    final oldIndices = List.generate(count, (i) => start + i).toSet();
+    indices.removeWhere(oldIndices.contains);
+    // Offset indices after deletion point.
+    for (var i = 0; i < indices.length; i++) {
+      if (indices[i] >= end) {
+        indices[i] -= count;
+      }
+    }
+  }
+
+  @override
+  void clear() {
+    indices.clear();
+  }
+}
 
 /// This provider handles the currently playing music so that multiple widgets
 /// can control music.
@@ -30,8 +91,10 @@ class MusicPlayerBackgroundTask extends BaseAudioHandler {
               FinampSettingsHelper.finampSettings.bufferDuration,
         )),
   );
-  ConcatenatingAudioSource _queueAudioSource =
-      ConcatenatingAudioSource(children: []);
+  ConcatenatingAudioSource _queueAudioSource = ConcatenatingAudioSource(
+    children: [],
+    shuffleOrder: FinampShuffleOrder(),
+  );
   final _audioServiceBackgroundTaskLogger = Logger("MusicPlayerBackgroundTask");
   final _jellyfinApiHelper = GetIt.instance<JellyfinApiHelper>();
   final _finampUserHelper = GetIt.instance<FinampUserHelper>();
@@ -218,10 +281,20 @@ class MusicPlayerBackgroundTask extends BaseAudioHandler {
 
   Future<void> insertQueueItemsNext(List<MediaItem> mediaItems) async {
     try {
+      var idx = _player.currentIndex;
+      if (idx != null) {
+        if (_player.shuffleModeEnabled) {
+          var next = _player.shuffleIndices?.indexOf(idx);
+          idx = next == -1 || next == null ? null : next + 1;
+        } else {
+          ++idx;
+        }
+      }
+      idx ??= 0;
+
       final sources =
           await Future.wait(mediaItems.map((i) => _mediaItemToAudioSource(i)));
-      await _queueAudioSource.insertAll(
-          (_player.currentIndex ?? -1) + 1, sources);
+      await _queueAudioSource.insertAll(idx, sources);
       queue.add(_queueFromSource());
     } catch (e) {
       _audioServiceBackgroundTaskLogger.severe(e);
@@ -241,6 +314,7 @@ class MusicPlayerBackgroundTask extends BaseAudioHandler {
       // Create a new ConcatenatingAudioSource with the new queue.
       _queueAudioSource = ConcatenatingAudioSource(
         children: audioSources,
+        shuffleOrder: FinampShuffleOrder(),
       );
 
       try {


### PR DESCRIPTION
I've seen that the UI redesign project intends to cover this, but I thought I'd offer this as a quality-of-life backport for the current UI until that gets released.  This partially covers #221, and maybe covers #92 depending on opinion.  Apologies for any style errors (and for the faux pas of swinging in out of the blue with a PR), my Dart is pretty rusty.

This has been tested on iOS Simulator and an iPhone 11 running iOS 16.6.

Open questions and future work:
- There is no i18n for this, I'm monolingual
- The icon is confusing but `Icons` doesn't really offer anything better than `queue_music`
- There are no toolbar items in the album screen for queuing, seemed like too big of a UX question for the scope of this PR
- Shuffle is horribly broken ([FIXED](https://github.com/jmshrv/finamp/pull/481#issuecomment-1667626056))
  - ~~The existing Add to Queue behaves badly with shuffle enabled (is there an open issue for this?), and the added ones behave worse~~ see linked comment
  - What is the expected behavior when the queue is modified and then shuffle is enabled/disabled?
  - ~~Does it make sense (and is it worth the effort) to calculate the preimage of `shuffleIndices` when modifying the queue with shuffle enabled?~~