### PR TITLE
:bug: Fix sort by DateCreated not working when offline

### DIFF
--- a/lib/services/jellyfin_api.dart
+++ b/lib/services/jellyfin_api.dart
@@ -14,7 +14,7 @@ import 'jellyfin_api_helper.dart';
 part 'jellyfin_api.chopper.dart';
 
 const String defaultFields =
-    "parentId,indexNumber,songCount,childCount,providerIds,genres,tags,Etag,albumPrimaryImageTag,parentPrimaryImageItemId";
+    "ChildCount,DateCreated,DateLastMediaAdded,Etag,Genres,IndexNumber,ParentId,ProviderIds,Tags,albumPrimaryImageTag,parentPrimaryImageItemId,songCount";
 
 @ChopperApi()
 abstract class JellyfinApi extends ChopperService {


### PR DESCRIPTION
By default, the DateCreated field is missing from the Jellyfin Items response. This causes the DateCreated field to always be null on BaseItemDtos, so it's not available for sorting when offline.

By adding the field name to the defaultFields, this is resolved. However, all items will have to be resynced before sorting works offline.

I also sorted the fields and changed the field name capitalization to match the Jellyfin API docs. The unchanged fields aren't mentioned there, so I'm not sure they're even necessary.

Fixes #444. Targeting the main branch, but should be trivial to port to the redesign branch.