### PR TITLE
Fix adding playlists/albums to queue in offline mode

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -138,7 +138,7 @@ SPEC CHECKSUMS:
   audio_service: f509d65da41b9521a61f1c404dd58651f265a567
   audio_session: 4f3e461722055d21515cf3261b64c973c062f345
   CropViewController: 58fb440f30dac788b129d2a1f24cffdcb102669c
-  device_info_plus: 7545d84d8d1b896cb16a4ff98c19f07ec4b298ea
+  device_info_plus: c6fb39579d0f423935b0c9ce7ee2f44b71b9fce6
   DKCamera: a902b66921fca14b7a75266feb8c7568aa7caa71
   DKImagePickerController: b512c28220a2b8ac7419f21c491fc8534b7601ac
   DKPhotoGallery: fdfad5125a9fdda9cc57df834d49df790dbb4179
@@ -147,11 +147,11 @@ SPEC CHECKSUMS:
   flutter_downloader: b7301ae057deadd4b1650dc7c05375f10ff12c39
   FMDB: 2ce00b547f966261cd18927a3ddb07cb6f3db82a
   just_audio: baa7252489dbcf47a4c7cc9ca663e9661c99aafa
-  package_info_plus: fd030dabf36271f146f1f3beacd48f564b0f17f7
+  package_info_plus: 115f4ad11e0698c8c1c5d8a689390df880f47e85
   path_provider_foundation: 29f094ae23ebbca9d3d0cec13889cd9060c0e943
   permission_handler_apple: e76247795d700c14ea09e3a2d8855d41ee80a2e6
   SDWebImage: e5cc87bf736e60f49592f307bdf9e157189298a3
-  share_plus: 599aa54e4ea31d4b4c0e9c911bcc26c55e791028
+  share_plus: c3fef564749587fc939ef86ffb283ceac0baf9f5
   sqflite: 31f7eba61e3074736dff8807a9b41581e4f7f15a
   SwiftyGif: 6c3eafd0ce693cad58bb63d2b2fb9bacb8552780
 

--- a/lib/components/MusicScreen/album_item.dart
+++ b/lib/components/MusicScreen/album_item.dart
@@ -175,8 +175,8 @@ class _AlbumItemState extends State<AlbumItem> {
 
           switch (selection) {
             case _AlbumListTileMenuItems.addToQueue:
-
               List<BaseItemDto>? children;
+
               if (isOffline) {
                 final downloadsHelper = GetIt.instance<DownloadsHelper>();
 
@@ -193,20 +193,21 @@ class _AlbumItemState extends State<AlbumItem> {
                   includeItemTypes: "Audio",
                   isGenres: false,
                 );
-
               }
 
-              await _audioServiceHelper.addQueueItems(children!);
+              if (children != null) {
+                await _audioServiceHelper.addQueueItems(children);
 
-              if (!mounted) return;
+                if (!mounted) return;
 
-              ScaffoldMessenger.of(context).showSnackBar(SnackBar(
-                content: Text(AppLocalizations.of(context)!.addedToQueue),
-              ));
+                ScaffoldMessenger.of(context).showSnackBar(SnackBar(
+                  content: Text(AppLocalizations.of(context)!.addedToQueue),
+                ));
+              }
+
               break;
 
             case _AlbumListTileMenuItems.playNext:
-
               List<BaseItemDto>? children;
               if (isOffline) {
                 final downloadsHelper = GetIt.instance<DownloadsHelper>();
@@ -225,13 +226,18 @@ class _AlbumItemState extends State<AlbumItem> {
                   isGenres: false,
                 );
               }
-              await _audioServiceHelper.insertQueueItemsNext(children!);
 
-              if (!mounted) return;
+              if (children != null) {
+                await _audioServiceHelper.insertQueueItemsNext(children);
 
-              ScaffoldMessenger.of(context).showSnackBar(SnackBar(
-                content: Text(AppLocalizations.of(context)!.insertedIntoQueue),
-              ));
+                if (!mounted) return;
+
+                ScaffoldMessenger.of(context).showSnackBar(SnackBar(
+                  content:
+                      Text(AppLocalizations.of(context)!.insertedIntoQueue),
+                ));
+              }
+
               break;
 
             case _AlbumListTileMenuItems.addFavourite:

--- a/lib/components/MusicScreen/album_item.dart
+++ b/lib/components/MusicScreen/album_item.dart
@@ -1,4 +1,5 @@
 import 'package:finamp/components/MusicScreen/album_item_list_tile.dart';
+import 'package:finamp/services/downloads_helper.dart';
 import 'package:finamp/services/finamp_settings_helper.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
@@ -174,12 +175,27 @@ class _AlbumItemState extends State<AlbumItem> {
 
           switch (selection) {
             case _AlbumListTileMenuItems.addToQueue:
-              final children = await jellyfinApiHelper.getItems(
-                parentItem: widget.album,
-                sortBy: "ParentIndexNumber,IndexNumber,SortName",
-                includeItemTypes: "Audio",
-                isGenres: false,
-              );
+
+              List<BaseItemDto>? children;
+              if (isOffline) {
+                final downloadsHelper = GetIt.instance<DownloadsHelper>();
+
+                // The downloadedParent won't be null here if we've already
+                // navigated to it in offline mode
+                final downloadedParent =
+                    downloadsHelper.getDownloadedParent(widget.album.id)!;
+
+                children = downloadedParent.downloadedChildren.values.toList();
+              } else {
+                children = await jellyfinApiHelper.getItems(
+                  parentItem: widget.album,
+                  sortBy: "ParentIndexNumber,IndexNumber,SortName",
+                  includeItemTypes: "Audio",
+                  isGenres: false,
+                );
+
+              }
+
               await _audioServiceHelper.addQueueItems(children!);
 
               if (!mounted) return;
@@ -190,12 +206,25 @@ class _AlbumItemState extends State<AlbumItem> {
               break;
 
             case _AlbumListTileMenuItems.playNext:
-              final children = await jellyfinApiHelper.getItems(
-                parentItem: widget.album,
-                sortBy: "ParentIndexNumber,IndexNumber,SortName",
-                includeItemTypes: "Audio",
-                isGenres: false,
-              );
+
+              List<BaseItemDto>? children;
+              if (isOffline) {
+                final downloadsHelper = GetIt.instance<DownloadsHelper>();
+
+                // The downloadedParent won't be null here if we've already
+                // navigated to it in offline mode
+                final downloadedParent =
+                    downloadsHelper.getDownloadedParent(widget.album.id)!;
+
+                children = downloadedParent.downloadedChildren.values.toList();
+              } else {
+                children = await jellyfinApiHelper.getItems(
+                  parentItem: widget.album,
+                  sortBy: "ParentIndexNumber,IndexNumber,SortName",
+                  includeItemTypes: "Audio",
+                  isGenres: false,
+                );
+              }
               await _audioServiceHelper.insertQueueItemsNext(children!);
 
               if (!mounted) return;


### PR DESCRIPTION
Up until now albums and playlists were fetched from the server when adding them to the queue, even if offline mode was active.  
This PR changes the behavior to instead use the downloaded items for these actions instead.

This fix will probably also need to be implemented for the redesign.