### PR TITLE
:sparkles: Store listens when offline or if submission failed

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -6,6 +6,7 @@ import 'package:audio_service/audio_service.dart';
 import 'package:audio_session/audio_session.dart';
 import 'package:finamp/services/finamp_settings_helper.dart';
 import 'package:finamp/services/finamp_user_helper.dart';
+import 'package:finamp/services/offline_listen_helper.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_downloader/flutter_downloader.dart';
@@ -18,37 +19,37 @@ import 'package:logging/logging.dart';
 import 'package:uuid/uuid.dart';
 
 import 'generate_material_color.dart';
+import 'models/finamp_models.dart';
+import 'models/jellyfin_models.dart';
 import 'models/locale_adapter.dart';
 import 'models/theme_mode_adapter.dart';
-import 'screens/language_selection_screen.dart';
-import 'services/locale_helper.dart';
-import 'services/theme_mode_helper.dart';
-import 'setup_logging.dart';
-import 'screens/user_selector.dart';
-import 'screens/music_screen.dart';
-import 'screens/view_selector.dart';
+import 'screens/add_download_location_screen.dart';
+import 'screens/add_to_playlist_screen.dart';
 import 'screens/album_screen.dart';
-import 'screens/player_screen.dart';
-import 'screens/splash_screen.dart';
+import 'screens/artist_screen.dart';
+import 'screens/audio_service_settings_screen.dart';
 import 'screens/downloads_error_screen.dart';
 import 'screens/downloads_screen.dart';
-import 'screens/artist_screen.dart';
-import 'screens/logs_screen.dart';
-import 'screens/settings_screen.dart';
-import 'screens/transcoding_settings_screen.dart';
 import 'screens/downloads_settings_screen.dart';
-import 'screens/add_download_location_screen.dart';
-import 'screens/audio_service_settings_screen.dart';
-import 'screens/tabs_settings_screen.dart';
-import 'screens/add_to_playlist_screen.dart';
+import 'screens/language_selection_screen.dart';
 import 'screens/layout_settings_screen.dart';
+import 'screens/logs_screen.dart';
+import 'screens/music_screen.dart';
+import 'screens/player_screen.dart';
+import 'screens/settings_screen.dart';
+import 'screens/splash_screen.dart';
+import 'screens/tabs_settings_screen.dart';
+import 'screens/transcoding_settings_screen.dart';
+import 'screens/user_selector.dart';
+import 'screens/view_selector.dart';
 import 'services/audio_service_helper.dart';
-import 'services/jellyfin_api_helper.dart';
-import 'services/downloads_helper.dart';
 import 'services/download_update_stream.dart';
+import 'services/downloads_helper.dart';
+import 'services/jellyfin_api_helper.dart';
+import 'services/locale_helper.dart';
 import 'services/music_player_background_task.dart';
-import 'models/jellyfin_models.dart';
-import 'models/finamp_models.dart';
+import 'services/theme_mode_helper.dart';
+import 'setup_logging.dart';
 
 void main() async {
   // If the app has failed, this is set to true. If true, we don't attempt to run the main app since the error app has started.
@@ -60,6 +61,7 @@ void main() async {
     _migrateSortOptions();
     _setupFinampUserHelper();
     _setupJellyfinApiData();
+    _setupOfflineListenLogHelper();
     await _setupDownloader();
     await _setupDownloadsHelper();
     await _setupAudioServiceHelper();
@@ -89,6 +91,10 @@ void main() async {
 
 void _setupJellyfinApiData() {
   GetIt.instance.registerSingleton(JellyfinApiHelper());
+}
+
+void _setupOfflineListenLogHelper() {
+  GetIt.instance.registerSingleton(OfflineListenLogHelper());
 }
 
 Future<void> _setupDownloadsHelper() async {

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -175,6 +175,7 @@ Future<void> setupHive() async {
   Hive.registerAdapter(DownloadedImageAdapter());
   Hive.registerAdapter(ThemeModeAdapter());
   Hive.registerAdapter(LocaleAdapter());
+  Hive.registerAdapter(OfflineListenAdapter());
   await Future.wait([
     Hive.openBox<DownloadedParent>("DownloadedParents"),
     Hive.openBox<DownloadedSong>("DownloadedItems"),
@@ -186,6 +187,7 @@ Future<void> setupHive() async {
     Hive.openBox<String>("DownloadedImageIds"),
     Hive.openBox<ThemeMode>("ThemeMode"),
     Hive.openBox<Locale?>(LocaleHelper.boxName),
+    Hive.openBox<OfflineListen>("OfflineListens")
   ]);
 
   // If the settings box is empty, we add an initial settings value here.

--- a/lib/models/finamp_models.dart
+++ b/lib/models/finamp_models.dart
@@ -5,12 +5,12 @@ import 'package:flutter_downloader/flutter_downloader.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:hive/hive.dart';
 import 'package:json_annotation/json_annotation.dart';
-import 'package:uuid/uuid.dart';
 import 'package:path/path.dart' as path_helper;
+import 'package:uuid/uuid.dart';
 
 import '../services/finamp_settings_helper.dart';
-import 'jellyfin_models.dart';
 import '../services/get_internal_song_dir.dart';
+import 'jellyfin_models.dart';
 
 part 'finamp_models.g.dart';
 
@@ -570,4 +570,40 @@ class DownloadedImage {
         requiredBy: requiredBy ?? [],
         downloadLocationId: downloadLocationId,
       );
+}
+
+@HiveType(typeId: 43)
+class OfflineListen {
+  OfflineListen({
+    required this.timestamp,
+    required this.userId,
+    required this.itemId,
+    required this.name,
+    this.artist,
+    this.album,
+    this.trackMbid,
+  });
+
+  /// The stop timestamp of the listen, measured in seconds since the epoch.
+  @HiveField(0)
+  int timestamp;
+
+  @HiveField(1)
+  String userId;
+
+  @HiveField(2)
+  String itemId;
+
+  @HiveField(3)
+  String name;
+
+  @HiveField(4)
+  String? artist;
+
+  @HiveField(5)
+  String? album;
+
+  // The MusicBrainz ID of the track, if available.
+  @HiveField(6)
+  String? trackMbid;
 }

--- a/lib/models/finamp_models.g.dart
+++ b/lib/models/finamp_models.g.dart
@@ -372,6 +372,58 @@ class DownloadedImageAdapter extends TypeAdapter<DownloadedImage> {
           typeId == other.typeId;
 }
 
+class OfflineListenAdapter extends TypeAdapter<OfflineListen> {
+  @override
+  final int typeId = 43;
+
+  @override
+  OfflineListen read(BinaryReader reader) {
+    final numOfFields = reader.readByte();
+    final fields = <int, dynamic>{
+      for (int i = 0; i < numOfFields; i++) reader.readByte(): reader.read(),
+    };
+    return OfflineListen(
+      timestamp: fields[0] as int,
+      userId: fields[1] as String,
+      itemId: fields[2] as String,
+      name: fields[3] as String,
+      artist: fields[4] as String?,
+      album: fields[5] as String?,
+      trackMbid: fields[6] as String?,
+    );
+  }
+
+  @override
+  void write(BinaryWriter writer, OfflineListen obj) {
+    writer
+      ..writeByte(7)
+      ..writeByte(0)
+      ..write(obj.timestamp)
+      ..writeByte(1)
+      ..write(obj.userId)
+      ..writeByte(2)
+      ..write(obj.itemId)
+      ..writeByte(3)
+      ..write(obj.name)
+      ..writeByte(4)
+      ..write(obj.artist)
+      ..writeByte(5)
+      ..write(obj.album)
+      ..writeByte(6)
+      ..write(obj.trackMbid);
+  }
+
+  @override
+  int get hashCode => typeId.hashCode;
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is OfflineListenAdapter &&
+          runtimeType == other.runtimeType &&
+          typeId == other.typeId;
+}
+
 class TabContentTypeAdapter extends TypeAdapter<TabContentType> {
   @override
   final int typeId = 36;

--- a/lib/services/finamp_user_helper.dart
+++ b/lib/services/finamp_user_helper.dart
@@ -13,6 +13,9 @@ class FinampUserHelper {
   /// Checks if there are any saved users.
   bool get isUsersEmpty => _finampUserBox.isEmpty;
 
+  /// Loads the id from CurrentUserId. Returns null if no id is stored.
+  String? get currentUserId => _currentUserIdBox.get("CurrentUserId");
+
   /// Loads the FinampUser with the id from CurrentUserId. Returns null if no
   /// user exists.
   FinampUser? get currentUser =>

--- a/lib/services/offline_listen_helper.dart
+++ b/lib/services/offline_listen_helper.dart
@@ -1,0 +1,64 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:audio_service/audio_service.dart';
+import 'package:logging/logging.dart';
+import 'package:path_provider/path_provider.dart';
+
+/// Logs offline listens or failed submissions to a file.
+class OfflineListenLogHelper {
+  final _logger = Logger("OfflineListenLogHelper");
+
+  Future<Directory> get _logDirectory async {
+    if (!Platform.isAndroid) {
+      return await getApplicationDocumentsDirectory();
+    }
+
+    final List<Directory>? dirs =
+        await getExternalStorageDirectories(type: StorageDirectory.documents);
+    return dirs?.first ?? await getApplicationDocumentsDirectory();
+  }
+
+  Future<File> get _logFile async {
+    final Directory directory = await _logDirectory;
+    return File("${directory.path}/listens.json");
+  }
+
+  Future<void> logOfflineListen(MediaItem item) async {
+    final timestamp = DateTime.now().millisecondsSinceEpoch ~/ 1000;
+    final itemJson = item.extras!["itemJson"];
+    final id = itemJson["Id"];
+    final name = itemJson["Name"];
+    final albumArtist = itemJson["AlbumArtist"];
+    final album = itemJson["Album"];
+    final trackMbid = itemJson["ProviderIds"]?["MusicBrainzTrack"];
+
+    await _logOfflineListen(timestamp, id, name, albumArtist, album, trackMbid);
+  }
+
+  Future<void> _logOfflineListen(
+    int timestamp,
+    String id,
+    String name,
+    String? artist,
+    String? album,
+    String? trackMbid,
+  ) async {
+    final data = {
+      'timestamp': timestamp,
+      'id': id,
+      'title': name,
+      'artist': artist,
+      'album': album,
+      'track_mbid': trackMbid,
+    };
+    final content = json.encode(data) + Platform.lineTerminator;
+
+    final file = await _logFile;
+    try {
+      file.writeAsString(content, mode: FileMode.append, flush: true);
+    } catch (e) {
+      _logger.warning("Failed to write listen to file: $content");
+    }
+  }
+}

--- a/lib/services/offline_listen_helper.dart
+++ b/lib/services/offline_listen_helper.dart
@@ -27,6 +27,9 @@ class OfflineListenLogHelper {
     return File("${directory.path}/listens.json");
   }
 
+  /// Logs a listen to a file.
+  ///
+  /// This is used when the user is offline or submitting live playback events fails.
   Future<void> logOfflineListen(MediaItem item) async {
     final itemJson = item.extras!["itemJson"];
 
@@ -41,6 +44,11 @@ class OfflineListenLogHelper {
     );
   }
 
+  /// Logs a listen to a file.
+  ///
+  /// This is used when the user is offline or submitting live playback events fails.
+  /// The [timestamp] provided to this function should be in seconds
+  /// and marks the time the track was stopped.
   Future<void> _logOfflineListen({
     required int timestamp,
     required String itemId,


### PR DESCRIPTION
Useful if you want to manually export them to ListenBrainz or similar later on.

The biggest problem is that the exported file is not easily viewable at the moment. On newer Android versions, you can only view the files when attached to a computer (or with root permissions). On iOS, it's not possible at all.
However, we can probably build some export feature later on.