### PR TITLE
:sparkles: Upgrade chopper and aggregate chopper logs to single entry

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,5 +1,5 @@
 buildscript {
-    ext.kotlin_version = '1.7.10'
+    ext.kotlin_version = '1.8.10'
     repositories {
         google()
         mavenCentral()

--- a/lib/services/chopper_aggregate_logger.dart
+++ b/lib/services/chopper_aggregate_logger.dart
@@ -1,0 +1,118 @@
+import 'dart:async';
+import 'dart:collection';
+
+import 'package:chopper/chopper.dart' as chopper;
+import 'package:chopper/src/chopper_log_record.dart';
+import 'package:logging/logging.dart';
+
+/// A logger that aggregates the request and response logs from Chopper.
+/// Once a request (or response) is completed,
+/// the whole request log is flushed to the delegated chopperLogger.
+///
+/// All other operations are delegated by default.
+class ChopperAggregateLogger implements Logger {
+  final Logger _delegate = chopper.chopperLogger;
+
+  final Map<chopper.Request, StringBuffer> _requests = HashMap();
+
+  final Map<chopper.Response, StringBuffer> _responses = HashMap();
+
+  @override
+  String get name => _delegate.name;
+
+  @override
+  String get fullName => _delegate.fullName;
+
+  @override
+  Logger? get parent => _delegate.parent;
+
+  @override
+  Level get level => _delegate.level;
+
+  @override
+  set level(Level? value) {
+    _delegate.level = value;
+  }
+
+  @override
+  Map<String, Logger> get children => _delegate.children;
+
+  @override
+  void log(Level logLevel, Object? message,
+      [Object? error, StackTrace? stackTrace, Zone? zone]) {
+    if (message is ChopperLogRecord) {
+      if (message.request != null) {
+        _requests[message.request]?.writeln(message.message);
+        return;
+      } else if (message.response != null) {
+        _responses[message.response]?.writeln(message.message);
+        return;
+      }
+    }
+    _delegate.log(logLevel, message, error, stackTrace, zone);
+  }
+
+  void onStartRequest(chopper.Request request) {
+    _requests[request] = StringBuffer();
+  }
+
+  void onEndRequest(chopper.Request request) {
+    info(_requests.remove(request)?.toString().trim());
+  }
+
+  void onStartResponse(chopper.Response response) {
+    _responses[response] = StringBuffer();
+  }
+
+  void onEndResponse(chopper.Response response) {
+    info(_responses.remove(response)?.toString().trim());
+  }
+
+  @override
+  Stream<Level?> get onLevelChanged => _delegate.onLevelChanged;
+
+  @override
+  Stream<LogRecord> get onRecord => _delegate.onRecord;
+
+  @override
+  void clearListeners() {
+    _delegate.clearListeners();
+  }
+
+  @override
+  bool isLoggable(Level value) {
+    return _delegate.isLoggable(value);
+  }
+
+  @override
+  void finest(Object? message, [Object? error, StackTrace? stackTrace]) =>
+      log(Level.FINEST, message, error, stackTrace);
+
+  @override
+  void finer(Object? message, [Object? error, StackTrace? stackTrace]) =>
+      log(Level.FINER, message, error, stackTrace);
+
+  @override
+  void fine(Object? message, [Object? error, StackTrace? stackTrace]) =>
+      log(Level.FINE, message, error, stackTrace);
+
+  @override
+  void config(Object? message, [Object? error, StackTrace? stackTrace]) =>
+      log(Level.CONFIG, message, error, stackTrace);
+
+  @override
+  void info(Object? message, [Object? error, StackTrace? stackTrace]) =>
+      log(Level.INFO, message, error, stackTrace);
+
+  @override
+  void warning(Object? message, [Object? error, StackTrace? stackTrace]) =>
+      log(Level.WARNING, message, error, stackTrace);
+
+  @override
+  void severe(Object? message, [Object? error, StackTrace? stackTrace]) =>
+      log(Level.SEVERE, message, error, stackTrace);
+
+  @override
+  void shout(Object? message, [Object? error, StackTrace? stackTrace]) =>
+      log(Level.SHOUT, message, error, stackTrace);
+}

--- a/lib/services/http_aggregate_logging_interceptor.dart
+++ b/lib/services/http_aggregate_logging_interceptor.dart
@@ -1,0 +1,29 @@
+import 'dart:async';
+
+import 'package:chopper/chopper.dart';
+import 'package:finamp/services/chopper_aggregate_logger.dart';
+
+final aggregateLogger = ChopperAggregateLogger();
+
+/// A HttpLoggingInterceptor that aggregates the request and
+/// response logs from Chopper, using the [ChopperAggregateLogger].
+class HttpAggregateLoggingInterceptor extends HttpLoggingInterceptor {
+  HttpAggregateLoggingInterceptor({level = Level.body})
+      : super(level: level, logger: aggregateLogger);
+
+  @override
+  FutureOr<Request> onRequest(Request request) async {
+    aggregateLogger.onStartRequest(request);
+    final result = await super.onRequest(request);
+    aggregateLogger.onEndRequest(request);
+    return result;
+  }
+
+  @override
+  FutureOr<Response> onResponse(Response response) {
+    aggregateLogger.onStartResponse(response);
+    final result = super.onResponse(response);
+    aggregateLogger.onEndResponse(response);
+    return result;
+  }
+}

--- a/lib/services/jellyfin_api.dart
+++ b/lib/services/jellyfin_api.dart
@@ -3,6 +3,7 @@ import 'dart:io' show Platform;
 import 'package:android_id/android_id.dart';
 import 'package:chopper/chopper.dart';
 import 'package:device_info_plus/device_info_plus.dart';
+import 'package:finamp/services/http_aggregate_logging_interceptor.dart';
 import 'package:get_it/get_it.dart';
 import 'package:package_info_plus/package_info_plus.dart';
 
@@ -413,7 +414,7 @@ abstract class JellyfinApi extends ChopperService {
         //   return request.copyWith(
         //       headers: {"X-Emby-Authentication": await getAuthHeader()});
         // },
-        HttpLoggingInterceptor(),
+        HttpAggregateLoggingInterceptor(),
       ],
     );
 

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -181,18 +181,18 @@ packages:
     dependency: "direct main"
     description:
       name: chopper
-      sha256: "23aac2db54f6a7854ed8984fba4b33222e53123c71a0ccf01d2b1087a1b5aab7"
+      sha256: "8cc23242759fb2d8a325e3e2371094f73e14fec02f01ebaba51e03db5e9eabab"
       url: "https://pub.dev"
     source: hosted
-    version: "6.1.4"
+    version: "7.0.3"
   chopper_generator:
     dependency: "direct dev"
     description:
       name: chopper_generator
-      sha256: "09d512f1acb086cf4101bef02bdb23ee7a8eb55a9935f53af866736606c57523"
+      sha256: "3e55981c7c208269263263d61d23afec9f08ddb022e728bd3ab2cb344096b1a2"
       url: "https://pub.dev"
     source: hosted
-    version: "6.0.3"
+    version: "7.0.1"
   cli_util:
     dependency: transitive
     description:
@@ -325,10 +325,10 @@ packages:
     dependency: "direct main"
     description:
       name: file_picker
-      sha256: b85eb92b175767fdaa0c543bf3b0d1f610fe966412ea72845fe5ba7801e763ff
+      sha256: "9d6e95ec73abbd31ec54d0e0df8a961017e165aba1395e462e5b31ea0c165daf"
       url: "https://pub.dev"
     source: hosted
-    version: "5.2.10"
+    version: "5.3.1"
   file_sizes:
     dependency: "direct main"
     description:
@@ -490,10 +490,10 @@ packages:
     dependency: transitive
     description:
       name: http
-      sha256: "5895291c13fa8a3bd82e76d5627f69e0d85ca6a30dcac95c4ea19a5d555879c2"
+      sha256: "759d1a329847dd0f39226c688d3e06a6b8679668e350e2891a6474f8b4bb8525"
       url: "https://pub.dev"
     source: hosted
-    version: "0.13.6"
+    version: "1.1.0"
   http_multi_server:
     dependency: transitive
     description:
@@ -683,10 +683,10 @@ packages:
     dependency: "direct main"
     description:
       name: package_info_plus
-      sha256: "10259b111176fba5c505b102e3a5b022b51dd97e30522e906d6922c745584745"
+      sha256: "6ff267fcd9d48cb61c8df74a82680e8b82e940231bb5f68356672fde0397334a"
       url: "https://pub.dev"
     source: hosted
-    version: "3.1.2"
+    version: "4.1.0"
   package_info_plus_platform_interface:
     dependency: transitive
     description:
@@ -875,10 +875,10 @@ packages:
     dependency: "direct main"
     description:
       name: share_plus
-      sha256: b1f15232d41e9701ab2f04181f21610c36c83a12ae426b79b4bd011c567934b1
+      sha256: "6cec740fa0943a826951223e76218df002804adb588235a8910dc3d6b0654e11"
       url: "https://pub.dev"
     source: hosted
-    version: "6.3.4"
+    version: "7.1.0"
   share_plus_platform_interface:
     dependency: transitive
     description:
@@ -1120,10 +1120,10 @@ packages:
     dependency: transitive
     description:
       name: win32
-      sha256: a6f0236dbda0f63aa9a25ad1ff9a9d8a4eaaa5012da0dc59d21afdb1dc361ca4
+      sha256: "5a751eddf9db89b3e5f9d50c20ab8612296e4e8db69009788d6c8b060a84191c"
       url: "https://pub.dev"
     source: hosted
-    version: "3.1.4"
+    version: "4.1.4"
   xdg_directories:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -27,7 +27,7 @@ dependencies:
     sdk: flutter
 
   json_annotation: ^4.8.0
-  chopper: ^6.1.1
+  chopper: ^7.0.3
   get_it: ^7.2.0
   just_audio: ^0.9.32
   audio_service: ^0.18.9
@@ -51,9 +51,9 @@ dependencies:
   infinite_scroll_pagination: ^3.2.0
   flutter_sticky_header: ^0.6.5
   device_info_plus: ^8.2.0
-  package_info_plus: ^3.1.0
+  package_info_plus: ^4.1.0
   octo_image: ^1.0.2
-  share_plus: ^6.3.2
+  share_plus: ^7.1.0
 
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.
@@ -77,7 +77,7 @@ dev_dependencies:
   flutter_test:
     sdk: flutter
   build_runner: ^2.3.3
-  chopper_generator: ^6.0.0
+  chopper_generator: ^7.0.1
   hive_generator: ^2.0.0
   json_serializable: ^6.6.1
   flutter_launcher_icons: ^0.13.0


### PR DESCRIPTION
Currently, the log screen has a lot of short or empty entries from chopper, aggregating the chopper logs per request and response fixes this. However, this requires the latest chopper version (since the required changes were also contributed by myself), and that required a few more updates. Preferably, you'd make those dependency updates yourself and afterward I rebase this PR.