### PR TITLE
Playing Directly from Artist Page

### DIFF
--- a/lib/components/ArtistScreen/artist_play_button.dart
+++ b/lib/components/ArtistScreen/artist_play_button.dart
@@ -52,12 +52,27 @@ class _ArtistPlayButtonState extends State<ArtistPlayButton> {
               }
              }
             
-             songs.sort((a, b) => a.indexNumber!.compareTo(b.indexNumber!));
+             // We have to sort by hand in offline mode because a downloadedParent for artists hasn't been implemented
+             Map<String, List<BaseItemDto>> groupedSongs = {};
+             for (BaseItemDto song in songs) {
+              groupedSongs.putIfAbsent((song.albumId ?? 'unknown'), () => []);
+              groupedSongs[song.albumId]!.add(song);
+             }
+
+             groupedSongs.forEach((album, albumSongs) {
+               albumSongs.sort((a, b) => a.indexNumber!.compareTo(b.indexNumber!));
+             });
+
+             final List<BaseItemDto> sortedSongs = [];
+             groupedSongs.values.forEach((albumSongs) {
+               sortedSongs.addAll(albumSongs);
+             });
+            
 
               return IconButton(
                 onPressed: () async {
                   await _audioServiceHelper
-                         .replaceQueueWithItem(itemList: songs);
+                         .replaceQueueWithItem(itemList: sortedSongs);
                 },
                 icon: const Icon(Icons.play_arrow),
               );

--- a/lib/components/ArtistScreen/artist_play_button.dart
+++ b/lib/components/ArtistScreen/artist_play_button.dart
@@ -1,0 +1,65 @@
+import 'package:flutter/material.dart';
+import 'package:get_it/get_it.dart';
+
+
+import '../../models/jellyfin_models.dart';
+import '../../services/jellyfin_api_helper.dart';
+import '../../services/audio_service_helper.dart';
+
+class ArtistPlayButton extends StatefulWidget {
+  const ArtistPlayButton({
+    Key? key,
+    required this.artist,
+  }) : super(key: key);
+
+  final BaseItemDto artist;
+  
+
+  @override
+  State<ArtistPlayButton> createState() => _ArtistPlayButtonState();
+}
+
+class _ArtistPlayButtonState extends State<ArtistPlayButton> {
+  static const _disabledButton = IconButton(
+    onPressed: null,
+    icon: Icon(Icons.play_arrow)
+    );
+    Future<List<BaseItemDto>?>? artistPlayButtonFuture;
+
+    final jellyfinApiHelper = GetIt.instance<JellyfinApiHelper>();
+    final audioServiceHelper = GetIt.instance<AudioServiceHelper>();
+
+    @override
+    initState() {
+       artistPlayButtonFuture ??= jellyfinApiHelper.getItems(
+            parentItem: widget.artist,
+            includeItemTypes: "Audio",
+            sortBy: 'PremiereDate,Album,SortName',
+            isGenres: false,
+          );
+          super.initState();
+    }
+    
+    @override
+    Widget build(BuildContext context) {
+      return FutureBuilder<List<BaseItemDto>?>(
+        future: artistPlayButtonFuture,
+        builder: (context, snapshot) {
+          if (snapshot.hasData){
+            final List<BaseItemDto> items = snapshot.data!;
+
+            return IconButton(
+              onPressed: () async {
+                await audioServiceHelper
+                       .replaceQueueWithItem(itemList: items);
+              }, 
+              icon: const Icon(Icons.play_arrow),
+              );
+          } else {
+            return _disabledButton;
+          }
+        },
+      );
+    }
+
+}

--- a/lib/components/ArtistScreen/artist_play_button.dart
+++ b/lib/components/ArtistScreen/artist_play_button.dart
@@ -60,7 +60,7 @@ class _ArtistPlayButtonState extends State<ArtistPlayButton> {
              }
 
              groupedSongs.forEach((album, albumSongs) {
-               albumSongs.sort((a, b) => a.indexNumber!.compareTo(b.indexNumber!));
+               albumSongs.sort((a, b) => (a.indexNumber ?? 0).compareTo(b.indexNumber ?? 0));
              });
 
              final List<BaseItemDto> sortedSongs = [];

--- a/lib/components/ArtistScreen/artist_play_button.dart
+++ b/lib/components/ArtistScreen/artist_play_button.dart
@@ -1,10 +1,14 @@
 import 'package:flutter/material.dart';
 import 'package:get_it/get_it.dart';
+import 'package:hive/hive.dart';
 
 
 import '../../models/jellyfin_models.dart';
+import '../../models/finamp_models.dart';
 import '../../services/jellyfin_api_helper.dart';
 import '../../services/audio_service_helper.dart';
+import '../../services/finamp_settings_helper.dart';
+import '../../services/downloads_helper.dart';
 
 class ArtistPlayButton extends StatefulWidget {
   const ArtistPlayButton({
@@ -26,40 +30,65 @@ class _ArtistPlayButtonState extends State<ArtistPlayButton> {
     );
     Future<List<BaseItemDto>?>? artistPlayButtonFuture;
 
-    final jellyfinApiHelper = GetIt.instance<JellyfinApiHelper>();
-    final audioServiceHelper = GetIt.instance<AudioServiceHelper>();
+    final _jellyfinApiHelper = GetIt.instance<JellyfinApiHelper>();
+    final _audioServiceHelper = GetIt.instance<AudioServiceHelper>();
+
 
     @override
-    initState() {
-       artistPlayButtonFuture ??= jellyfinApiHelper.getItems(
+    Widget build(BuildContext context) {
+      return ValueListenableBuilder<Box<FinampSettings>>(
+        valueListenable: FinampSettingsHelper.finampSettingsListener,
+        builder: (context, box, _) {
+          final isOffline = box.get("FinampSettings")?.isOffline ?? false;
+
+          if (isOffline) {
+             final downloadsHelper = GetIt.instance<DownloadsHelper>();
+
+             final List<BaseItemDto>songs = [];
+
+             for (DownloadedSong item in downloadsHelper.downloadedItems) {
+              if (item.song.albumArtist == widget.artist.name) {
+                songs.add(item.song);
+              }
+             }
+            
+             songs.sort((a, b) => a.indexNumber!.compareTo(b.indexNumber!));
+
+              return IconButton(
+                onPressed: () async {
+                  await _audioServiceHelper
+                         .replaceQueueWithItem(itemList: songs);
+                },
+                icon: const Icon(Icons.play_arrow),
+              );
+          } else {
+            artistPlayButtonFuture ??= _jellyfinApiHelper.getItems(
             parentItem: widget.artist,
             includeItemTypes: "Audio",
             sortBy: 'PremiereDate,Album,SortName',
             isGenres: false,
-          );
-          super.initState();
-    }
-    
-    @override
-    Widget build(BuildContext context) {
-      return FutureBuilder<List<BaseItemDto>?>(
-        future: artistPlayButtonFuture,
-        builder: (context, snapshot) {
-          if (snapshot.hasData){
-            final List<BaseItemDto> items = snapshot.data!;
+            );
 
-            return IconButton(
-              onPressed: () async {
-                await audioServiceHelper
-                       .replaceQueueWithItem(itemList: items);
-              }, 
-              icon: const Icon(Icons.play_arrow),
-              );
-          } else {
-            return _disabledButton;
-          }
+            return FutureBuilder<List<BaseItemDto>?>(
+            future: artistPlayButtonFuture,
+            builder: (context, snapshot) {
+              if (snapshot.hasData){
+                final List<BaseItemDto> items = snapshot.data!;
+
+                return IconButton(
+                  onPressed: () async {
+                    await _audioServiceHelper
+                           .replaceQueueWithItem(itemList: items);
+                  }, 
+                  icon: const Icon(Icons.play_arrow),
+                  );
+              } else {
+                return _disabledButton;
+              }
+            },
+          );
+         }
         },
       );
     }
-
 }

--- a/lib/components/ArtistScreen/artist_shuffle_button.dart
+++ b/lib/components/ArtistScreen/artist_shuffle_button.dart
@@ -10,8 +10,8 @@ import '../../services/audio_service_helper.dart';
 import '../../services/finamp_settings_helper.dart';
 import '../../services/downloads_helper.dart';
 
-class ArtistPlayButton extends StatefulWidget {
-  const ArtistPlayButton({
+class ArtistShuffleButton extends StatefulWidget {
+  const ArtistShuffleButton({
     Key? key,
     required this.artist,
   }) : super(key: key);
@@ -20,15 +20,15 @@ class ArtistPlayButton extends StatefulWidget {
   
 
   @override
-  State<ArtistPlayButton> createState() => _ArtistPlayButtonState();
+  State<ArtistShuffleButton> createState() => _ArtistShuffleButtonState();
 }
 
-class _ArtistPlayButtonState extends State<ArtistPlayButton> {
+class _ArtistShuffleButtonState extends State<ArtistShuffleButton> {
   static const _disabledButton = IconButton(
     onPressed: null,
     icon: Icon(Icons.play_arrow)
     );
-    Future<List<BaseItemDto>?>? artistPlayButtonFuture;
+    Future<List<BaseItemDto>?>? artistShuffleButtonFuture;
 
     final _jellyfinApiHelper = GetIt.instance<JellyfinApiHelper>();
     final _audioServiceHelper = GetIt.instance<AudioServiceHelper>();
@@ -52,28 +52,15 @@ class _ArtistPlayButtonState extends State<ArtistPlayButton> {
               }
              }
             
-             // We have to sort by hand in offline mode because a downloadedParent for artists hasn't been implemented
-             Map<String, List<BaseItemDto>> groupedSongs = {};
-             for (BaseItemDto song in artistsSongs) {
-              groupedSongs.putIfAbsent((song.albumId ?? 'unknown'), () => []);
-              groupedSongs[song.albumId]!.add(song);
-             }
-
-             final List<BaseItemDto> sortedSongs = [];
-             groupedSongs.forEach((album, albumSongs) {
-               albumSongs.sort((a, b) => (a.indexNumber ?? 0).compareTo(b.indexNumber ?? 0));
-               sortedSongs.addAll(albumSongs);
-             });
-
               return IconButton(
                 onPressed: () async {
                   await _audioServiceHelper
-                         .replaceQueueWithItem(itemList: sortedSongs);
+                         .replaceQueueWithItem(itemList: artistsSongs, shuffle: true);
                 },
-                icon: const Icon(Icons.play_arrow),
+                icon: const Icon(Icons.shuffle),
               );
           } else {
-            artistPlayButtonFuture ??= _jellyfinApiHelper.getItems(
+            artistShuffleButtonFuture ??= _jellyfinApiHelper.getItems(
             parentItem: widget.artist,
             includeItemTypes: "Audio",
             sortBy: 'PremiereDate,Album,SortName',
@@ -81,7 +68,7 @@ class _ArtistPlayButtonState extends State<ArtistPlayButton> {
             );
 
             return FutureBuilder<List<BaseItemDto>?>(
-            future: artistPlayButtonFuture,
+            future: artistShuffleButtonFuture,
             builder: (context, snapshot) {
               if (snapshot.hasData){
                 final List<BaseItemDto> items = snapshot.data!;
@@ -89,9 +76,9 @@ class _ArtistPlayButtonState extends State<ArtistPlayButton> {
                 return IconButton(
                   onPressed: () async {
                     await _audioServiceHelper
-                           .replaceQueueWithItem(itemList: items);
+                           .replaceQueueWithItem(itemList: items, shuffle: true);
                   }, 
-                  icon: const Icon(Icons.play_arrow),
+                  icon: const Icon(Icons.shuffle),
                   );
               } else {
                 return _disabledButton;

--- a/lib/components/MusicScreen/music_screen_tab_view.dart
+++ b/lib/components/MusicScreen/music_screen_tab_view.dart
@@ -28,6 +28,7 @@ class MusicScreenTabView extends StatefulWidget {
     this.sortBy,
     this.sortOrder,
     this.view,
+    this.albumArtist,
   }) : super(key: key);
 
   final TabContentType tabContentType;
@@ -37,6 +38,7 @@ class MusicScreenTabView extends StatefulWidget {
   final SortBy? sortBy;
   final SortOrder? sortOrder;
   final BaseItemDto? view;
+  final String? albumArtist; 
 
   @override
   State<MusicScreenTabView> createState() => _MusicScreenTabViewState();
@@ -183,12 +185,14 @@ class _MusicScreenTabViewState extends State<MusicScreenTabView>
                     .map((e) => e.song)
                     .toList();
               } else {
+                String? albumArtist = widget.albumArtist;
                 offlineSortedItems = downloadsHelper.downloadedParents
                     .where((element) =>
                         element.item.type ==
                             _includeItemTypes(widget.tabContentType) &&
                         element.viewId ==
-                            _finampUserHelper.currentUser!.currentViewId)
+                            _finampUserHelper.currentUser!.currentViewId &&
+                            (albumArtist == null || element.item.albumArtist?.toLowerCase() == albumArtist.toLowerCase()))
                     .map((e) => e.item)
                     .toList();
               }

--- a/lib/screens/artist_screen.dart
+++ b/lib/screens/artist_screen.dart
@@ -6,6 +6,7 @@ import '../components/ArtistScreen/artist_download_button.dart';
 import '../components/MusicScreen/music_screen_tab_view.dart';
 import '../components/now_playing_bar.dart';
 import '../components/favourite_button.dart';
+import '../components/ArtistScreen/artist_play_button.dart';
 
 class ArtistScreen extends StatelessWidget {
   const ArtistScreen({
@@ -28,7 +29,7 @@ class ArtistScreen extends StatelessWidget {
         title: Text(artist.name ?? "Unknown Name"),
         actions: [
           // this screen is also used for genres, which can't be favorited
-          if (artist.type != "MusicGenre") FavoriteButton(item: artist),
+          if (artist.type != "MusicGenre") ArtistPlayButton(artist: artist), FavoriteButton(item: artist),
           ArtistDownloadButton(artist: artist)
         ],
       ),

--- a/lib/screens/artist_screen.dart
+++ b/lib/screens/artist_screen.dart
@@ -39,6 +39,7 @@ class ArtistScreen extends StatelessWidget {
         parentItem: artist,
         isFavourite: false,
         sortBy: SortBy.premiereDate,
+        albumArtist: artist.name,
       ),
       bottomNavigationBar: const NowPlayingBar(),
     );

--- a/lib/screens/artist_screen.dart
+++ b/lib/screens/artist_screen.dart
@@ -7,6 +7,7 @@ import '../components/MusicScreen/music_screen_tab_view.dart';
 import '../components/now_playing_bar.dart';
 import '../components/favourite_button.dart';
 import '../components/ArtistScreen/artist_play_button.dart';
+import '../components/ArtistScreen/artist_shuffle_button.dart';
 
 class ArtistScreen extends StatelessWidget {
   const ArtistScreen({
@@ -30,6 +31,7 @@ class ArtistScreen extends StatelessWidget {
         actions: [
           // this screen is also used for genres, which can't be favorited
           if (artist.type != "MusicGenre") ArtistPlayButton(artist: artist),
+          if (artist.type != "MusicGenre") ArtistShuffleButton(artist: artist), 
           if (artist.type != "MusicGenre") FavoriteButton(item: artist),
           ArtistDownloadButton(artist: artist)
         ],

--- a/lib/screens/artist_screen.dart
+++ b/lib/screens/artist_screen.dart
@@ -29,7 +29,8 @@ class ArtistScreen extends StatelessWidget {
         title: Text(artist.name ?? "Unknown Name"),
         actions: [
           // this screen is also used for genres, which can't be favorited
-          if (artist.type != "MusicGenre") ArtistPlayButton(artist: artist), FavoriteButton(item: artist),
+          if (artist.type != "MusicGenre") ArtistPlayButton(artist: artist),
+          if (artist.type != "MusicGenre") FavoriteButton(item: artist),
           ArtistDownloadButton(artist: artist)
         ],
       ),

--- a/lib/screens/artist_screen.dart
+++ b/lib/screens/artist_screen.dart
@@ -38,6 +38,7 @@ class ArtistScreen extends StatelessWidget {
         tabContentType: TabContentType.albums,
         parentItem: artist,
         isFavourite: false,
+        sortBy: SortBy.premiereDate,
       ),
       bottomNavigationBar: const NowPlayingBar(),
     );


### PR DESCRIPTION
Implements #424 

Adds a button to play all albums of an artist in both offline mode and online mode. Previously, the artist view in offline mode would just show up as a white screen if albums from multiple artists were downloaded. I had to add a bit of code to music_screen_tab_view.dart to make sure only the albums corresponding with the artist show up. Otherwise all downloaded albums in offline mode would show up in each individual artist view.

Also, how do I setup the environment for the redesign branch? I would have written the code in the redesign branch, but I couldn't get that branch to build. I suspect I just set up the environment incorrectly. 

Before:
![IMG_8149](https://github.com/jmshrv/finamp/assets/84159993/c29774a0-dbd7-48dd-91fe-256b38ba8059)

After:
![IMG_8148](https://github.com/jmshrv/finamp/assets/84159993/46e20c7f-0708-42df-a742-41138be18f5b)

