### PR TITLE
:eyes: Further tweak color scheme

### DIFF
--- a/lib/color_schemes.g.dart
+++ b/lib/color_schemes.g.dart
@@ -1,34 +1,39 @@
 import 'package:flutter/material.dart';
 
-/// The accent color that this color scheme is based on,
-/// using the [M3 Theme Builder](https://m3.material.io/theme-builder).
-const defaultAccentColor = Color(0xFF00A4DC);
+const jellyfinBlueColor = Color(0xFF00A4DC);
+const jellyfinPurpleColor = Color(0xFFAA5CC3);
 
 const lightColorScheme = ColorScheme(
   brightness: Brightness.light,
+  // Primary
   primary: Color(0xFF00668A),
   onPrimary: Color(0xFFFFFFFF),
-  primaryContainer: Color(0xFFC3E7FF),
+  primaryContainer: Color(0xFFC4E8FF),
   onPrimaryContainer: Color(0xFF001E2C),
-  secondary: Color(0xFF4E616D),
+  // Secondary
+  secondary: Color(0xFF406374),
   onSecondary: Color(0xFFFFFFFF),
-  secondaryContainer: Color(0xFFD1E5F4),
-  onSecondaryContainer: Color(0xFF0A1E28),
-  tertiary: Color(0xFF00668A),
+  secondaryContainer: Color(0xFFCCE8F8),
+  onSecondaryContainer: Color(0xFF1B333F),
+  // Tertiary
+  tertiary: Color(0xFF893DA2),
   onTertiary: Color(0xFFFFFFFF),
-  tertiaryContainer: Color(0xFFC3E7FF),
-  onTertiaryContainer: Color(0xFF001E2C),
+  tertiaryContainer: Color(0xFFFAD7FF),
+  onTertiaryContainer: Color(0xFF330044),
+  // Error
   error: Color(0xFFBA1A1A),
   errorContainer: Color(0xFFFFDAD6),
   onError: Color(0xFFFFFFFF),
   onErrorContainer: Color(0xFF410002),
-  background: Color(0xFFFBFCFF),
+  // Background & Surface
+  background: Color(0xFFFCFDFE),
   onBackground: Color(0xFF191C1E),
-  surface: Color(0xFFFBFCFF),
+  surface: Color(0xFFFCFDFE),
   onSurface: Color(0xFF191C1E),
-  surfaceVariant: Color(0xFFDCE3E9),
+  surfaceVariant: Color(0xFFDDE4E8),
   onSurfaceVariant: Color(0xFF41484D),
-  outline: Color(0xFF71787D),
+  // Other colors
+  outline: Color(0xFF727A7F),
   onInverseSurface: Color(0xFFF0F1F3),
   inverseSurface: Color(0xFF2E3133),
   inversePrimary: Color(0xFF7BD0FF),
@@ -40,29 +45,35 @@ const lightColorScheme = ColorScheme(
 
 const darkColorScheme = ColorScheme(
   brightness: Brightness.dark,
-  primary: Color(0xFF7BD0FF),
-  onPrimary: Color(0xFF003549),
-  primaryContainer: Color(0xFF004C69),
+  // Primary
+  primary: jellyfinBlueColor,
+  onPrimary: Color(0xFF001E2C),
+  primaryContainer: Color(0xFF004C68),
   onPrimaryContainer: Color(0xFFC3E7FF),
-  secondary: Color(0xFFB5C9D7),
-  onSecondary: Color(0xFF20333E),
-  secondaryContainer: Color(0xFF364955),
-  onSecondaryContainer: Color(0xFFD1E5F4),
-  tertiary: Color(0xFF7BD0FF),
-  onTertiary: Color(0xFF003549),
-  tertiaryContainer: Color(0xFF004C69),
-  onTertiaryContainer: Color(0xFFC3E7FF),
+  // Secondary
+  secondary: Color(0xFF60B4DD),
+  onSecondary: Color(0xFF112732),
+  secondaryContainer: Color(0xFF206B8C),
+  onSecondaryContainer: Color(0xFFCEEEFF),
+  // Tertiary
+  tertiary: Color(0xFFC979E2),
+  onTertiary: Color(0xFF3D0050),
+  tertiaryContainer: Color(0xFF762A90),
+  onTertiaryContainer: Color(0xFFFAD7FF),
+  // Error
   error: Color(0xFFFFB4AB),
   errorContainer: Color(0xFF93000A),
   onError: Color(0xFF690005),
   onErrorContainer: Color(0xFFFFDAD6),
-  background: Color(0xFF191C1E),
+  // Background & Surface
+  background: Color(0xFF101315),
   onBackground: Color(0xFFE1E2E5),
-  surface: Color(0xFF191C1E),
+  surface: Color(0xFF101315),
   onSurface: Color(0xFFE1E2E5),
-  surfaceVariant: Color(0xFF41484D),
+  surfaceVariant: Color(0xFF333A3E),
   onSurfaceVariant: Color(0xFFC0C7CD),
-  outline: Color(0xFF8B9297),
+  // Other colors
+  outline: Color(0xFF80878C),
   onInverseSurface: Color(0xFF191C1E),
   inverseSurface: Color(0xFFE1E2E5),
   inversePrimary: Color(0xFF00668A),

--- a/lib/components/AlbumScreen/song_list_tile.dart
+++ b/lib/components/AlbumScreen/song_list_tile.dart
@@ -4,18 +4,18 @@ import 'package:get_it/get_it.dart';
 import 'package:mini_music_visualizer/mini_music_visualizer.dart';
 
 import '../../models/jellyfin_models.dart';
+import '../../screens/add_to_playlist_screen.dart';
+import '../../screens/album_screen.dart';
 import '../../services/audio_service_helper.dart';
-import '../../services/jellyfin_api_helper.dart';
-import '../../services/finamp_settings_helper.dart';
 import '../../services/downloads_helper.dart';
+import '../../services/finamp_settings_helper.dart';
+import '../../services/jellyfin_api_helper.dart';
 import '../../services/media_state_stream.dart';
 import '../../services/process_artist.dart';
-import '../../screens/album_screen.dart';
-import '../../screens/add_to_playlist_screen.dart';
-import '../favourite_button.dart';
 import '../album_image.dart';
-import '../print_duration.dart';
 import '../error_snackbar.dart';
+import '../favourite_button.dart';
+import '../print_duration.dart';
 import 'downloaded_indicator.dart';
 
 enum SongListTileMenuItems {
@@ -184,12 +184,11 @@ class _SongListTileState extends State<SongListTile> {
               mainAxisSize: MainAxisSize.min,
               children: [
                 if (isCurrentlyPlaying &&
-                    (snapshot.data?.playbackState.playing ?? false
-                    ))
+                    (snapshot.data?.playbackState.playing ?? false))
                   Padding(
                     padding: const EdgeInsets.symmetric(horizontal: 8),
                     child: MiniMusicVisualizer(
-                      color: Theme.of(context).colorScheme.primary,
+                      color: Theme.of(context).colorScheme.secondary,
                       width: 4,
                       height: 15,
                     ),
@@ -450,10 +449,10 @@ class _SongListTileState extends State<SongListTile> {
                   ? DismissDirection.none
                   : DismissDirection.horizontal,
               background: Container(
-                color: Theme.of(context).colorScheme.secondary,
+                color: Theme.of(context).colorScheme.secondaryContainer,
                 alignment: Alignment.centerLeft,
-                child: const Padding(
-                  padding: EdgeInsets.symmetric(horizontal: 16.0),
+                child: Padding(
+                  padding: const EdgeInsets.symmetric(horizontal: 16.0),
                   child: Row(
                     children: [
                       AspectRatio(
@@ -461,8 +460,13 @@ class _SongListTileState extends State<SongListTile> {
                         child: FittedBox(
                           fit: BoxFit.fitHeight,
                           child: Padding(
-                            padding: EdgeInsets.symmetric(vertical: 8.0),
-                            child: Icon(Icons.queue_music),
+                            padding: const EdgeInsets.symmetric(vertical: 8.0),
+                            child: Icon(
+                              Icons.queue_music,
+                              color: Theme.of(context)
+                                  .colorScheme
+                                  .onSecondaryContainer,
+                            ),
                           ),
                         ),
                       )

--- a/lib/components/MusicScreen/view_list_tile.dart
+++ b/lib/components/MusicScreen/view_list_tile.dart
@@ -18,14 +18,14 @@ class ViewListTile extends StatelessWidget {
       leading: ViewIcon(
         collectionType: view.collectionType,
         color: finampUserHelper.currentUser!.currentViewId == view.id
-            ? Theme.of(context).colorScheme.secondary
+            ? Theme.of(context).colorScheme.primary
             : null,
       ),
       title: Text(
         view.name ?? "Unknown Name",
         style: TextStyle(
           color: finampUserHelper.currentUser!.currentViewId == view.id
-              ? Theme.of(context).colorScheme.secondary
+              ? Theme.of(context).colorScheme.primary
               : null,
         ),
       ),

--- a/lib/components/PlayerScreen/progress_slider.dart
+++ b/lib/components/PlayerScreen/progress_slider.dart
@@ -37,6 +37,8 @@ class _ProgressSliderState extends State<ProgressSlider> {
 
     _sliderThemeData = SliderTheme.of(context).copyWith(
       trackHeight: 4.0,
+      inactiveTrackColor:
+          Theme.of(context).colorScheme.surfaceVariant.withOpacity(0.5),
     );
   }
 


### PR DESCRIPTION
Couldn't help myself and made some further refinements, as teased in #561.

- Use original Jellyfin colors in dark theme (for the light theme, they're too light, unfortunately)
- Base secondary color upon desaturated primary color (reduced chroma)
- Add a proper tertiary color based on the purple Jellyfin accent - right now, it doesn't seem to be used anywhere, though
- Make dark theme backgrounds slightly darker
- Use the secondaryContainer color for the drag-to-queue indicator
- Make progress slider inactive color 50% opaque to be less harsh on the eyes