### PR TITLE
[Desktop Beta] Add Splitscreen Mode

### DIFF
--- a/lib/components/AddDownloadLocationScreen/custom_download_location_form.dart
+++ b/lib/components/AddDownloadLocationScreen/custom_download_location_form.dart
@@ -131,9 +131,10 @@ class _CustomDownloadLocationFormState
             },
           ),
           const Padding(padding: EdgeInsets.all(8.0)),
-          Text(AppLocalizations.of(context)!.customLocationsBuggy,
-              textAlign: TextAlign.center,
-              style: const TextStyle(color: Colors.red)),
+          if (Platform.isIOS || Platform.isAndroid)
+            Text(AppLocalizations.of(context)!.customLocationsBuggy,
+                textAlign: TextAlign.center,
+                style: const TextStyle(color: Colors.red)),
         ],
       ),
     );

--- a/lib/components/AlbumScreen/album_screen_content.dart
+++ b/lib/components/AlbumScreen/album_screen_content.dart
@@ -61,73 +61,71 @@ class _AlbumScreenContentState extends State<AlbumScreenContent> {
       }
     }
 
-    return Scrollbar(
-      child: CustomScrollView(
-        slivers: [
-          SliverAppBar(
-            title: Text(widget.parent.name ??
-                AppLocalizations.of(context)!.unknownName),
-            // 125 + 64 is the total height of the widget we use as a
-            // FlexibleSpaceBar. We add the toolbar height since the widget
-            // should appear below the appbar.
-            // TODO: This height is affected by platform density.
-            expandedHeight: kToolbarHeight + 125 + 80,
-            collapsedHeight: kToolbarHeight + 125 + 80,
-            pinned: true,
-            flexibleSpace: AlbumScreenContentFlexibleSpaceBar(
-              parentItem: widget.parent,
-              isPlaylist: widget.parent.type == "Playlist",
-              items: widget.queueChildren,
-            ),
-            actions: [
-              if (widget.parent.type == "Playlist" &&
-                  !FinampSettingsHelper.finampSettings.isOffline)
-                PlaylistNameEditButton(playlist: widget.parent),
-              FavoriteButton(item: widget.parent),
-              DownloadButton(
-                  item: DownloadStub.fromItem(
-                      type: DownloadItemType.collection, item: widget.parent),
-                  children: widget.displayChildren.length)
-            ],
+    return CustomScrollView(
+      slivers: [
+        SliverAppBar(
+          title: Text(
+              widget.parent.name ?? AppLocalizations.of(context)!.unknownName),
+          // 125 + 64 is the total height of the widget we use as a
+          // FlexibleSpaceBar. We add the toolbar height since the widget
+          // should appear below the appbar.
+          // TODO: This height is affected by platform density.
+          expandedHeight: kToolbarHeight + 125 + 80,
+          collapsedHeight: kToolbarHeight + 125 + 80,
+          pinned: true,
+          flexibleSpace: AlbumScreenContentFlexibleSpaceBar(
+            parentItem: widget.parent,
+            isPlaylist: widget.parent.type == "Playlist",
+            items: widget.queueChildren,
           ),
-          if (widget.displayChildren.length > 1 &&
-              childrenPerDisc.length >
-                  1) // show headers only for multi disc albums
-            for (var childrenOfThisDisc in childrenPerDisc)
-              SliverStickyHeader(
-                header: Container(
-                  padding: const EdgeInsets.symmetric(
-                    horizontal: 16.0,
-                    vertical: 16.0,
-                  ),
-                  color: Theme.of(context).colorScheme.surfaceVariant,
-                  child: Text(
-                    AppLocalizations.of(context)!
-                        .discNumber(childrenOfThisDisc[0].parentIndexNumber!),
-                    style: const TextStyle(fontSize: 20.0),
-                  ),
+          actions: [
+            if (widget.parent.type == "Playlist" &&
+                !FinampSettingsHelper.finampSettings.isOffline)
+              PlaylistNameEditButton(playlist: widget.parent),
+            FavoriteButton(item: widget.parent),
+            DownloadButton(
+                item: DownloadStub.fromItem(
+                    type: DownloadItemType.collection, item: widget.parent),
+                children: widget.displayChildren.length)
+          ],
+        ),
+        if (widget.displayChildren.length > 1 &&
+            childrenPerDisc.length >
+                1) // show headers only for multi disc albums
+          for (var childrenOfThisDisc in childrenPerDisc)
+            SliverStickyHeader(
+              header: Container(
+                padding: const EdgeInsets.symmetric(
+                  horizontal: 16.0,
+                  vertical: 16.0,
                 ),
-                sliver: SongsSliverList(
-                  childrenForList: childrenOfThisDisc,
-                  childrenForQueue: Future.value(widget.queueChildren),
-                  parent: widget.parent,
-                  onRemoveFromList: onDelete,
+                color: Theme.of(context).colorScheme.surfaceVariant,
+                child: Text(
+                  AppLocalizations.of(context)!
+                      .discNumber(childrenOfThisDisc[0].parentIndexNumber!),
+                  style: const TextStyle(fontSize: 20.0),
                 ),
-              )
-          else if (widget.displayChildren.isNotEmpty)
-            SongsSliverList(
-              childrenForList: widget.displayChildren,
-              childrenForQueue: Future.value(widget.queueChildren),
-              parent: widget.parent,
-              onRemoveFromList: onDelete,
-            ),
-          SliverToBoxAdapter(
-            child: Container(
-              height: MediaQuery.paddingOf(context).bottom,
-            ),
-          )
-        ],
-      ),
+              ),
+              sliver: SongsSliverList(
+                childrenForList: childrenOfThisDisc,
+                childrenForQueue: Future.value(widget.queueChildren),
+                parent: widget.parent,
+                onRemoveFromList: onDelete,
+              ),
+            )
+        else if (widget.displayChildren.isNotEmpty)
+          SongsSliverList(
+            childrenForList: widget.displayChildren,
+            childrenForQueue: Future.value(widget.queueChildren),
+            parent: widget.parent,
+            onRemoveFromList: onDelete,
+          ),
+        SliverToBoxAdapter(
+          child: Container(
+            height: MediaQuery.paddingOf(context).bottom,
+          ),
+        )
+      ],
     );
   }
 }

--- a/lib/components/AlbumScreen/album_screen_content_flexible_space_bar.dart
+++ b/lib/components/AlbumScreen/album_screen_content_flexible_space_bar.dart
@@ -1,6 +1,3 @@
-import 'dart:io';
-import 'dart:math';
-
 import 'package:finamp/components/Buttons/cta_medium.dart';
 import 'package:finamp/components/global_snackbar.dart';
 import 'package:finamp/models/finamp_models.dart';
@@ -59,7 +56,10 @@ class AlbumScreenContentFlexibleSpaceBar extends StatelessWidget {
                   AppLocalizations.of(context)!.placeholderSource),
           id: parentItem.id,
           item: parentItem,
-          contextLufs: (isPlaylist || parentItem.lufs == 0.0) ? null : parentItem.lufs, // album LUFS sometimes end up being simply `0`, but that's not the actual value
+          contextLufs: (isPlaylist || parentItem.lufs == 0.0)
+              ? null
+              : parentItem
+                  .lufs, // album LUFS sometimes end up being simply `0`, but that's not the actual value
         ),
         order: FinampPlaybackOrder.linear,
       );
@@ -78,7 +78,10 @@ class AlbumScreenContentFlexibleSpaceBar extends StatelessWidget {
                   AppLocalizations.of(context)!.placeholderSource),
           id: parentItem.id,
           item: parentItem,
-          contextLufs: (isPlaylist || parentItem.lufs == 0.0) ? null : parentItem.lufs, // album LUFS sometimes end up being simply `0`, but that's not the actual value
+          contextLufs: (isPlaylist || parentItem.lufs == 0.0)
+              ? null
+              : parentItem
+                  .lufs, // album LUFS sometimes end up being simply `0`, but that's not the actual value
         ),
         order: FinampPlaybackOrder.shuffled,
       );
@@ -97,11 +100,16 @@ class AlbumScreenContentFlexibleSpaceBar extends StatelessWidget {
                   AppLocalizations.of(context)!.placeholderSource),
           id: parentItem.id,
           item: parentItem,
-          contextLufs: (isPlaylist || parentItem.lufs == 0.0) ? null : parentItem.lufs, // album LUFS sometimes end up being simply `0`, but that's not the actual value
+          contextLufs: (isPlaylist || parentItem.lufs == 0.0)
+              ? null
+              : parentItem
+                  .lufs, // album LUFS sometimes end up being simply `0`, but that's not the actual value
         ),
       );
-      GlobalSnackbar.message((scaffold) => AppLocalizations.of(scaffold)!
-          .confirmAddToNextUp(isPlaylist ? "playlist" : "album"), isConfirmation: true);
+      GlobalSnackbar.message(
+          (scaffold) => AppLocalizations.of(scaffold)!
+              .confirmAddToNextUp(isPlaylist ? "playlist" : "album"),
+          isConfirmation: true);
     }
 
     void addAlbumNext() {
@@ -117,10 +125,15 @@ class AlbumScreenContentFlexibleSpaceBar extends StatelessWidget {
                     AppLocalizations.of(context)!.placeholderSource),
             id: parentItem.id,
             item: parentItem,
-            contextLufs: (isPlaylist || parentItem.lufs == 0.0) ? null : parentItem.lufs, // album LUFS sometimes end up being simply `0`, but that's not the actual value
+            contextLufs: (isPlaylist || parentItem.lufs == 0.0)
+                ? null
+                : parentItem
+                    .lufs, // album LUFS sometimes end up being simply `0`, but that's not the actual value
           ));
-      GlobalSnackbar.message((scaffold) => AppLocalizations.of(scaffold)!
-          .confirmPlayNext(isPlaylist ? "playlist" : "album"), isConfirmation: true);
+      GlobalSnackbar.message(
+          (scaffold) => AppLocalizations.of(scaffold)!
+              .confirmPlayNext(isPlaylist ? "playlist" : "album"),
+          isConfirmation: true);
     }
 
     void shuffleAlbumToNextUp() {
@@ -139,10 +152,14 @@ class AlbumScreenContentFlexibleSpaceBar extends StatelessWidget {
                     AppLocalizations.of(context)!.placeholderSource),
             id: parentItem.id,
             item: parentItem,
-            contextLufs: (isPlaylist || parentItem.lufs == 0.0) ? null : parentItem.lufs, // album LUFS sometimes end up being simply `0`, but that's not the actual value
+            contextLufs: (isPlaylist || parentItem.lufs == 0.0)
+                ? null
+                : parentItem
+                    .lufs, // album LUFS sometimes end up being simply `0`, but that's not the actual value
           ));
-      GlobalSnackbar.message((scaffold) => AppLocalizations.of(scaffold)!
-          .confirmShuffleToNextUp, isConfirmation: true);
+      GlobalSnackbar.message(
+          (scaffold) => AppLocalizations.of(scaffold)!.confirmShuffleToNextUp,
+          isConfirmation: true);
     }
 
     void shuffleAlbumNext() {
@@ -161,10 +178,14 @@ class AlbumScreenContentFlexibleSpaceBar extends StatelessWidget {
                     AppLocalizations.of(context)!.placeholderSource),
             id: parentItem.id,
             item: parentItem,
-            contextLufs: (isPlaylist || parentItem.lufs == 0.0) ? null : parentItem.lufs, // album LUFS sometimes end up being simply `0`, but that's not the actual value
+            contextLufs: (isPlaylist || parentItem.lufs == 0.0)
+                ? null
+                : parentItem
+                    .lufs, // album LUFS sometimes end up being simply `0`, but that's not the actual value
           ));
-      GlobalSnackbar.message((scaffold) => AppLocalizations.of(scaffold)!
-          .confirmShuffleNext, isConfirmation: true);
+      GlobalSnackbar.message(
+          (scaffold) => AppLocalizations.of(scaffold)!.confirmShuffleNext,
+          isConfirmation: true);
     }
 
     void addAlbumToQueue() {
@@ -182,8 +203,10 @@ class AlbumScreenContentFlexibleSpaceBar extends StatelessWidget {
           item: parentItem,
         ),
       );
-      GlobalSnackbar.message((scaffold) => AppLocalizations.of(scaffold)!
-          .confirmAddToQueue(isPlaylist ? "playlist" : "album"), isConfirmation: true);
+      GlobalSnackbar.message(
+          (scaffold) => AppLocalizations.of(scaffold)!
+              .confirmAddToQueue(isPlaylist ? "playlist" : "album"),
+          isConfirmation: true);
     }
 
     void shuffleAlbumToQueue() {
@@ -203,8 +226,9 @@ class AlbumScreenContentFlexibleSpaceBar extends StatelessWidget {
             id: parentItem.id,
             item: parentItem,
           ));
-      GlobalSnackbar.message((scaffold) => AppLocalizations.of(scaffold)!
-          .confirmShuffleToQueue, isConfirmation: true);
+      GlobalSnackbar.message(
+          (scaffold) => AppLocalizations.of(scaffold)!.confirmShuffleToQueue,
+          isConfirmation: true);
     }
 
     return FlexibleSpaceBar(
@@ -251,7 +275,8 @@ class AlbumScreenContentFlexibleSpaceBar extends StatelessWidget {
                                   icon: TablerIcons.player_play,
                                   onPressed: () => playAlbum(),
                                   // set the minimum width as 25% of the screen width,
-                                  minWidth: MediaQuery.of(context).size.width * 0.25,
+                                  minWidth:
+                                      MediaQuery.of(context).size.width * 0.25,
                                 ),
                                 PopupMenuButton<AlbumMenuItems>(
                                   enableFeedback: true,
@@ -279,8 +304,8 @@ class AlbumScreenContentFlexibleSpaceBar extends StatelessWidget {
                                       PopupMenuItem<AlbumMenuItems>(
                                         value: AlbumMenuItems.addToNextUp,
                                         child: ListTile(
-                                          leading:
-                                              const Icon(TablerIcons.corner_right_down_double),
+                                          leading: const Icon(TablerIcons
+                                              .corner_right_down_double),
                                           title: Text(
                                               AppLocalizations.of(context)!
                                                   .addToNextUp),
@@ -335,7 +360,8 @@ class AlbumScreenContentFlexibleSpaceBar extends StatelessWidget {
                                   icon: TablerIcons.arrows_shuffle,
                                   onPressed: () => shuffleAlbum(),
                                   // set the minimum width as 25% of the screen width,
-                                  minWidth: MediaQuery.of(context).size.width * 0.25,
+                                  minWidth:
+                                      MediaQuery.of(context).size.width * 0.25,
                                 ),
                                 PopupMenuButton<AlbumMenuItems>(
                                   enableFeedback: true,
@@ -363,8 +389,8 @@ class AlbumScreenContentFlexibleSpaceBar extends StatelessWidget {
                                       PopupMenuItem<AlbumMenuItems>(
                                         value: AlbumMenuItems.shuffleToNextUp,
                                         child: ListTile(
-                                          leading:
-                                              const Icon(TablerIcons.corner_right_down_double),
+                                          leading: const Icon(TablerIcons
+                                              .corner_right_down_double),
                                           title: Text(
                                               AppLocalizations.of(context)!
                                                   .shuffleToNextUp),

--- a/lib/components/AlbumScreen/download_dialog.dart
+++ b/lib/components/AlbumScreen/download_dialog.dart
@@ -18,14 +18,14 @@ class DownloadDialog extends StatefulWidget {
     super.key,
     required this.item,
     required this.viewId,
-    required this.needsDirectory,
+    required this.downloadLocationId,
     required this.needsTranscode,
     required this.children,
   });
 
   final DownloadStub item;
   final String viewId;
-  final bool needsDirectory;
+  final String? downloadLocationId;
   final bool needsTranscode;
   final List<BaseItemDto>? children;
 
@@ -45,23 +45,32 @@ class DownloadDialog extends StatefulWidget {
     bool needTranscode =
         FinampSettingsHelper.finampSettings.shouldTranscodeDownloads ==
             TranscodeDownloadsSetting.ask;
-    bool needDownload = FinampSettingsHelper
-            .finampSettings.downloadLocationsMap.values
-            .where((element) =>
-                element.baseDirectory != DownloadLocationType.internalDocuments)
-            .length !=
-        1;
-    if (!needTranscode && !needDownload) {
+    String? downloadLocation =
+        FinampSettingsHelper.finampSettings.defaultDownloadLocation;
+    if (!FinampSettingsHelper.finampSettings.downloadLocationsMap
+        .containsKey(downloadLocation)) {
+      downloadLocation = null;
+    }
+    if (downloadLocation == null) {
+      var locations = FinampSettingsHelper
+          .finampSettings.downloadLocationsMap.values
+          .where((element) =>
+              element.baseDirectory != DownloadLocationType.internalDocuments);
+      if (locations.length == 1) {
+        downloadLocation = locations.first.id;
+      }
+    }
+    if (!needTranscode && downloadLocation != null) {
       final downloadsService = GetIt.instance<DownloadsService>();
       var profile = FinampSettingsHelper
                   .finampSettings.shouldTranscodeDownloads ==
               TranscodeDownloadsSetting.always
           ? FinampSettingsHelper.finampSettings.downloadTranscodingProfile
           : DownloadProfile(transcodeCodec: FinampTranscodingCodec.original);
-      profile.downloadLocationId =
-          FinampSettingsHelper.finampSettings.internalSongDir.id;
-      GlobalSnackbar.message((scaffold) =>
-          AppLocalizations.of(scaffold)!.confirmDownloadStarted, isConfirmation: true);
+      profile.downloadLocationId = downloadLocation;
+      GlobalSnackbar.message(
+          (scaffold) => AppLocalizations.of(scaffold)!.confirmDownloadStarted,
+          isConfirmation: true);
       unawaited(downloadsService
           .addDownload(stub: item, viewId: viewId!, transcodeProfile: profile)
           // TODO only show the enqueued confirmation if the enqueuing took longer than ~10 seconds
@@ -83,7 +92,7 @@ class DownloadDialog extends StatefulWidget {
         builder: (context) => DownloadDialog._build(
             item: item,
             viewId: viewId!,
-            needsDirectory: needDownload,
+            downloadLocationId: downloadLocation,
             needsTranscode: needTranscode,
             children: children),
       );
@@ -137,7 +146,7 @@ class _DownloadDialogState extends State<DownloadDialog> {
       content: Column(
         mainAxisSize: MainAxisSize.min,
         children: [
-          if (widget.needsDirectory)
+          if (widget.downloadLocationId == null)
             DropdownButton<DownloadLocation>(
                 hint: Text(AppLocalizations.of(context)!.location),
                 isExpanded: true,
@@ -186,7 +195,7 @@ class _DownloadDialogState extends State<DownloadDialog> {
         ),
         TextButton(
           onPressed: (selectedDownloadLocation == null &&
-                      widget.needsDirectory) ||
+                      widget.downloadLocationId == null) ||
                   (transcode == null && widget.needsTranscode)
               ? null
               : () async {
@@ -199,9 +208,8 @@ class _DownloadDialogState extends State<DownloadDialog> {
                               TranscodeDownloadsSetting.always)!
                       ? transcodeProfile
                       : originalProfile;
-                  profile.downloadLocationId = widget.needsDirectory
-                      ? selectedDownloadLocation!.id
-                      : FinampSettingsHelper.finampSettings.internalSongDir.id;
+                  profile.downloadLocationId =
+                      widget.downloadLocationId ?? selectedDownloadLocation!.id;
                   await downloadsService
                       .addDownload(
                           stub: widget.item,

--- a/lib/components/AlbumScreen/song_menu.dart
+++ b/lib/components/AlbumScreen/song_menu.dart
@@ -1,4 +1,6 @@
 import 'dart:async';
+import 'dart:io';
+import 'dart:math';
 
 import 'package:finamp/components/PlayerScreen/queue_list.dart';
 import 'package:finamp/components/PlayerScreen/sleep_timer_cancel_dialog.dart';
@@ -15,7 +17,6 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_tabler_icons/flutter_tabler_icons.dart';
 import 'package:flutter_vibrate/flutter_vibrate.dart';
 import 'package:get_it/get_it.dart';
-import 'package:modal_bottom_sheet/modal_bottom_sheet.dart';
 import 'package:rxdart/rxdart.dart';
 
 import '../../models/jellyfin_models.dart';
@@ -47,12 +48,14 @@ Future<void> showModalSongMenu({
 
   Vibrate.feedback(FeedbackType.impact);
 
-  await showMaterialModalBottomSheet(
+  await showModalBottomSheet(
       context: context,
-      //constraints: BoxConstraints(
-      //    maxWidth: min(500, MediaQuery.sizeOf(context).width * 0.9)),
+      constraints: BoxConstraints(
+          maxWidth: min(500, MediaQuery.sizeOf(context).width * 0.9)),
       isDismissible: true,
       enableDrag: true,
+      useSafeArea: true,
+      isScrollControlled: true,
       clipBehavior: Clip.hardEdge,
       shape: const RoundedRectangleBorder(
         borderRadius: BorderRadius.only(
@@ -125,6 +128,7 @@ class _SongMenuState extends ConsumerState<SongMenu> {
   final _queueService = GetIt.instance<QueueService>();
 
   ColorScheme? _imageTheme;
+  final ScrollController _controller = ScrollController();
 
   @override
   void initState() {
@@ -198,480 +202,515 @@ class _SongMenuState extends ConsumerState<SongMenu> {
       item: widget.item,
     )));
 
-    return Stack(
-      children: [
-        if (FinampSettingsHelper.finampSettings.showCoverAsPlayerBackground)
-          BlurredPlayerScreenBackground(
-              customImageProvider: imageProvider,
-              opacityFactor:
-                  Theme.of(context).brightness == Brightness.dark ? 1.0 : 1.0),
-        CustomScrollView(
-          controller: ModalScrollController.of(context),
-          shrinkWrap: true,
-          physics: const ClampingScrollPhysics(),
-          slivers: [
-            SliverPersistentHeader(
-              delegate: SongMenuSliverAppBar(
-                item: widget.item,
-              ),
-              pinned: true,
-            ),
-            if (widget.showPlaybackControls)
-              StreamBuilder<PlaybackBehaviorInfo>(
-                stream: Rx.combineLatest2(
-                    _queueService.getPlaybackOrderStream(),
-                    _queueService.getLoopModeStream(),
-                    (a, b) => PlaybackBehaviorInfo(a, b)),
-                builder: (context, snapshot) {
-                  if (!snapshot.hasData) return const SliverToBoxAdapter();
+    Widget menu(BuildContext context, ScrollController controller) => Stack(
+          children: [
+            if (FinampSettingsHelper.finampSettings.showCoverAsPlayerBackground)
+              BlurredPlayerScreenBackground(
+                  customImageProvider: imageProvider,
+                  opacityFactor: Theme.of(context).brightness == Brightness.dark
+                      ? 1.0
+                      : 1.0),
+            CustomScrollView(
+              shrinkWrap: true,
+              physics: const ClampingScrollPhysics(),
+              controller: controller,
+              slivers: [
+                SliverPersistentHeader(
+                  delegate: SongMenuSliverAppBar(
+                    item: widget.item,
+                  ),
+                  pinned: true,
+                ),
+                if (widget.showPlaybackControls)
+                  StreamBuilder<PlaybackBehaviorInfo>(
+                    stream: Rx.combineLatest2(
+                        _queueService.getPlaybackOrderStream(),
+                        _queueService.getLoopModeStream(),
+                        (a, b) => PlaybackBehaviorInfo(a, b)),
+                    builder: (context, snapshot) {
+                      if (!snapshot.hasData) return const SliverToBoxAdapter();
 
-                  final playbackBehavior = snapshot.data!;
-                  const playbackOrderIcons = {
-                    FinampPlaybackOrder.linear: TablerIcons.arrows_right,
-                    FinampPlaybackOrder.shuffled: TablerIcons.arrows_shuffle,
-                  };
-                  final playbackOrderTooltips = {
-                    FinampPlaybackOrder.linear: AppLocalizations.of(context)
-                            ?.playbackOrderLinearButtonLabel ??
-                        "Playing in order",
-                    FinampPlaybackOrder.shuffled: AppLocalizations.of(context)
-                            ?.playbackOrderShuffledButtonLabel ??
-                        "Shuffling",
-                  };
-                  const loopModeIcons = {
-                    FinampLoopMode.none: TablerIcons.repeat,
-                    FinampLoopMode.one: TablerIcons.repeat_once,
-                    FinampLoopMode.all: TablerIcons.repeat,
-                  };
-                  final loopModeTooltips = {
-                    FinampLoopMode.none:
-                        AppLocalizations.of(context)?.loopModeNoneButtonLabel ??
+                      final playbackBehavior = snapshot.data!;
+                      const playbackOrderIcons = {
+                        FinampPlaybackOrder.linear: TablerIcons.arrows_right,
+                        FinampPlaybackOrder.shuffled:
+                            TablerIcons.arrows_shuffle,
+                      };
+                      final playbackOrderTooltips = {
+                        FinampPlaybackOrder.linear: AppLocalizations.of(context)
+                                ?.playbackOrderLinearButtonLabel ??
+                            "Playing in order",
+                        FinampPlaybackOrder.shuffled:
+                            AppLocalizations.of(context)
+                                    ?.playbackOrderShuffledButtonLabel ??
+                                "Shuffling",
+                      };
+                      const loopModeIcons = {
+                        FinampLoopMode.none: TablerIcons.repeat,
+                        FinampLoopMode.one: TablerIcons.repeat_once,
+                        FinampLoopMode.all: TablerIcons.repeat,
+                      };
+                      final loopModeTooltips = {
+                        FinampLoopMode.none: AppLocalizations.of(context)
+                                ?.loopModeNoneButtonLabel ??
                             "Looping off",
-                    FinampLoopMode.one:
-                        AppLocalizations.of(context)?.loopModeOneButtonLabel ??
+                        FinampLoopMode.one: AppLocalizations.of(context)
+                                ?.loopModeOneButtonLabel ??
                             "Looping this song",
-                    FinampLoopMode.all:
-                        AppLocalizations.of(context)?.loopModeAllButtonLabel ??
+                        FinampLoopMode.all: AppLocalizations.of(context)
+                                ?.loopModeAllButtonLabel ??
                             "Looping all",
-                  };
+                      };
 
-                  return SliverCrossAxisGroup(
-                    // return SliverGrid.count(
-                    //   crossAxisCount: 3,
-                    //   mainAxisSpacing: 40,
-                    //   children: [
-                    slivers: [
-                      PlaybackAction(
-                        icon: playbackOrderIcons[playbackBehavior.order]!,
-                        onPressed: () async {
-                          _queueService.togglePlaybackOrder();
-                        },
-                        tooltip: playbackOrderTooltips[playbackBehavior.order]!,
-                        iconColor: playbackBehavior.order ==
-                                FinampPlaybackOrder.shuffled
-                            ? iconColor
-                            : Theme.of(context).textTheme.bodyMedium?.color ??
-                                Colors.white,
-                      ),
-                      ValueListenableBuilder<Timer?>(
-                        valueListenable: _audioHandler.sleepTimer,
-                        builder: (context, timerValue, child) {
-                          final remainingMinutes =
-                              (_audioHandler.sleepTimerRemaining.inSeconds /
-                                      60.0)
-                                  .ceil();
-                          return PlaybackAction(
-                            icon: timerValue != null
-                                ? TablerIcons.hourglass_high
-                                : TablerIcons.hourglass_empty,
+                      return SliverCrossAxisGroup(
+                        // return SliverGrid.count(
+                        //   crossAxisCount: 3,
+                        //   mainAxisSpacing: 40,
+                        //   children: [
+                        slivers: [
+                          PlaybackAction(
+                            icon: playbackOrderIcons[playbackBehavior.order]!,
                             onPressed: () async {
-                              if (timerValue != null) {
-                                showDialog(
-                                  context: context,
-                                  builder: (context) =>
-                                      const SleepTimerCancelDialog(),
-                                );
-                              } else {
-                                await showDialog(
-                                  context: context,
-                                  builder: (context) =>
-                                      const SleepTimerDialog(),
-                                );
-                              }
+                              _queueService.togglePlaybackOrder();
                             },
-                            tooltip: timerValue != null
-                                ? AppLocalizations.of(context)
-                                        ?.sleepTimerRemainingTime(
-                                            remainingMinutes) ??
-                                    "Sleeping in $remainingMinutes minutes"
-                                : AppLocalizations.of(context)!
-                                    .sleepTimerTooltip,
-                            iconColor: timerValue != null
+                            tooltip:
+                                playbackOrderTooltips[playbackBehavior.order]!,
+                            iconColor: playbackBehavior.order ==
+                                    FinampPlaybackOrder.shuffled
                                 ? iconColor
                                 : Theme.of(context)
                                         .textTheme
                                         .bodyMedium
                                         ?.color ??
                                     Colors.white,
-                          );
-                        },
-                      ),
-                      PlaybackAction(
-                        icon: loopModeIcons[playbackBehavior.loop]!,
-                        onPressed: () async {
-                          _queueService.toggleLoopMode();
-                        },
-                        tooltip: loopModeTooltips[playbackBehavior.loop]!,
-                        iconColor: playbackBehavior.loop == FinampLoopMode.none
-                            ? Theme.of(context).textTheme.bodyMedium?.color ??
-                                Colors.white
-                            : iconColor,
-                      ),
-                    ],
-                  );
-                },
-              ),
-            SliverPadding(
-              padding: const EdgeInsets.only(left: 8.0),
-              sliver: SliverList(
-                delegate: SliverChildListDelegate([
-                  ListTile(
-                    enabled: !widget.isOffline,
-                    leading: widget.item.userData!.isFavorite
-                        ? Icon(
-                            Icons.favorite,
-                            color: widget.isOffline
-                                ? iconColor.withOpacity(0.3)
-                                : iconColor,
-                          )
-                        : Icon(
-                            Icons.favorite_border,
-                            color: widget.isOffline
-                                ? iconColor.withOpacity(0.3)
-                                : iconColor,
                           ),
-                    title: Text(widget.item.userData!.isFavorite
-                        ? AppLocalizations.of(context)!.removeFavourite
-                        : AppLocalizations.of(context)!.addFavourite),
-                    onTap: () async {
-                      await toggleFavorite();
-                      if (mounted) Navigator.pop(context);
+                          ValueListenableBuilder<Timer?>(
+                            valueListenable: _audioHandler.sleepTimer,
+                            builder: (context, timerValue, child) {
+                              final remainingMinutes =
+                                  (_audioHandler.sleepTimerRemaining.inSeconds /
+                                          60.0)
+                                      .ceil();
+                              return PlaybackAction(
+                                icon: timerValue != null
+                                    ? TablerIcons.hourglass_high
+                                    : TablerIcons.hourglass_empty,
+                                onPressed: () async {
+                                  if (timerValue != null) {
+                                    showDialog(
+                                      context: context,
+                                      builder: (context) =>
+                                          const SleepTimerCancelDialog(),
+                                    );
+                                  } else {
+                                    await showDialog(
+                                      context: context,
+                                      builder: (context) =>
+                                          const SleepTimerDialog(),
+                                    );
+                                  }
+                                },
+                                tooltip: timerValue != null
+                                    ? AppLocalizations.of(context)
+                                            ?.sleepTimerRemainingTime(
+                                                remainingMinutes) ??
+                                        "Sleeping in $remainingMinutes minutes"
+                                    : AppLocalizations.of(context)!
+                                        .sleepTimerTooltip,
+                                iconColor: timerValue != null
+                                    ? iconColor
+                                    : Theme.of(context)
+                                            .textTheme
+                                            .bodyMedium
+                                            ?.color ??
+                                        Colors.white,
+                              );
+                            },
+                          ),
+                          PlaybackAction(
+                            icon: loopModeIcons[playbackBehavior.loop]!,
+                            onPressed: () async {
+                              _queueService.toggleLoopMode();
+                            },
+                            tooltip: loopModeTooltips[playbackBehavior.loop]!,
+                            iconColor:
+                                playbackBehavior.loop == FinampLoopMode.none
+                                    ? Theme.of(context)
+                                            .textTheme
+                                            .bodyMedium
+                                            ?.color ??
+                                        Colors.white
+                                    : iconColor,
+                          ),
+                        ],
+                      );
                     },
                   ),
-                  Visibility(
-                    visible: _queueService.getQueue().nextUp.isNotEmpty,
-                    child: ListTile(
-                      leading: Icon(
-                        TablerIcons.corner_right_down,
-                        color: iconColor,
+                SliverPadding(
+                  padding: const EdgeInsets.only(left: 8.0),
+                  sliver: SliverList(
+                    delegate: SliverChildListDelegate([
+                      ListTile(
+                        enabled: !widget.isOffline,
+                        leading: widget.item.userData!.isFavorite
+                            ? Icon(
+                                Icons.favorite,
+                                color: widget.isOffline
+                                    ? iconColor.withOpacity(0.3)
+                                    : iconColor,
+                              )
+                            : Icon(
+                                Icons.favorite_border,
+                                color: widget.isOffline
+                                    ? iconColor.withOpacity(0.3)
+                                    : iconColor,
+                              ),
+                        title: Text(widget.item.userData!.isFavorite
+                            ? AppLocalizations.of(context)!.removeFavourite
+                            : AppLocalizations.of(context)!.addFavourite),
+                        onTap: () async {
+                          await toggleFavorite();
+                          if (mounted) Navigator.pop(context);
+                        },
                       ),
-                      title: Text(AppLocalizations.of(context)!.playNext),
-                      onTap: () async {
-                        await _queueService.addNext(
-                            items: [widget.item],
-                            source: QueueItemSource(
-                                type: QueueItemSourceType.nextUp,
-                                name: const QueueItemSourceName(
-                                    type: QueueItemSourceNameType.nextUp),
-                                id: widget.item.id));
+                      Visibility(
+                        visible: _queueService.getQueue().nextUp.isNotEmpty,
+                        child: ListTile(
+                          leading: Icon(
+                            TablerIcons.corner_right_down,
+                            color: iconColor,
+                          ),
+                          title: Text(AppLocalizations.of(context)!.playNext),
+                          onTap: () async {
+                            await _queueService.addNext(
+                                items: [widget.item],
+                                source: QueueItemSource(
+                                    type: QueueItemSourceType.nextUp,
+                                    name: const QueueItemSourceName(
+                                        type: QueueItemSourceNameType.nextUp),
+                                    id: widget.item.id));
 
-                        if (!mounted) return;
+                            if (!mounted) return;
 
-                        GlobalSnackbar.message(
-                            (context) => AppLocalizations.of(context)!
-                                .confirmPlayNext("track"),
-                            isConfirmation: true);
-                        Navigator.pop(context);
-                      },
-                    ),
-                  ),
-                  ListTile(
-                    leading: Icon(
-                      TablerIcons.corner_right_down_double,
-                      color: iconColor,
-                    ),
-                    title: Text(AppLocalizations.of(context)!.addToNextUp),
-                    onTap: () async {
-                      await _queueService.addToNextUp(
-                          items: [widget.item],
-                          source: QueueItemSource(
-                              type: QueueItemSourceType.nextUp,
-                              name: const QueueItemSourceName(
-                                  type: QueueItemSourceNameType.nextUp),
-                              id: widget.item.id));
-
-                      if (!mounted) return;
-
-                      GlobalSnackbar.message(
-                          (context) => AppLocalizations.of(context)!
-                              .confirmAddToNextUp("track"),
-                          isConfirmation: true);
-                      Navigator.pop(context);
-                    },
-                  ),
-                  ListTile(
-                    leading: Icon(
-                      TablerIcons.playlist,
-                      color: iconColor,
-                    ),
-                    title: Text(AppLocalizations.of(context)!.addToQueue),
-                    onTap: () async {
-                      await _queueService.addToQueue(
-                          items: [widget.item],
-                          source: QueueItemSource(
-                              type: QueueItemSourceType.queue,
-                              name: const QueueItemSourceName(
-                                  type: QueueItemSourceNameType.queue),
-                              id: widget.item.id));
-
-                      if (!mounted) return;
-
-                      GlobalSnackbar.message(
-                          (context) =>
-                              AppLocalizations.of(context)!.addedToQueue,
-                          isConfirmation: true);
-                      Navigator.pop(context);
-                    },
-                  ),
-                  Visibility(
-                    visible: widget.isInPlaylist &&
-                        widget.parentItem != null &&
-                        !widget.isOffline,
-                    child: ListTile(
-                      leading: Icon(
-                        Icons.playlist_remove,
-                        color: iconColor,
+                            GlobalSnackbar.message(
+                                (context) => AppLocalizations.of(context)!
+                                    .confirmPlayNext("track"),
+                                isConfirmation: true);
+                            Navigator.pop(context);
+                          },
+                        ),
                       ),
-                      title: Text(AppLocalizations.of(context)!
-                          .removeFromPlaylistTitle),
-                      enabled: widget.isInPlaylist &&
-                          widget.parentItem != null &&
-                          !widget.isOffline,
-                      onTap: () async {
-                        try {
-                          await _jellyfinApiHelper.removeItemsFromPlaylist(
-                              playlistId: widget.parentItem!.id,
-                              entryIds: [widget.item.playlistItemId!]);
+                      ListTile(
+                        leading: Icon(
+                          TablerIcons.corner_right_down_double,
+                          color: iconColor,
+                        ),
+                        title: Text(AppLocalizations.of(context)!.addToNextUp),
+                        onTap: () async {
+                          await _queueService.addToNextUp(
+                              items: [widget.item],
+                              source: QueueItemSource(
+                                  type: QueueItemSourceType.nextUp,
+                                  name: const QueueItemSourceName(
+                                      type: QueueItemSourceNameType.nextUp),
+                                  id: widget.item.id));
 
                           if (!mounted) return;
-
-                          await _jellyfinApiHelper.getItems(
-                            parentItem: await _jellyfinApiHelper
-                                .getItemById(widget.item.parentId!),
-                            sortBy: "ParentIndexNumber,IndexNumber,SortName",
-                            includeItemTypes: "Audio",
-                          );
-
-                          if (!mounted) return;
-
-                          if (widget.onRemoveFromList != null)
-                            widget.onRemoveFromList!();
 
                           GlobalSnackbar.message(
                               (context) => AppLocalizations.of(context)!
-                                  .removedFromPlaylist,
+                                  .confirmAddToNextUp("track"),
                               isConfirmation: true);
                           Navigator.pop(context);
-                        } catch (e) {
-                          GlobalSnackbar.error(e);
-                        }
-                      },
-                    ),
-                  ),
-                  Visibility(
-                    visible: !widget.isOffline,
-                    child: ListTile(
-                      leading: Icon(
-                        Icons.playlist_add,
-                        color: iconColor,
+                        },
                       ),
-                      title: Text(
-                          AppLocalizations.of(context)!.addToPlaylistTitle),
-                      enabled: !widget.isOffline,
-                      onTap: () {
-                        Navigator.pop(context);
-                        Navigator.of(context).pushNamed(
-                            AddToPlaylistScreen.routeName,
-                            arguments: widget.item.id);
-                      },
-                    ),
-                  ),
-                  Visibility(
-                    visible: !widget.isOffline,
-                    child: ListTile(
-                      leading: Icon(
-                        Icons.explore,
-                        color: iconColor,
-                      ),
-                      title: Text(AppLocalizations.of(context)!.instantMix),
-                      enabled: !widget.isOffline,
-                      onTap: () async {
-                        await _audioServiceHelper
-                            .startInstantMixForItem(widget.item);
+                      ListTile(
+                        leading: Icon(
+                          TablerIcons.playlist,
+                          color: iconColor,
+                        ),
+                        title: Text(AppLocalizations.of(context)!.addToQueue),
+                        onTap: () async {
+                          await _queueService.addToQueue(
+                              items: [widget.item],
+                              source: QueueItemSource(
+                                  type: QueueItemSourceType.queue,
+                                  name: const QueueItemSourceName(
+                                      type: QueueItemSourceNameType.queue),
+                                  id: widget.item.id));
 
-                        if (!mounted) return;
+                          if (!mounted) return;
 
-                        GlobalSnackbar.message(
-                            (context) => AppLocalizations.of(context)!
-                                .startingInstantMix,
-                            isConfirmation: true);
-                        Navigator.pop(context);
-                      },
-                    ),
-                  ),
-                  Visibility(
-                    visible: widget.canGoToAlbum,
-                    child: ListTile(
-                      leading: Icon(
-                        Icons.album,
-                        color: iconColor,
-                      ),
-                      title: Text(AppLocalizations.of(context)!.goToAlbum),
-                      enabled: widget.canGoToAlbum,
-                      onTap: () async {
-                        late BaseItemDto album;
-                        try {
-                          if (FinampSettingsHelper.finampSettings.isOffline) {
-                            final downloadsService =
-                                GetIt.instance<DownloadsService>();
-                            album = (await downloadsService.getCollectionInfo(
-                                    id: widget.item.albumId!))!
-                                .baseItem!;
-                          } else {
-                            album = await _jellyfinApiHelper
-                                .getItemById(widget.item.albumId!);
-                          }
-                        } catch (e) {
-                          GlobalSnackbar.error(e);
-                          return;
-                        }
-                        if (mounted) {
+                          GlobalSnackbar.message(
+                              (context) =>
+                                  AppLocalizations.of(context)!.addedToQueue,
+                              isConfirmation: true);
                           Navigator.pop(context);
-                          Navigator.of(context).pushNamed(AlbumScreen.routeName,
-                              arguments: album);
-                        }
-                      },
-                    ),
-                  ),
-                  Visibility(
-                    visible: widget.canGoToArtist,
-                    child: ListTile(
-                      leading: Icon(
-                        Icons.person,
-                        color: iconColor,
+                        },
                       ),
-                      title: Text(AppLocalizations.of(context)!.goToArtist),
-                      enabled: widget.canGoToArtist,
-                      onTap: () async {
-                        late BaseItemDto artist;
-                        try {
-                          if (FinampSettingsHelper.finampSettings.isOffline) {
-                            final downloadsService =
-                                GetIt.instance<DownloadsService>();
-                            artist = (await downloadsService.getCollectionInfo(
-                                    id: widget.item.artistItems!.first.id))!
-                                .baseItem!;
-                          } else {
-                            artist = await _jellyfinApiHelper
-                                .getItemById(widget.item.artistItems!.first.id);
-                          }
-                        } catch (e) {
-                          GlobalSnackbar.error(e);
-                          return;
-                        }
-                        if (mounted) {
-                          Navigator.pop(context);
-                          Navigator.of(context).pushNamed(
-                              ArtistScreen.routeName,
-                              arguments: artist);
-                        }
-                      },
-                    ),
-                  ),
-                  Visibility(
-                    visible: widget.canGoToGenre,
-                    child: ListTile(
-                      leading: Icon(
-                        Icons.category_outlined,
-                        color: iconColor,
+                      Visibility(
+                        visible: widget.isInPlaylist &&
+                            widget.parentItem != null &&
+                            !widget.isOffline,
+                        child: ListTile(
+                          leading: Icon(
+                            Icons.playlist_remove,
+                            color: iconColor,
+                          ),
+                          title: Text(AppLocalizations.of(context)!
+                              .removeFromPlaylistTitle),
+                          enabled: widget.isInPlaylist &&
+                              widget.parentItem != null &&
+                              !widget.isOffline,
+                          onTap: () async {
+                            try {
+                              await _jellyfinApiHelper.removeItemsFromPlaylist(
+                                  playlistId: widget.parentItem!.id,
+                                  entryIds: [widget.item.playlistItemId!]);
+
+                              if (!mounted) return;
+
+                              await _jellyfinApiHelper.getItems(
+                                parentItem: await _jellyfinApiHelper
+                                    .getItemById(widget.item.parentId!),
+                                sortBy:
+                                    "ParentIndexNumber,IndexNumber,SortName",
+                                includeItemTypes: "Audio",
+                              );
+
+                              if (!mounted) return;
+
+                              if (widget.onRemoveFromList != null)
+                                widget.onRemoveFromList!();
+
+                              GlobalSnackbar.message(
+                                  (context) => AppLocalizations.of(context)!
+                                      .removedFromPlaylist,
+                                  isConfirmation: true);
+                              Navigator.pop(context);
+                            } catch (e) {
+                              GlobalSnackbar.error(e);
+                            }
+                          },
+                        ),
                       ),
-                      title: Text(AppLocalizations.of(context)!.goToGenre),
-                      enabled: widget.canGoToGenre,
-                      onTap: () async {
-                        late BaseItemDto genre;
-                        try {
-                          if (FinampSettingsHelper.finampSettings.isOffline) {
-                            final downloadsService =
-                                GetIt.instance<DownloadsService>();
-                            genre = (await downloadsService.getCollectionInfo(
-                                    id: widget.item.genreItems!.first.id))!
-                                .baseItem!;
-                          } else {
-                            genre = await _jellyfinApiHelper
-                                .getItemById(widget.item.genreItems!.first.id);
-                          }
-                        } catch (e) {
-                          GlobalSnackbar.error(e);
-                          return;
-                        }
-                        if (mounted) {
-                          Navigator.pop(context);
-                          Navigator.of(context).pushNamed(
-                              ArtistScreen.routeName,
-                              arguments: genre);
-                        }
-                      },
-                    ),
-                  ),
-                  Visibility(
-                    visible: isDownloadRequired,
-                    // TODO add some sort of disabled state with tooltip saying to delete the parent
-                    // Need to do on other delete buttons too
-                    // Do we want to try showing lock on right clicks?
-                    // Currently only download or delete are shown.
-                    child: ListTile(
-                      leading: Icon(
-                        Icons.delete_outlined,
-                        color: iconColor,
+                      Visibility(
+                        visible: !widget.isOffline,
+                        child: ListTile(
+                          leading: Icon(
+                            Icons.playlist_add,
+                            color: iconColor,
+                          ),
+                          title: Text(
+                              AppLocalizations.of(context)!.addToPlaylistTitle),
+                          enabled: !widget.isOffline,
+                          onTap: () {
+                            Navigator.pop(context);
+                            Navigator.of(context).pushNamed(
+                                AddToPlaylistScreen.routeName,
+                                arguments: widget.item.id);
+                          },
+                        ),
                       ),
-                      title: Text(AppLocalizations.of(context)!.deleteItem),
-                      enabled: !widget.isOffline && isDownloadRequired,
-                      onTap: () async {
-                        var item = DownloadStub.fromItem(
-                            type: DownloadItemType.song, item: widget.item);
-                        unawaited(downloadsService.deleteDownload(stub: item));
-                        if (mounted) {
-                          Navigator.pop(context);
-                        }
-                      },
-                    ),
-                  ),
-                  Visibility(
-                    visible: !widget.isOffline && !isDownloadRequired,
-                    child: ListTile(
-                      leading: Icon(
-                        Icons.file_download_outlined,
-                        color: iconColor,
+                      Visibility(
+                        visible: !widget.isOffline,
+                        child: ListTile(
+                          leading: Icon(
+                            Icons.explore,
+                            color: iconColor,
+                          ),
+                          title: Text(AppLocalizations.of(context)!.instantMix),
+                          enabled: !widget.isOffline,
+                          onTap: () async {
+                            await _audioServiceHelper
+                                .startInstantMixForItem(widget.item);
+
+                            if (!mounted) return;
+
+                            GlobalSnackbar.message(
+                                (context) => AppLocalizations.of(context)!
+                                    .startingInstantMix,
+                                isConfirmation: true);
+                            Navigator.pop(context);
+                          },
+                        ),
                       ),
-                      title: Text(AppLocalizations.of(context)!.downloadItem),
-                      enabled: !widget.isOffline && !isDownloadRequired,
-                      onTap: () async {
-                        var item = DownloadStub.fromItem(
-                            type: DownloadItemType.song, item: widget.item);
-                        await DownloadDialog.show(context, item, null);
-                        if (mounted) {
-                          Navigator.pop(context);
-                        }
-                      },
-                    ),
+                      Visibility(
+                        visible: widget.canGoToAlbum,
+                        child: ListTile(
+                          leading: Icon(
+                            Icons.album,
+                            color: iconColor,
+                          ),
+                          title: Text(AppLocalizations.of(context)!.goToAlbum),
+                          enabled: widget.canGoToAlbum,
+                          onTap: () async {
+                            late BaseItemDto album;
+                            try {
+                              if (FinampSettingsHelper
+                                  .finampSettings.isOffline) {
+                                final downloadsService =
+                                    GetIt.instance<DownloadsService>();
+                                album =
+                                    (await downloadsService.getCollectionInfo(
+                                            id: widget.item.albumId!))!
+                                        .baseItem!;
+                              } else {
+                                album = await _jellyfinApiHelper
+                                    .getItemById(widget.item.albumId!);
+                              }
+                            } catch (e) {
+                              GlobalSnackbar.error(e);
+                              return;
+                            }
+                            if (mounted) {
+                              Navigator.pop(context);
+                              Navigator.of(context).pushNamed(
+                                  AlbumScreen.routeName,
+                                  arguments: album);
+                            }
+                          },
+                        ),
+                      ),
+                      Visibility(
+                        visible: widget.canGoToArtist,
+                        child: ListTile(
+                          leading: Icon(
+                            Icons.person,
+                            color: iconColor,
+                          ),
+                          title: Text(AppLocalizations.of(context)!.goToArtist),
+                          enabled: widget.canGoToArtist,
+                          onTap: () async {
+                            late BaseItemDto artist;
+                            try {
+                              if (FinampSettingsHelper
+                                  .finampSettings.isOffline) {
+                                final downloadsService =
+                                    GetIt.instance<DownloadsService>();
+                                artist =
+                                    (await downloadsService.getCollectionInfo(
+                                            id: widget
+                                                .item.artistItems!.first.id))!
+                                        .baseItem!;
+                              } else {
+                                artist = await _jellyfinApiHelper.getItemById(
+                                    widget.item.artistItems!.first.id);
+                              }
+                            } catch (e) {
+                              GlobalSnackbar.error(e);
+                              return;
+                            }
+                            if (mounted) {
+                              Navigator.pop(context);
+                              Navigator.of(context).pushNamed(
+                                  ArtistScreen.routeName,
+                                  arguments: artist);
+                            }
+                          },
+                        ),
+                      ),
+                      Visibility(
+                        visible: widget.canGoToGenre,
+                        child: ListTile(
+                          leading: Icon(
+                            Icons.category_outlined,
+                            color: iconColor,
+                          ),
+                          title: Text(AppLocalizations.of(context)!.goToGenre),
+                          enabled: widget.canGoToGenre,
+                          onTap: () async {
+                            late BaseItemDto genre;
+                            try {
+                              if (FinampSettingsHelper
+                                  .finampSettings.isOffline) {
+                                final downloadsService =
+                                    GetIt.instance<DownloadsService>();
+                                genre =
+                                    (await downloadsService.getCollectionInfo(
+                                            id: widget
+                                                .item.genreItems!.first.id))!
+                                        .baseItem!;
+                              } else {
+                                genre = await _jellyfinApiHelper.getItemById(
+                                    widget.item.genreItems!.first.id);
+                              }
+                            } catch (e) {
+                              GlobalSnackbar.error(e);
+                              return;
+                            }
+                            if (mounted) {
+                              Navigator.pop(context);
+                              Navigator.of(context).pushNamed(
+                                  ArtistScreen.routeName,
+                                  arguments: genre);
+                            }
+                          },
+                        ),
+                      ),
+                      Visibility(
+                        visible: isDownloadRequired,
+                        // TODO add some sort of disabled state with tooltip saying to delete the parent
+                        // Need to do on other delete buttons too
+                        // Do we want to try showing lock on right clicks?
+                        // Currently only download or delete are shown.
+                        child: ListTile(
+                          leading: Icon(
+                            Icons.delete_outlined,
+                            color: iconColor,
+                          ),
+                          title: Text(AppLocalizations.of(context)!.deleteItem),
+                          enabled: !widget.isOffline && isDownloadRequired,
+                          onTap: () async {
+                            var item = DownloadStub.fromItem(
+                                type: DownloadItemType.song, item: widget.item);
+                            unawaited(
+                                downloadsService.deleteDownload(stub: item));
+                            if (mounted) {
+                              Navigator.pop(context);
+                            }
+                          },
+                        ),
+                      ),
+                      Visibility(
+                        visible: !widget.isOffline && !isDownloadRequired,
+                        child: ListTile(
+                          leading: Icon(
+                            Icons.file_download_outlined,
+                            color: iconColor,
+                          ),
+                          title:
+                              Text(AppLocalizations.of(context)!.downloadItem),
+                          enabled: !widget.isOffline && !isDownloadRequired,
+                          onTap: () async {
+                            var item = DownloadStub.fromItem(
+                                type: DownloadItemType.song, item: widget.item);
+                            await DownloadDialog.show(context, item, null);
+                            if (mounted) {
+                              Navigator.pop(context);
+                            }
+                          },
+                        ),
+                      ),
+                    ]),
                   ),
-                ]),
-              ),
-            )
+                )
+              ],
+            ),
           ],
-        ),
-      ],
-    );
+        );
+
+    if (Platform.isIOS || Platform.isAndroid) {
+      return DraggableScrollableSheet(
+          snap: true,
+          snapSizes: widget.showPlaybackControls ? const [0.6] : const [0.45],
+          initialChildSize: widget.showPlaybackControls ? 0.6 : 0.45,
+          minChildSize: 0.3,
+          expand: false,
+          builder: menu);
+    } else {
+      return menu(context, _controller);
+    }
   }
 }
 

--- a/lib/components/AlbumScreen/song_menu.dart
+++ b/lib/components/AlbumScreen/song_menu.dart
@@ -6,6 +6,7 @@ import 'package:finamp/components/PlayerScreen/sleep_timer_dialog.dart';
 import 'package:finamp/models/finamp_models.dart';
 import 'package:finamp/screens/artist_screen.dart';
 import 'package:finamp/screens/blurred_player_screen_background.dart';
+import 'package:finamp/services/album_image_provider.dart';
 import 'package:finamp/services/music_player_background_task.dart';
 import 'package:finamp/services/queue_service.dart';
 import 'package:flutter/material.dart';
@@ -14,6 +15,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_tabler_icons/flutter_tabler_icons.dart';
 import 'package:flutter_vibrate/flutter_vibrate.dart';
 import 'package:get_it/get_it.dart';
+import 'package:modal_bottom_sheet/modal_bottom_sheet.dart';
 import 'package:rxdart/rxdart.dart';
 
 import '../../models/jellyfin_models.dart';
@@ -23,7 +25,6 @@ import '../../services/audio_service_helper.dart';
 import '../../services/downloads_service.dart';
 import '../../services/finamp_settings_helper.dart';
 import '../../services/jellyfin_api_helper.dart';
-import '../../services/player_screen_theme_provider.dart';
 import '../PlayerScreen/album_chip.dart';
 import '../PlayerScreen/artist_chip.dart';
 import '../album_image.dart';
@@ -46,11 +47,12 @@ Future<void> showModalSongMenu({
 
   Vibrate.feedback(FeedbackType.impact);
 
-  await showModalBottomSheet(
+  await showMaterialModalBottomSheet(
       context: context,
+      //constraints: BoxConstraints(
+      //    maxWidth: min(500, MediaQuery.sizeOf(context).width * 0.9)),
       isDismissible: true,
       enableDrag: true,
-      isScrollControlled: true,
       clipBehavior: Clip.hardEdge,
       shape: const RoundedRectangleBorder(
         borderRadius: BorderRadius.only(
@@ -62,7 +64,6 @@ Future<void> showModalSongMenu({
               ? Colors.white
               : Colors.black)
           .withOpacity(0.9),
-      useSafeArea: true,
       builder: (BuildContext context) {
         return SongMenu(
           item: item,
@@ -79,7 +80,7 @@ Future<void> showModalSongMenu({
       });
 }
 
-class SongMenu extends StatefulWidget {
+class SongMenu extends ConsumerStatefulWidget {
   const SongMenu({
     super.key,
     required this.item,
@@ -106,7 +107,7 @@ class SongMenu extends StatefulWidget {
   final ColorScheme? playerScreenTheme;
 
   @override
-  State<SongMenu> createState() => _SongMenuState();
+  ConsumerState<SongMenu> createState() => _SongMenuState();
 }
 
 bool isBaseItemInQueueItem(BaseItemDto baseItem, FinampQueueItem? queueItem) {
@@ -117,14 +118,13 @@ bool isBaseItemInQueueItem(BaseItemDto baseItem, FinampQueueItem? queueItem) {
   return false;
 }
 
-class _SongMenuState extends State<SongMenu> {
+class _SongMenuState extends ConsumerState<SongMenu> {
   final _jellyfinApiHelper = GetIt.instance<JellyfinApiHelper>();
   final _audioServiceHelper = GetIt.instance<AudioServiceHelper>();
   final _audioHandler = GetIt.instance<MusicPlayerBackgroundTask>();
   final _queueService = GetIt.instance<QueueService>();
 
   ColorScheme? _imageTheme;
-  ImageProvider? _imageProvider;
 
   @override
   void initState() {
@@ -136,15 +136,15 @@ class _SongMenuState extends State<SongMenu> {
   /// Sets the item's favourite on the Jellyfin server.
   Future<void> toggleFavorite() async {
     try {
-
       final isOffline = FinampSettingsHelper.finampSettings.isOffline;
 
       if (isOffline) {
         Vibrate.feedback(FeedbackType.error);
-        GlobalSnackbar.message((context) => AppLocalizations.of(context)!.notAvailableInOfflineMode);
+        GlobalSnackbar.message((context) =>
+            AppLocalizations.of(context)!.notAvailableInOfflineMode);
         return;
       }
-      
+
       final currentTrack = _queueService.getCurrentTrack();
       if (isBaseItemInQueueItem(widget.item, currentTrack)) {
         setFavourite(currentTrack!, context);
@@ -194,543 +194,492 @@ class _SongMenuState extends State<SongMenu> {
             null)
         .isRequired;
 
-    return Stack(children: [
-      DraggableScrollableSheet(
-        snap: true,
-        snapSizes: widget.showPlaybackControls ? const [0.6] : const [0.45],
-        initialChildSize: widget.showPlaybackControls ? 0.6 : 0.45,
-        minChildSize: 0.3,
-        expand: false,
-        builder: (context, scrollController) {
-          return Stack(
-            children: [
-              if (FinampSettingsHelper
-                  .finampSettings.showCoverAsPlayerBackground)
-                BlurredPlayerScreenBackground(
-                    customImageProvider: _imageProvider,
-                    opacityFactor:
-                        Theme.of(context).brightness == Brightness.dark
-                            ? 1.0
-                            : 1.0),
-              CustomScrollView(
-                controller: scrollController,
-                physics: const ClampingScrollPhysics(),
-                slivers: [
-                  SliverPersistentHeader(
-                    delegate: SongMenuSliverAppBar(
-                      item: widget.item,
-                      theme: _imageTheme,
-                      imageProviderCallback: (ImageProvider provider) {
-                        WidgetsBinding.instance.addPostFrameCallback((_) {
-                          if (mounted) {
-                            setState(() {
-                              _imageProvider = provider;
-                            });
-                          }
-                        });
-                      },
-                      imageThemeCallback: (ColorScheme colorScheme) {
-                        WidgetsBinding.instance.addPostFrameCallback((_) {
-                          if (mounted) {
-                            setState(() {
-                              _imageTheme = colorScheme;
-                            });
-                          }
-                        });
-                      },
-                    ),
-                    pinned: true,
-                  ),
-                  if (widget.showPlaybackControls)
-                    StreamBuilder<PlaybackBehaviorInfo>(
-                      stream: Rx.combineLatest2(
-                          _queueService.getPlaybackOrderStream(),
-                          _queueService.getLoopModeStream(),
-                          (a, b) => PlaybackBehaviorInfo(a, b)),
-                      builder: (context, snapshot) {
-                        if (!snapshot.hasData)
-                          return const SliverToBoxAdapter();
+    var imageProvider = ref.watch(albumImageProvider(AlbumImageRequest(
+      item: widget.item,
+    )));
 
-                        final playbackBehavior = snapshot.data!;
-                        const playbackOrderIcons = {
-                          FinampPlaybackOrder.linear: TablerIcons.arrows_right,
-                          FinampPlaybackOrder.shuffled:
-                              TablerIcons.arrows_shuffle,
-                        };
-                        final playbackOrderTooltips = {
-                          FinampPlaybackOrder.linear:
-                              AppLocalizations.of(context)
-                                      ?.playbackOrderLinearButtonLabel ??
-                                  "Playing in order",
-                          FinampPlaybackOrder.shuffled:
-                              AppLocalizations.of(context)
-                                      ?.playbackOrderShuffledButtonLabel ??
-                                  "Shuffling",
-                        };
-                        const loopModeIcons = {
-                          FinampLoopMode.none: TablerIcons.repeat,
-                          FinampLoopMode.one: TablerIcons.repeat_once,
-                          FinampLoopMode.all: TablerIcons.repeat,
-                        };
-                        final loopModeTooltips = {
-                          FinampLoopMode.none: AppLocalizations.of(context)
-                                  ?.loopModeNoneButtonLabel ??
-                              "Looping off",
-                          FinampLoopMode.one: AppLocalizations.of(context)
-                                  ?.loopModeOneButtonLabel ??
-                              "Looping this song",
-                          FinampLoopMode.all: AppLocalizations.of(context)
-                                  ?.loopModeAllButtonLabel ??
-                              "Looping all",
-                        };
-
-                        return SliverCrossAxisGroup(
-                          // return SliverGrid.count(
-                          //   crossAxisCount: 3,
-                          //   mainAxisSpacing: 40,
-                          //   children: [
-                          slivers: [
-                            PlaybackAction(
-                              icon: playbackOrderIcons[playbackBehavior.order]!,
-                              onPressed: () async {
-                                _queueService.togglePlaybackOrder();
-                              },
-                              tooltip: playbackOrderTooltips[
-                                  playbackBehavior.order]!,
-                              iconColor: playbackBehavior.order ==
-                                      FinampPlaybackOrder.shuffled
-                                  ? iconColor
-                                  : Theme.of(context)
-                                          .textTheme
-                                          .bodyMedium
-                                          ?.color ??
-                                      Colors.white,
-                            ),
-                            ValueListenableBuilder<Timer?>(
-                              valueListenable: _audioHandler.sleepTimer,
-                              builder: (context, timerValue, child) {
-                                final remainingMinutes = (_audioHandler
-                                            .sleepTimerRemaining.inSeconds /
-                                        60.0)
-                                    .ceil();
-                                return PlaybackAction(
-                                  icon: timerValue != null
-                                      ? TablerIcons.hourglass_high
-                                      : TablerIcons.hourglass_empty,
-                                  onPressed: () async {
-                                    if (timerValue != null) {
-                                      showDialog(
-                                        context: context,
-                                        builder: (context) =>
-                                            const SleepTimerCancelDialog(),
-                                      );
-                                    } else {
-                                      await showDialog(
-                                        context: context,
-                                        builder: (context) =>
-                                            const SleepTimerDialog(),
-                                      );
-                                    }
-                                  },
-                                  tooltip: timerValue != null
-                                      ? AppLocalizations.of(context)
-                                              ?.sleepTimerRemainingTime(
-                                                  remainingMinutes) ??
-                                          "Sleeping in $remainingMinutes minutes"
-                                      : AppLocalizations.of(context)!
-                                          .sleepTimerTooltip,
-                                  iconColor: timerValue != null
-                                      ? iconColor
-                                      : Theme.of(context)
-                                              .textTheme
-                                              .bodyMedium
-                                              ?.color ??
-                                          Colors.white,
-                                );
-                              },
-                            ),
-                            PlaybackAction(
-                              icon: loopModeIcons[playbackBehavior.loop]!,
-                              onPressed: () async {
-                                _queueService.toggleLoopMode();
-                              },
-                              tooltip: loopModeTooltips[playbackBehavior.loop]!,
-                              iconColor:
-                                  playbackBehavior.loop == FinampLoopMode.none
-                                      ? Theme.of(context)
-                                              .textTheme
-                                              .bodyMedium
-                                              ?.color ??
-                                          Colors.white
-                                      : iconColor,
-                            ),
-                          ],
-                        );
-                      },
-                    ),
-                  SliverPadding(
-                    padding: const EdgeInsets.only(left: 8.0),
-                    sliver: SliverList(
-                      delegate: SliverChildListDelegate([
-                        ListTile(
-                          enabled: !widget.isOffline,
-                          leading: widget.item.userData!.isFavorite
-                              ? Icon(
-                                  Icons.favorite,
-                                  color: widget.isOffline ? iconColor.withOpacity(0.3) : iconColor,
-                                )
-                              : Icon(
-                                  Icons.favorite_border,
-                                  color: widget.isOffline ? iconColor.withOpacity(0.3) : iconColor,
-                                ),
-                          title: Text(widget.item.userData!.isFavorite
-                              ? AppLocalizations.of(context)!.removeFavourite
-                              : AppLocalizations.of(context)!.addFavourite),
-                          onTap: () async {
-                            await toggleFavorite();
-                            if (mounted) Navigator.pop(context);
-                          },
-                        ),
-                        Visibility(
-                          visible: _queueService.getQueue().nextUp.isNotEmpty,
-                          child: ListTile(
-                            leading: Icon(
-                              TablerIcons.corner_right_down,
-                              color: iconColor,
-                            ),
-                            title: Text(AppLocalizations.of(context)!.playNext),
-                            onTap: () async {
-                              await _queueService.addNext(
-                                  items: [widget.item],
-                                  source: QueueItemSource(
-                                      type: QueueItemSourceType.nextUp,
-                                      name: const QueueItemSourceName(
-                                          type: QueueItemSourceNameType.nextUp),
-                                      id: widget.item.id));
-
-                              if (!mounted) return;
-
-                              GlobalSnackbar.message((context) =>
-                                  AppLocalizations.of(context)!.confirmPlayNext("track"), isConfirmation: true);
-                              Navigator.pop(context);
-                            },
-                          ),
-                        ),
-                        ListTile(
-                          leading: Icon(
-                            TablerIcons.corner_right_down_double,
-                            color: iconColor,
-                          ),
-                          title:
-                              Text(AppLocalizations.of(context)!.addToNextUp),
-                          onTap: () async {
-                            await _queueService.addToNextUp(
-                                items: [widget.item],
-                                source: QueueItemSource(
-                                    type: QueueItemSourceType.nextUp,
-                                    name: const QueueItemSourceName(
-                                        type: QueueItemSourceNameType.nextUp),
-                                    id: widget.item.id));
-
-                            if (!mounted) return;
-
-                            GlobalSnackbar.message((context) =>
-                                AppLocalizations.of(context)!.confirmAddToNextUp("track"), isConfirmation: true);
-                            Navigator.pop(context);
-                          },
-                        ),
-                        ListTile(
-                          leading: Icon(
-                            TablerIcons.playlist,
-                            color: iconColor,
-                          ),
-                          title: Text(AppLocalizations.of(context)!.addToQueue),
-                          onTap: () async {
-                            await _queueService.addToQueue(
-                                items: [widget.item],
-                                source: QueueItemSource(
-                                    type: QueueItemSourceType.queue,
-                                    name: const QueueItemSourceName(
-                                        type: QueueItemSourceNameType.queue),
-                                    id: widget.item.id));
-
-                            if (!mounted) return;
-
-                            GlobalSnackbar.message((context) =>
-                                AppLocalizations.of(context)!.addedToQueue, isConfirmation: true);
-                            Navigator.pop(context);
-                          },
-                        ),
-                        Visibility(
-                          visible: widget.isInPlaylist && widget.parentItem != null && !widget.isOffline,
-                          child: ListTile(
-                            leading: Icon(
-                              Icons.playlist_remove,
-                              color: iconColor,
-                            ),
-                            title: Text(AppLocalizations.of(context)!
-                                .removeFromPlaylistTitle),
-                            enabled: widget.isInPlaylist && widget.parentItem != null && !widget.isOffline,
-                            onTap: () async {
-                              try {
-                                await _jellyfinApiHelper
-                                    .removeItemsFromPlaylist(
-                                        playlistId: widget.parentItem!.id,
-                                        entryIds: [
-                                      widget.item.playlistItemId!
-                                    ]);
-
-                                if (!mounted) return;
-
-                                await _jellyfinApiHelper.getItems(
-                                  parentItem: await _jellyfinApiHelper
-                                      .getItemById(widget.item.parentId!),
-                                  sortBy:
-                                      "ParentIndexNumber,IndexNumber,SortName",
-                                  includeItemTypes: "Audio",
-                                );
-
-                                if (!mounted) return;
-
-                                if (widget.onRemoveFromList != null)
-                                  widget.onRemoveFromList!();
-
-                                GlobalSnackbar.message((context) =>
-                                    AppLocalizations.of(context)!.removedFromPlaylist, isConfirmation: true);
-                                Navigator.pop(context);
-                              } catch (e) {
-                                GlobalSnackbar.error(e);
-                              }
-                            },
-                          ),
-                        ),
-                        Visibility(
-                          visible: !widget.isOffline,
-                          child: ListTile(
-                            leading: Icon(
-                              Icons.playlist_add,
-                              color: iconColor,
-                            ),
-                            title: Text(AppLocalizations.of(context)!
-                                .addToPlaylistTitle),
-                            enabled: !widget.isOffline,
-                            onTap: () {
-                              Navigator.pop(context);
-                              Navigator.of(context).pushNamed(
-                                  AddToPlaylistScreen.routeName,
-                                  arguments: widget.item.id);
-                            },
-                          ),
-                        ),
-                        Visibility(
-                          visible: !widget.isOffline,
-                          child: ListTile(
-                            leading: Icon(
-                              Icons.explore,
-                              color: iconColor,
-                            ),
-                            title:
-                                Text(AppLocalizations.of(context)!.instantMix),
-                            enabled: !widget.isOffline,
-                            onTap: () async {
-                              await _audioServiceHelper
-                                  .startInstantMixForItem(widget.item);
-
-                              if (!mounted) return;
-
-                              GlobalSnackbar.message((context) =>
-                                  AppLocalizations.of(context)!.startingInstantMix, isConfirmation: true);
-                              Navigator.pop(context);
-                            },
-                          ),
-                        ),
-                        Visibility(
-                          visible: widget.canGoToAlbum,
-                          child: ListTile(
-                            leading: Icon(
-                              Icons.album,
-                              color: iconColor,
-                            ),
-                            title:
-                                Text(AppLocalizations.of(context)!.goToAlbum),
-                            enabled: widget.canGoToAlbum,
-                            onTap: () async {
-                              late BaseItemDto album;
-                              try {
-                                if (FinampSettingsHelper
-                                    .finampSettings.isOffline) {
-                                  final downloadsService =
-                                      GetIt.instance<DownloadsService>();
-                                  album =
-                                      (await downloadsService.getCollectionInfo(
-                                              id: widget.item.albumId!))!
-                                          .baseItem!;
-                                } else {
-                                  album = await _jellyfinApiHelper
-                                      .getItemById(widget.item.albumId!);
-                                }
-                              } catch (e) {
-                                GlobalSnackbar.error(e);
-                                return;
-                              }
-                              if (mounted) {
-                                Navigator.pop(context);
-                                Navigator.of(context).pushNamed(
-                                    AlbumScreen.routeName,
-                                    arguments: album);
-                              }
-                            },
-                          ),
-                        ),
-                        Visibility(
-                          visible: widget.canGoToArtist,
-                          child: ListTile(
-                            leading: Icon(
-                              Icons.person,
-                              color: iconColor,
-                            ),
-                            title:
-                                Text(AppLocalizations.of(context)!.goToArtist),
-                            enabled: widget.canGoToArtist,
-                            onTap: () async {
-                              late BaseItemDto artist;
-                              try {
-                                if (FinampSettingsHelper
-                                    .finampSettings.isOffline) {
-                                  final downloadsService =
-                                      GetIt.instance<DownloadsService>();
-                                  artist =
-                                      (await downloadsService.getCollectionInfo(
-                                              id: widget
-                                                  .item.artistItems!.first.id))!
-                                          .baseItem!;
-                                } else {
-                                  artist = await _jellyfinApiHelper.getItemById(
-                                      widget.item.artistItems!.first.id);
-                                }
-                              } catch (e) {
-                                GlobalSnackbar.error(e);
-                                return;
-                              }
-                              if (mounted) {
-                                Navigator.pop(context);
-                                Navigator.of(context).pushNamed(
-                                    ArtistScreen.routeName,
-                                    arguments: artist);
-                              }
-                            },
-                          ),
-                        ),
-                        Visibility(
-                          visible: widget.canGoToGenre,
-                          child: ListTile(
-                            leading: Icon(
-                              Icons.category_outlined,
-                              color: iconColor,
-                            ),
-                            title:
-                                Text(AppLocalizations.of(context)!.goToGenre),
-                            enabled: widget.canGoToGenre,
-                            onTap: () async {
-                              late BaseItemDto genre;
-                              try {
-                                if (FinampSettingsHelper
-                                    .finampSettings.isOffline) {
-                                  final downloadsService =
-                                      GetIt.instance<DownloadsService>();
-                                  genre =
-                                      (await downloadsService.getCollectionInfo(
-                                              id: widget
-                                                  .item.genreItems!.first.id))!
-                                          .baseItem!;
-                                } else {
-                                  genre = await _jellyfinApiHelper.getItemById(
-                                      widget.item.genreItems!.first.id);
-                                }
-                              } catch (e) {
-                                GlobalSnackbar.error(e);
-                                return;
-                              }
-                              if (mounted) {
-                                Navigator.pop(context);
-                                Navigator.of(context).pushNamed(
-                                    ArtistScreen.routeName,
-                                    arguments: genre);
-                              }
-                            },
-                          ),
-                        ),
-                        Visibility(
-                          visible: isDownloadRequired,
-                          // TODO add some sort of disabled state with tooltip saying to delete the parent
-                          // Need to do on other delete buttons too
-                          // Do we want to try showing lock on right clicks?
-                          // Currently only download or delete are shown.
-                          child: ListTile(
-                            leading: Icon(
-                              Icons.delete_outlined,
-                              color: iconColor,
-                            ),
-                            title:
-                                Text(AppLocalizations.of(context)!.deleteItem),
-                            enabled: !widget.isOffline && isDownloadRequired,
-                            onTap: () async {
-                              var item = DownloadStub.fromItem(
-                                  type: DownloadItemType.song,
-                                  item: widget.item);
-                              unawaited(
-                                  downloadsService.deleteDownload(stub: item));
-                              if (mounted) {
-                                Navigator.pop(context);
-                              }
-                            },
-                          ),
-                        ),
-                        Visibility(
-                          visible: !widget.isOffline && !isDownloadRequired,
-                          child: ListTile(
-                            leading: Icon(
-                              Icons.file_download_outlined,
-                              color: iconColor,
-                            ),
-                            title: Text(
-                                AppLocalizations.of(context)!.downloadItem),
-                            enabled: !widget.isOffline && !isDownloadRequired,
-                            onTap: () async {
-                              var item = DownloadStub.fromItem(
-                                  type: DownloadItemType.song,
-                                  item: widget.item);
-                              await DownloadDialog.show(context, item, null);
-                              if (mounted) {
-                                Navigator.pop(context);
-                              }
-                            },
-                          ),
-                        ),
-                      ]),
-                    ),
-                  )
-                ],
+    return Stack(
+      children: [
+        if (FinampSettingsHelper.finampSettings.showCoverAsPlayerBackground)
+          BlurredPlayerScreenBackground(
+              customImageProvider: imageProvider,
+              opacityFactor:
+                  Theme.of(context).brightness == Brightness.dark ? 1.0 : 1.0),
+        CustomScrollView(
+          controller: ModalScrollController.of(context),
+          shrinkWrap: true,
+          physics: const ClampingScrollPhysics(),
+          slivers: [
+            SliverPersistentHeader(
+              delegate: SongMenuSliverAppBar(
+                item: widget.item,
               ),
-            ],
-          );
-        },
-      ),
-    ]);
+              pinned: true,
+            ),
+            if (widget.showPlaybackControls)
+              StreamBuilder<PlaybackBehaviorInfo>(
+                stream: Rx.combineLatest2(
+                    _queueService.getPlaybackOrderStream(),
+                    _queueService.getLoopModeStream(),
+                    (a, b) => PlaybackBehaviorInfo(a, b)),
+                builder: (context, snapshot) {
+                  if (!snapshot.hasData) return const SliverToBoxAdapter();
+
+                  final playbackBehavior = snapshot.data!;
+                  const playbackOrderIcons = {
+                    FinampPlaybackOrder.linear: TablerIcons.arrows_right,
+                    FinampPlaybackOrder.shuffled: TablerIcons.arrows_shuffle,
+                  };
+                  final playbackOrderTooltips = {
+                    FinampPlaybackOrder.linear: AppLocalizations.of(context)
+                            ?.playbackOrderLinearButtonLabel ??
+                        "Playing in order",
+                    FinampPlaybackOrder.shuffled: AppLocalizations.of(context)
+                            ?.playbackOrderShuffledButtonLabel ??
+                        "Shuffling",
+                  };
+                  const loopModeIcons = {
+                    FinampLoopMode.none: TablerIcons.repeat,
+                    FinampLoopMode.one: TablerIcons.repeat_once,
+                    FinampLoopMode.all: TablerIcons.repeat,
+                  };
+                  final loopModeTooltips = {
+                    FinampLoopMode.none:
+                        AppLocalizations.of(context)?.loopModeNoneButtonLabel ??
+                            "Looping off",
+                    FinampLoopMode.one:
+                        AppLocalizations.of(context)?.loopModeOneButtonLabel ??
+                            "Looping this song",
+                    FinampLoopMode.all:
+                        AppLocalizations.of(context)?.loopModeAllButtonLabel ??
+                            "Looping all",
+                  };
+
+                  return SliverCrossAxisGroup(
+                    // return SliverGrid.count(
+                    //   crossAxisCount: 3,
+                    //   mainAxisSpacing: 40,
+                    //   children: [
+                    slivers: [
+                      PlaybackAction(
+                        icon: playbackOrderIcons[playbackBehavior.order]!,
+                        onPressed: () async {
+                          _queueService.togglePlaybackOrder();
+                        },
+                        tooltip: playbackOrderTooltips[playbackBehavior.order]!,
+                        iconColor: playbackBehavior.order ==
+                                FinampPlaybackOrder.shuffled
+                            ? iconColor
+                            : Theme.of(context).textTheme.bodyMedium?.color ??
+                                Colors.white,
+                      ),
+                      ValueListenableBuilder<Timer?>(
+                        valueListenable: _audioHandler.sleepTimer,
+                        builder: (context, timerValue, child) {
+                          final remainingMinutes =
+                              (_audioHandler.sleepTimerRemaining.inSeconds /
+                                      60.0)
+                                  .ceil();
+                          return PlaybackAction(
+                            icon: timerValue != null
+                                ? TablerIcons.hourglass_high
+                                : TablerIcons.hourglass_empty,
+                            onPressed: () async {
+                              if (timerValue != null) {
+                                showDialog(
+                                  context: context,
+                                  builder: (context) =>
+                                      const SleepTimerCancelDialog(),
+                                );
+                              } else {
+                                await showDialog(
+                                  context: context,
+                                  builder: (context) =>
+                                      const SleepTimerDialog(),
+                                );
+                              }
+                            },
+                            tooltip: timerValue != null
+                                ? AppLocalizations.of(context)
+                                        ?.sleepTimerRemainingTime(
+                                            remainingMinutes) ??
+                                    "Sleeping in $remainingMinutes minutes"
+                                : AppLocalizations.of(context)!
+                                    .sleepTimerTooltip,
+                            iconColor: timerValue != null
+                                ? iconColor
+                                : Theme.of(context)
+                                        .textTheme
+                                        .bodyMedium
+                                        ?.color ??
+                                    Colors.white,
+                          );
+                        },
+                      ),
+                      PlaybackAction(
+                        icon: loopModeIcons[playbackBehavior.loop]!,
+                        onPressed: () async {
+                          _queueService.toggleLoopMode();
+                        },
+                        tooltip: loopModeTooltips[playbackBehavior.loop]!,
+                        iconColor: playbackBehavior.loop == FinampLoopMode.none
+                            ? Theme.of(context).textTheme.bodyMedium?.color ??
+                                Colors.white
+                            : iconColor,
+                      ),
+                    ],
+                  );
+                },
+              ),
+            SliverPadding(
+              padding: const EdgeInsets.only(left: 8.0),
+              sliver: SliverList(
+                delegate: SliverChildListDelegate([
+                  ListTile(
+                    enabled: !widget.isOffline,
+                    leading: widget.item.userData!.isFavorite
+                        ? Icon(
+                            Icons.favorite,
+                            color: widget.isOffline
+                                ? iconColor.withOpacity(0.3)
+                                : iconColor,
+                          )
+                        : Icon(
+                            Icons.favorite_border,
+                            color: widget.isOffline
+                                ? iconColor.withOpacity(0.3)
+                                : iconColor,
+                          ),
+                    title: Text(widget.item.userData!.isFavorite
+                        ? AppLocalizations.of(context)!.removeFavourite
+                        : AppLocalizations.of(context)!.addFavourite),
+                    onTap: () async {
+                      await toggleFavorite();
+                      if (mounted) Navigator.pop(context);
+                    },
+                  ),
+                  Visibility(
+                    visible: _queueService.getQueue().nextUp.isNotEmpty,
+                    child: ListTile(
+                      leading: Icon(
+                        TablerIcons.corner_right_down,
+                        color: iconColor,
+                      ),
+                      title: Text(AppLocalizations.of(context)!.playNext),
+                      onTap: () async {
+                        await _queueService.addNext(
+                            items: [widget.item],
+                            source: QueueItemSource(
+                                type: QueueItemSourceType.nextUp,
+                                name: const QueueItemSourceName(
+                                    type: QueueItemSourceNameType.nextUp),
+                                id: widget.item.id));
+
+                        if (!mounted) return;
+
+                        GlobalSnackbar.message(
+                            (context) => AppLocalizations.of(context)!
+                                .confirmPlayNext("track"),
+                            isConfirmation: true);
+                        Navigator.pop(context);
+                      },
+                    ),
+                  ),
+                  ListTile(
+                    leading: Icon(
+                      TablerIcons.corner_right_down_double,
+                      color: iconColor,
+                    ),
+                    title: Text(AppLocalizations.of(context)!.addToNextUp),
+                    onTap: () async {
+                      await _queueService.addToNextUp(
+                          items: [widget.item],
+                          source: QueueItemSource(
+                              type: QueueItemSourceType.nextUp,
+                              name: const QueueItemSourceName(
+                                  type: QueueItemSourceNameType.nextUp),
+                              id: widget.item.id));
+
+                      if (!mounted) return;
+
+                      GlobalSnackbar.message(
+                          (context) => AppLocalizations.of(context)!
+                              .confirmAddToNextUp("track"),
+                          isConfirmation: true);
+                      Navigator.pop(context);
+                    },
+                  ),
+                  ListTile(
+                    leading: Icon(
+                      TablerIcons.playlist,
+                      color: iconColor,
+                    ),
+                    title: Text(AppLocalizations.of(context)!.addToQueue),
+                    onTap: () async {
+                      await _queueService.addToQueue(
+                          items: [widget.item],
+                          source: QueueItemSource(
+                              type: QueueItemSourceType.queue,
+                              name: const QueueItemSourceName(
+                                  type: QueueItemSourceNameType.queue),
+                              id: widget.item.id));
+
+                      if (!mounted) return;
+
+                      GlobalSnackbar.message(
+                          (context) =>
+                              AppLocalizations.of(context)!.addedToQueue,
+                          isConfirmation: true);
+                      Navigator.pop(context);
+                    },
+                  ),
+                  Visibility(
+                    visible: widget.isInPlaylist &&
+                        widget.parentItem != null &&
+                        !widget.isOffline,
+                    child: ListTile(
+                      leading: Icon(
+                        Icons.playlist_remove,
+                        color: iconColor,
+                      ),
+                      title: Text(AppLocalizations.of(context)!
+                          .removeFromPlaylistTitle),
+                      enabled: widget.isInPlaylist &&
+                          widget.parentItem != null &&
+                          !widget.isOffline,
+                      onTap: () async {
+                        try {
+                          await _jellyfinApiHelper.removeItemsFromPlaylist(
+                              playlistId: widget.parentItem!.id,
+                              entryIds: [widget.item.playlistItemId!]);
+
+                          if (!mounted) return;
+
+                          await _jellyfinApiHelper.getItems(
+                            parentItem: await _jellyfinApiHelper
+                                .getItemById(widget.item.parentId!),
+                            sortBy: "ParentIndexNumber,IndexNumber,SortName",
+                            includeItemTypes: "Audio",
+                          );
+
+                          if (!mounted) return;
+
+                          if (widget.onRemoveFromList != null)
+                            widget.onRemoveFromList!();
+
+                          GlobalSnackbar.message(
+                              (context) => AppLocalizations.of(context)!
+                                  .removedFromPlaylist,
+                              isConfirmation: true);
+                          Navigator.pop(context);
+                        } catch (e) {
+                          GlobalSnackbar.error(e);
+                        }
+                      },
+                    ),
+                  ),
+                  Visibility(
+                    visible: !widget.isOffline,
+                    child: ListTile(
+                      leading: Icon(
+                        Icons.playlist_add,
+                        color: iconColor,
+                      ),
+                      title: Text(
+                          AppLocalizations.of(context)!.addToPlaylistTitle),
+                      enabled: !widget.isOffline,
+                      onTap: () {
+                        Navigator.pop(context);
+                        Navigator.of(context).pushNamed(
+                            AddToPlaylistScreen.routeName,
+                            arguments: widget.item.id);
+                      },
+                    ),
+                  ),
+                  Visibility(
+                    visible: !widget.isOffline,
+                    child: ListTile(
+                      leading: Icon(
+                        Icons.explore,
+                        color: iconColor,
+                      ),
+                      title: Text(AppLocalizations.of(context)!.instantMix),
+                      enabled: !widget.isOffline,
+                      onTap: () async {
+                        await _audioServiceHelper
+                            .startInstantMixForItem(widget.item);
+
+                        if (!mounted) return;
+
+                        GlobalSnackbar.message(
+                            (context) => AppLocalizations.of(context)!
+                                .startingInstantMix,
+                            isConfirmation: true);
+                        Navigator.pop(context);
+                      },
+                    ),
+                  ),
+                  Visibility(
+                    visible: widget.canGoToAlbum,
+                    child: ListTile(
+                      leading: Icon(
+                        Icons.album,
+                        color: iconColor,
+                      ),
+                      title: Text(AppLocalizations.of(context)!.goToAlbum),
+                      enabled: widget.canGoToAlbum,
+                      onTap: () async {
+                        late BaseItemDto album;
+                        try {
+                          if (FinampSettingsHelper.finampSettings.isOffline) {
+                            final downloadsService =
+                                GetIt.instance<DownloadsService>();
+                            album = (await downloadsService.getCollectionInfo(
+                                    id: widget.item.albumId!))!
+                                .baseItem!;
+                          } else {
+                            album = await _jellyfinApiHelper
+                                .getItemById(widget.item.albumId!);
+                          }
+                        } catch (e) {
+                          GlobalSnackbar.error(e);
+                          return;
+                        }
+                        if (mounted) {
+                          Navigator.pop(context);
+                          Navigator.of(context).pushNamed(AlbumScreen.routeName,
+                              arguments: album);
+                        }
+                      },
+                    ),
+                  ),
+                  Visibility(
+                    visible: widget.canGoToArtist,
+                    child: ListTile(
+                      leading: Icon(
+                        Icons.person,
+                        color: iconColor,
+                      ),
+                      title: Text(AppLocalizations.of(context)!.goToArtist),
+                      enabled: widget.canGoToArtist,
+                      onTap: () async {
+                        late BaseItemDto artist;
+                        try {
+                          if (FinampSettingsHelper.finampSettings.isOffline) {
+                            final downloadsService =
+                                GetIt.instance<DownloadsService>();
+                            artist = (await downloadsService.getCollectionInfo(
+                                    id: widget.item.artistItems!.first.id))!
+                                .baseItem!;
+                          } else {
+                            artist = await _jellyfinApiHelper
+                                .getItemById(widget.item.artistItems!.first.id);
+                          }
+                        } catch (e) {
+                          GlobalSnackbar.error(e);
+                          return;
+                        }
+                        if (mounted) {
+                          Navigator.pop(context);
+                          Navigator.of(context).pushNamed(
+                              ArtistScreen.routeName,
+                              arguments: artist);
+                        }
+                      },
+                    ),
+                  ),
+                  Visibility(
+                    visible: widget.canGoToGenre,
+                    child: ListTile(
+                      leading: Icon(
+                        Icons.category_outlined,
+                        color: iconColor,
+                      ),
+                      title: Text(AppLocalizations.of(context)!.goToGenre),
+                      enabled: widget.canGoToGenre,
+                      onTap: () async {
+                        late BaseItemDto genre;
+                        try {
+                          if (FinampSettingsHelper.finampSettings.isOffline) {
+                            final downloadsService =
+                                GetIt.instance<DownloadsService>();
+                            genre = (await downloadsService.getCollectionInfo(
+                                    id: widget.item.genreItems!.first.id))!
+                                .baseItem!;
+                          } else {
+                            genre = await _jellyfinApiHelper
+                                .getItemById(widget.item.genreItems!.first.id);
+                          }
+                        } catch (e) {
+                          GlobalSnackbar.error(e);
+                          return;
+                        }
+                        if (mounted) {
+                          Navigator.pop(context);
+                          Navigator.of(context).pushNamed(
+                              ArtistScreen.routeName,
+                              arguments: genre);
+                        }
+                      },
+                    ),
+                  ),
+                  Visibility(
+                    visible: isDownloadRequired,
+                    // TODO add some sort of disabled state with tooltip saying to delete the parent
+                    // Need to do on other delete buttons too
+                    // Do we want to try showing lock on right clicks?
+                    // Currently only download or delete are shown.
+                    child: ListTile(
+                      leading: Icon(
+                        Icons.delete_outlined,
+                        color: iconColor,
+                      ),
+                      title: Text(AppLocalizations.of(context)!.deleteItem),
+                      enabled: !widget.isOffline && isDownloadRequired,
+                      onTap: () async {
+                        var item = DownloadStub.fromItem(
+                            type: DownloadItemType.song, item: widget.item);
+                        unawaited(downloadsService.deleteDownload(stub: item));
+                        if (mounted) {
+                          Navigator.pop(context);
+                        }
+                      },
+                    ),
+                  ),
+                  Visibility(
+                    visible: !widget.isOffline && !isDownloadRequired,
+                    child: ListTile(
+                      leading: Icon(
+                        Icons.file_download_outlined,
+                        color: iconColor,
+                      ),
+                      title: Text(AppLocalizations.of(context)!.downloadItem),
+                      enabled: !widget.isOffline && !isDownloadRequired,
+                      onTap: () async {
+                        var item = DownloadStub.fromItem(
+                            type: DownloadItemType.song, item: widget.item);
+                        await DownloadDialog.show(context, item, null);
+                        if (mounted) {
+                          Navigator.pop(context);
+                        }
+                      },
+                    ),
+                  ),
+                ]),
+              ),
+            )
+          ],
+        ),
+      ],
+    );
   }
 }
 
 class SongMenuSliverAppBar extends SliverPersistentHeaderDelegate {
   BaseItemDto item;
-  final ColorScheme? theme;
-  final Function(ColorScheme)? imageThemeCallback;
-  final Function(ImageProvider)? imageProviderCallback;
 
   SongMenuSliverAppBar({
     required this.item,
-    required this.theme,
-    this.imageThemeCallback,
-    this.imageProviderCallback,
   });
 
   @override
@@ -738,9 +687,6 @@ class SongMenuSliverAppBar extends SliverPersistentHeaderDelegate {
       BuildContext context, double shrinkOffset, bool overlapsContent) {
     return _SongInfo(
       item: item,
-      theme: theme,
-      imageThemeCallback: imageThemeCallback,
-      imageProviderCallback: imageProviderCallback,
     );
   }
 
@@ -758,13 +704,11 @@ class SongMenuSliverAppBar extends SliverPersistentHeaderDelegate {
 class _SongInfo extends ConsumerStatefulWidget {
   const _SongInfo({
     required this.item,
-    required this.theme,
     this.imageThemeCallback,
     this.imageProviderCallback,
   });
 
   final BaseItemDto item;
-  final ColorScheme? theme;
   final Function(ColorScheme)? imageThemeCallback;
   final Function(ImageProvider)? imageProviderCallback;
 
@@ -773,17 +717,6 @@ class _SongInfo extends ConsumerStatefulWidget {
 }
 
 class _SongInfoState extends ConsumerState<_SongInfo> {
-  final _queueService = GetIt.instance<QueueService>();
-
-  VoidCallback? onDispose;
-  bool waitingForTheme = false;
-
-  @override
-  void dispose() {
-    onDispose?.call();
-    super.dispose();
-  }
-
   @override
   Widget build(BuildContext context) {
     return Container(
@@ -812,52 +745,6 @@ class _SongInfoState extends ConsumerState<_SongInfo> {
                   borderRadius: BorderRadius.zero,
                   autoScale:
                       false, // use the maximum resolution, so that the generated color scheme is consistent with the player screen
-                  imageProviderCallback: (imageProvider) async {
-                    if (widget.theme == null && imageProvider != null) {
-                      if (widget.imageProviderCallback != null) {
-                        widget.imageProviderCallback!(imageProvider);
-                      }
-
-                      ImageStream stream = imageProvider.resolve(
-                          const ImageConfiguration(devicePixelRatio: 1.0));
-                      ImageStreamListener? listener;
-
-                      ColorScheme newColorScheme;
-
-                      listener =
-                          ImageStreamListener((image, synchronousCall) async {
-                        stream.removeListener(listener!);
-                        if (waitingForTheme || widget.theme != null) {
-                          return;
-                        }
-                        themeProviderLogger.finest("Getting theme from image");
-                        waitingForTheme = true;
-                        newColorScheme = await getColorSchemeForImage(
-                            image.image, Theme.of(context).brightness);
-                        widget.imageThemeCallback?.call(newColorScheme);
-                        waitingForTheme = false;
-                      }, onError: (err, trace) {
-                        stream.removeListener(listener!);
-                        waitingForTheme = false;
-                        if (widget.theme != null) {
-                          return;
-                        }
-                        themeProviderLogger.warning(
-                            "Error getting color scheme for image", err, trace);
-                        newColorScheme =
-                            getDefaultTheme(Theme.of(context).brightness);
-                        widget.imageThemeCallback?.call(newColorScheme);
-                      });
-
-                      onDispose = () {
-                        stream.removeListener(listener!);
-                      };
-
-                      if (widget.theme == null && !waitingForTheme) {
-                        stream.addListener(listener);
-                      }
-                    }
-                  },
                 ),
               ),
               Expanded(

--- a/lib/components/ArtistScreen/artist_screen_content.dart
+++ b/lib/components/ArtistScreen/artist_screen_content.dart
@@ -120,8 +120,7 @@ class _ArtistScreenContentState extends State<ArtistScreenContent> {
             return sortedsongs;
           });
 
-          return Scrollbar(
-              child: CustomScrollView(slivers: <Widget>[
+          return CustomScrollView(slivers: <Widget>[
             SliverAppBar(
               title: Text(widget.parent.name ??
                   AppLocalizations.of(context)!.unknownName),
@@ -185,7 +184,7 @@ class _ArtistScreenContentState extends State<ArtistScreenContent> {
                 height: MediaQuery.paddingOf(context).bottom,
               ),
             )
-          ]));
+          ]);
         });
   }
 }

--- a/lib/components/DownloadLocationSettingsScreen/download_location_list.dart
+++ b/lib/components/DownloadLocationSettingsScreen/download_location_list.dart
@@ -18,9 +18,8 @@ class _DownloadLocationListState extends State<DownloadLocationList> {
   @override
   void initState() {
     super.initState();
-    downloadLocationsIterable = FinampSettingsHelper
-        .finampSettings.downloadLocationsMap.values
-        .where((element) => element.baseDirectory.needsPath);
+    downloadLocationsIterable =
+        FinampSettingsHelper.finampSettings.downloadLocationsMap.values;
   }
 
   @override

--- a/lib/components/DownloadLocationSettingsScreen/download_location_list_tile.dart
+++ b/lib/components/DownloadLocationSettingsScreen/download_location_list_tile.dart
@@ -1,9 +1,13 @@
+import 'package:finamp/services/finamp_settings_helper.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter_gen/gen_l10n/app_localizations.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:hive/hive.dart';
 
 import '../../models/finamp_models.dart';
 import 'download_location_delete_dialog.dart';
 
-class DownloadLocationListTile extends StatelessWidget {
+class DownloadLocationListTile extends ConsumerWidget {
   const DownloadLocationListTile({
     Key? key,
     required this.downloadLocation,
@@ -12,7 +16,11 @@ class DownloadLocationListTile extends StatelessWidget {
   final DownloadLocation downloadLocation;
 
   @override
-  Widget build(BuildContext context) {
+  Widget build(BuildContext context, WidgetRef ref) {
+    bool isDefault = ref.watch(FinampSettingsHelper.finampSettingsProvider
+        .select((value) =>
+            value.value?.defaultDownloadLocation == downloadLocation.id));
+
     return ListTile(
       title: Text(downloadLocation.name),
       subtitle: Text(
@@ -20,14 +28,33 @@ class DownloadLocationListTile extends StatelessWidget {
         maxLines: 1,
         overflow: TextOverflow.ellipsis,
       ),
-      trailing: IconButton(
-        icon: const Icon(Icons.delete),
-        onPressed: () => showDialog(
-          context: context,
-          builder: (context) => DownloadLocationDeleteDialog(
-            id: downloadLocation.id,
+      trailing: Row(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          IconButton(
+            icon: Icon(isDefault ? Icons.star : Icons.star_outline),
+            onPressed: () {
+              FinampSettings finampSettingsTemp =
+                  FinampSettingsHelper.finampSettings;
+              finampSettingsTemp.defaultDownloadLocation =
+                  isDefault ? null : downloadLocation.id;
+              Hive.box<FinampSettings>("FinampSettings")
+                  .put("FinampSettings", finampSettingsTemp);
+            },
+            tooltip:
+                AppLocalizations.of(context)!.defaultDownloadLocationButton,
           ),
-        ),
+          if (downloadLocation.baseDirectory.needsPath)
+            IconButton(
+              icon: const Icon(Icons.delete),
+              onPressed: () => showDialog(
+                context: context,
+                builder: (context) => DownloadLocationDeleteDialog(
+                  id: downloadLocation.id,
+                ),
+              ),
+            ),
+        ],
       ),
     );
   }

--- a/lib/components/LogsScreen/logs_view.dart
+++ b/lib/components/LogsScreen/logs_view.dart
@@ -1,8 +1,8 @@
 import 'package:flutter/material.dart';
 import 'package:get_it/get_it.dart';
 
-import 'log_tile.dart';
 import '../../services/finamp_logs_helper.dart';
+import 'log_tile.dart';
 
 class LogsView extends StatelessWidget {
   const LogsView({Key? key}) : super(key: key);
@@ -11,15 +11,13 @@ class LogsView extends StatelessWidget {
   Widget build(BuildContext context) {
     FinampLogsHelper finampLogsHelper = GetIt.instance<FinampLogsHelper>();
 
-    return Scrollbar(
-      child: ListView.builder(
-        itemCount: finampLogsHelper.logs.length,
-        reverse: true,
-        itemBuilder: (context, index) {
-          return LogTile(
-              logRecord: finampLogsHelper.logs.reversed.elementAt(index));
-        },
-      ),
+    return ListView.builder(
+      itemCount: finampLogsHelper.logs.length,
+      reverse: true,
+      itemBuilder: (context, index) {
+        return LogTile(
+            logRecord: finampLogsHelper.logs.reversed.elementAt(index));
+      },
     );
   }
 }

--- a/lib/components/MusicScreen/alphabet_item_list.dart
+++ b/lib/components/MusicScreen/alphabet_item_list.dart
@@ -36,14 +36,13 @@ class _AlphabetListState extends State<AlphabetList> {
 
   @override
   Widget build(BuildContext context) {
-    return Container(
-      alignment: Alignment.centerRight,
-      child: SingleChildScrollView(
-        padding: EdgeInsets.only(
-          right: 2,
-          bottom: MediaQuery.paddingOf(context).bottom,
-        ),
-        child: Column(
+    return Positioned(
+      right: 3 + MediaQuery.paddingOf(context).right,
+      top: 0,
+      bottom: MediaQuery.paddingOf(context).bottom,
+      child: LayoutBuilder(builder: (context, constraints) {
+        var listHeight = constraints.maxHeight;
+        return Column(
             mainAxisAlignment: MainAxisAlignment.center,
             children: List.generate(
               alphabet.length,
@@ -55,13 +54,16 @@ class _AlphabetListState extends State<AlphabetList> {
                 child: Container(
                   padding:
                       const EdgeInsets.symmetric(horizontal: 10, vertical: 2),
-                  child: Text(
-                    alphabet[x].toUpperCase(),
+                  height: listHeight / alphabet.length,
+                  child: FittedBox(
+                    child: Text(
+                      alphabet[x].toUpperCase(),
+                    ),
                   ),
                 ),
               ),
-            )),
-      ),
+            ));
+      }),
     );
   }
 

--- a/lib/components/MusicScreen/music_screen_drawer.dart
+++ b/lib/components/MusicScreen/music_screen_drawer.dart
@@ -25,114 +25,110 @@ class MusicScreenDrawer extends StatelessWidget {
         contentPadding: const EdgeInsetsDirectional.only(start: 16.0, end: 8.0),
         // Manually handle padding in leading/trailing icons
         horizontalTitleGap: 0,
-        child: Scrollbar(
-          child: CustomScrollView(
-            slivers: [
-              SliverList(
-                delegate: SliverChildListDelegate.fixed(
-                  [
-                    DrawerHeader(
-                        child: Stack(
-                      children: [
-                        Align(
-                          alignment: Alignment.topCenter,
-                          child: Padding(
-                            padding: const EdgeInsets.all(16.0),
-                            child: Image.asset(
-                              'images/finamp_cropped.png',
-                              width: 56,
-                              height: 56,
-                            ),
+        child: CustomScrollView(
+          slivers: [
+            SliverList(
+              delegate: SliverChildListDelegate.fixed(
+                [
+                  DrawerHeader(
+                      child: Stack(
+                    children: [
+                      Align(
+                        alignment: Alignment.topCenter,
+                        child: Padding(
+                          padding: const EdgeInsets.all(16.0),
+                          child: Image.asset(
+                            'images/finamp_cropped.png',
+                            width: 56,
+                            height: 56,
                           ),
                         ),
-                        Align(
-                            alignment: Alignment.bottomCenter -
-                                const Alignment(0, 0.2),
-                            child: Text(
-                              AppLocalizations.of(context)!.finamp,
-                              style: const TextStyle(fontSize: 20),
-                            )),
-                      ],
-                    )),
-                    ListTile(
-                      leading: const Padding(
-                        padding: EdgeInsets.only(right: 16),
-                        child: Icon(Icons.file_download),
                       ),
-                      title: Text(AppLocalizations.of(context)!.downloads),
-                      onTap: () => Navigator.of(context)
-                          .pushNamed(DownloadsScreen.routeName),
+                      Align(
+                          alignment:
+                              Alignment.bottomCenter - const Alignment(0, 0.2),
+                          child: Text(
+                            AppLocalizations.of(context)!.finamp,
+                            style: const TextStyle(fontSize: 20),
+                          )),
+                    ],
+                  )),
+                  ListTile(
+                    leading: const Padding(
+                      padding: EdgeInsets.only(right: 16),
+                      child: Icon(Icons.file_download),
                     ),
-                    ListTile(
-                      leading: const Padding(
-                        padding: EdgeInsets.only(right: 16),
-                        child: Icon(TablerIcons.clock),
-                      ),
-                      title:
-                          Text(AppLocalizations.of(context)!.playbackHistory),
-                      onTap: () => Navigator.of(context)
-                          .pushNamed(PlaybackHistoryScreen.routeName),
+                    title: Text(AppLocalizations.of(context)!.downloads),
+                    onTap: () => Navigator.of(context)
+                        .pushNamed(DownloadsScreen.routeName),
+                  ),
+                  ListTile(
+                    leading: const Padding(
+                      padding: EdgeInsets.only(right: 16),
+                      child: Icon(TablerIcons.clock),
                     ),
-                    const OfflineModeSwitchListTile(),
-                    const Divider(),
-                  ],
-                ),
+                    title: Text(AppLocalizations.of(context)!.playbackHistory),
+                    onTap: () => Navigator.of(context)
+                        .pushNamed(PlaybackHistoryScreen.routeName),
+                  ),
+                  const OfflineModeSwitchListTile(),
+                  const Divider(),
+                ],
               ),
-              // This causes an error when logging out if we show this widget
-              if (finampUserHelper.currentUser != null)
-                SliverList(
-                  delegate: SliverChildBuilderDelegate((context, index) {
-                    return ViewListTile(
-                        view: finampUserHelper.currentUser!.views.values
-                            .elementAt(index));
-                  }, childCount: finampUserHelper.currentUser!.views.length),
-                ),
-              SliverFillRemaining(
-                hasScrollBody: false,
-                child: SafeArea(
-                  bottom: true,
-                  top: false,
-                  child: Align(
-                    alignment: Alignment.bottomCenter,
-                    child: Column(
-                      mainAxisSize: MainAxisSize.min,
-                      children: [
-                        const Divider(),
-                        ListTile(
-                          leading: const Padding(
-                            padding: EdgeInsets.only(right: 16),
-                            child: Icon(Icons.warning),
-                          ),
-                          title: Text(AppLocalizations.of(context)!.logs),
-                          onTap: () => Navigator.of(context)
-                              .pushNamed(LogsScreen.routeName),
+            ),
+            // This causes an error when logging out if we show this widget
+            if (finampUserHelper.currentUser != null)
+              SliverList(
+                delegate: SliverChildBuilderDelegate((context, index) {
+                  return ViewListTile(
+                      view: finampUserHelper.currentUser!.views.values
+                          .elementAt(index));
+                }, childCount: finampUserHelper.currentUser!.views.length),
+              ),
+            SliverFillRemaining(
+              hasScrollBody: false,
+              child: SafeArea(
+                bottom: true,
+                top: false,
+                child: Align(
+                  alignment: Alignment.bottomCenter,
+                  child: Column(
+                    mainAxisSize: MainAxisSize.min,
+                    children: [
+                      const Divider(),
+                      ListTile(
+                        leading: const Padding(
+                          padding: EdgeInsets.only(right: 16),
+                          child: Icon(Icons.warning),
                         ),
-                        ListTile(
-                          leading: const Padding(
-                            padding: EdgeInsets.only(right: 16),
-                            child: Icon(Icons.auto_delete),
-                          ),
-                          title:
-                              Text(AppLocalizations.of(context)!.queuesScreen),
-                          onTap: () => Navigator.of(context)
-                              .pushNamed(QueueRestoreScreen.routeName),
+                        title: Text(AppLocalizations.of(context)!.logs),
+                        onTap: () => Navigator.of(context)
+                            .pushNamed(LogsScreen.routeName),
+                      ),
+                      ListTile(
+                        leading: const Padding(
+                          padding: EdgeInsets.only(right: 16),
+                          child: Icon(Icons.auto_delete),
                         ),
-                        ListTile(
-                          leading: const Padding(
-                            padding: EdgeInsets.only(right: 16),
-                            child: Icon(Icons.settings),
-                          ),
-                          title: Text(AppLocalizations.of(context)!.settings),
-                          onTap: () => Navigator.of(context)
-                              .pushNamed(SettingsScreen.routeName),
+                        title: Text(AppLocalizations.of(context)!.queuesScreen),
+                        onTap: () => Navigator.of(context)
+                            .pushNamed(QueueRestoreScreen.routeName),
+                      ),
+                      ListTile(
+                        leading: const Padding(
+                          padding: EdgeInsets.only(right: 16),
+                          child: Icon(Icons.settings),
                         ),
-                      ],
-                    ),
+                        title: Text(AppLocalizations.of(context)!.settings),
+                        onTap: () => Navigator.of(context)
+                            .pushNamed(SettingsScreen.routeName),
+                      ),
+                    ],
                   ),
                 ),
-              )
-            ],
-          ),
+              ),
+            )
+          ],
         ),
       ),
     );

--- a/lib/components/PlayerScreen/player_split_screen_scaffold.dart
+++ b/lib/components/PlayerScreen/player_split_screen_scaffold.dart
@@ -21,7 +21,9 @@ SplitViewController _controller =
 
 Widget buildPlayerSplitScreenScaffold(BuildContext context, Widget? widget) {
   return LayoutBuilder(builder: (context, constraints) {
-    if (constraints.maxWidth < 900) {
+    // Only use split screen if wide enough to easily show both views and tall enough
+    // that a landscape full-screen player is not preferred instead
+    if (constraints.maxWidth < 800 || constraints.maxHeight < 500) {
       _inSplitScreen = false;
       return widget!;
     }

--- a/lib/components/PlayerScreen/player_split_screen_scaffold.dart
+++ b/lib/components/PlayerScreen/player_split_screen_scaffold.dart
@@ -45,12 +45,17 @@ Widget buildPlayerSplitScreenScaffold(BuildContext context, Widget? widget) {
                         child: child!),
                     child: widget,
                   ),
-                  MediaQuery(
-                    data: MediaQuery.of(context).copyWith(
-                        size: Size(
-                            size.width *
-                                (1.0 - (_controller.weights[0] ?? 1.0)),
-                            size.height)),
+                  ListenableBuilder(
+                    listenable: _controller,
+                    builder: (context, child) {
+                      return MediaQuery(
+                          data: MediaQuery.of(context).copyWith(
+                              size: Size(
+                                  size.width *
+                                      (1.0 - (_controller.weights[0] ?? 1.0)),
+                                  size.height)),
+                          child: child!);
+                    },
                     child: HeroControllerScope(
                         controller: HeroController(),
                         child: Navigator(

--- a/lib/components/PlayerScreen/player_split_screen_scaffold.dart
+++ b/lib/components/PlayerScreen/player_split_screen_scaffold.dart
@@ -55,17 +55,12 @@ Widget buildPlayerSplitScreenScaffold(BuildContext context, Widget? widget) {
                   allowSplitScreen) {
                 _inSplitScreen = true;
                 var size = MediaQuery.sizeOf(context);
+                var padding = MediaQuery.paddingOf(context);
                 return SplitView(
+                    resizingAreaSize: 20,
+                    gripSize: 0,
                     viewMode: SplitViewMode.Horizontal,
                     controller: _controller,
-                    gripColorActive: color.withOpacity(0.75),
-                    gripColor: Color.alphaBlend(
-                        Theme.of(context).brightness == Brightness.dark
-                            ? color.withOpacity(0.35)
-                            : color.withOpacity(0.5),
-                        Theme.of(context).brightness == Brightness.dark
-                            ? Colors.black
-                            : Colors.white),
                     onWeightChanged: (weights) {
                       var box = Hive.box<FinampSettings>("FinampSettings");
                       FinampSettings finampSettingsTemp =
@@ -81,7 +76,9 @@ Widget buildPlayerSplitScreenScaffold(BuildContext context, Widget? widget) {
                                 size: Size(
                                     size.width *
                                         (_controller.weights[0] ?? 1.0),
-                                    size.height)),
+                                    size.height),
+                                padding: padding.copyWith(
+                                    right: padding.right + 10)),
                             child: child!),
                         child: widget,
                       ),

--- a/lib/components/PlayerScreen/player_split_screen_scaffold.dart
+++ b/lib/components/PlayerScreen/player_split_screen_scaffold.dart
@@ -1,0 +1,76 @@
+import 'package:finamp/components/global_snackbar.dart';
+import 'package:flutter/material.dart';
+import 'package:get_it/get_it.dart';
+import 'package:split_view/split_view.dart';
+
+import '../../models/finamp_models.dart';
+import '../../screens/player_screen.dart';
+import '../../services/queue_service.dart';
+
+bool _inSplitScreen = false;
+
+bool get usingPlayerSplitScreen => _inSplitScreen;
+
+SplitViewController _controller = SplitViewController(
+    weights: [0.7], limits: [WeightLimit(min: 0.3, max: 0.8)]);
+
+Widget buildPlayerSplitScreenScaffold(BuildContext context, Widget? widget) {
+  return LayoutBuilder(builder: (context, constraints) {
+    if (constraints.maxWidth < 900) {
+      _inSplitScreen = false;
+      return widget!;
+    }
+    final queueService = GetIt.instance<QueueService>();
+    return StreamBuilder<FinampQueueInfo?>(
+        stream: queueService.getQueueStream(),
+        initialData: queueService.getQueue(),
+        builder: (context, snapshot) {
+          if (snapshot.hasData &&
+              snapshot.data!.saveState != SavedQueueState.loading &&
+              snapshot.data!.saveState != SavedQueueState.failed &&
+              snapshot.data!.currentTrack != null) {
+            _inSplitScreen = true;
+            var size = MediaQuery.sizeOf(context);
+            return SplitView(
+                viewMode: SplitViewMode.Horizontal,
+                controller: _controller,
+                children: [
+                  ListenableBuilder(
+                    listenable: _controller,
+                    builder: (context, child) => MediaQuery(
+                        data: MediaQuery.of(context).copyWith(
+                            size: Size(
+                                size.width * (_controller.weights[0] ?? 1.0),
+                                size.height)),
+                        child: child!),
+                    child: widget,
+                  ),
+                  HeroControllerScope(
+                      controller: HeroController(),
+                      child: Navigator(
+                          pages: const [MaterialPage(child: PlayerScreen())],
+                          onPopPage: (_, __) => false,
+                          onGenerateRoute: (x) {
+                            GlobalSnackbar.materialAppNavigatorKey.currentState!
+                                .pushNamed(x.name!, arguments: x.arguments);
+                            return EmptyRoute();
+                          }))
+                ]);
+          } else {
+            _inSplitScreen = false;
+            return widget!;
+          }
+        });
+  });
+}
+
+class EmptyRoute extends Route {
+  @override
+  List<OverlayEntry> get overlayEntries =>
+      [OverlayEntry(builder: (_) => SizedBox.shrink())];
+  @override
+  void didAdd() {
+    super.didAdd();
+    navigator?.pop();
+  }
+}

--- a/lib/components/PlayerScreen/player_split_screen_scaffold.dart
+++ b/lib/components/PlayerScreen/player_split_screen_scaffold.dart
@@ -44,7 +44,7 @@ Widget buildPlayerSplitScreenScaffold(BuildContext context, Widget? widget) {
         bool allowSplitScreen = ref.watch(FinampSettingsHelper
                 .finampSettingsProvider
                 .select((value) => value.value?.allowSplitScreen)) ??
-            true;
+            FinampSettingsHelper.finampSettings.allowSplitScreen;
 
         return StreamBuilder<FinampQueueInfo?>(
             stream: queueService.getQueueStream(),

--- a/lib/components/PlayerScreen/player_split_screen_scaffold.dart
+++ b/lib/components/PlayerScreen/player_split_screen_scaffold.dart
@@ -46,11 +46,6 @@ Widget buildPlayerSplitScreenScaffold(BuildContext context, Widget? widget) {
                 .select((value) => value.value?.allowSplitScreen)) ??
             true;
 
-        WidgetsBinding.instance.addPostFrameCallback((_) {
-          GlobalSnackbar.materialAppNavigatorKey.currentState?.popUntil(
-              (x) => !ModalRoute.withName(PlayerScreen.routeName)(x));
-        });
-
         return StreamBuilder<FinampQueueInfo?>(
             stream: queueService.getQueueStream(),
             initialData: queueService.getQueue(),
@@ -61,6 +56,10 @@ Widget buildPlayerSplitScreenScaffold(BuildContext context, Widget? widget) {
                       snapshot.data!.currentTrack != null) &&
                   allowSplitScreen) {
                 _inSplitScreen = true;
+                WidgetsBinding.instance.addPostFrameCallback((_) {
+                  GlobalSnackbar.materialAppNavigatorKey.currentState?.popUntil(
+                      (x) => !ModalRoute.withName(PlayerScreen.routeName)(x));
+                });
                 var size = MediaQuery.sizeOf(context);
                 var padding = MediaQuery.paddingOf(context);
                 // When resizing window, update weights to keep player width consistent

--- a/lib/components/PlayerScreen/player_split_screen_scaffold.dart
+++ b/lib/components/PlayerScreen/player_split_screen_scaffold.dart
@@ -38,6 +38,12 @@ Widget buildPlayerSplitScreenScaffold(BuildContext context, Widget? widget) {
         Color color = ref
             .watch(playerScreenThemeProvider(Theme.of(context).brightness))
             .primary;
+
+        WidgetsBinding.instance.addPostFrameCallback((_) {
+          GlobalSnackbar.materialAppNavigatorKey.currentState?.popUntil(
+              (x) => !ModalRoute.withName(PlayerScreen.routeName)(x));
+        });
+
         return StreamBuilder<FinampQueueInfo?>(
             stream: queueService.getQueueStream(),
             initialData: queueService.getQueue(),
@@ -93,18 +99,20 @@ Widget buildPlayerSplitScreenScaffold(BuildContext context, Widget? widget) {
                         },
                         child: HeroControllerScope(
                             controller: HeroController(),
-                            child: Navigator(
-                                pages: const [
-                                  MaterialPage(child: PlayerScreen())
-                                ],
-                                onPopPage: (_, __) => false,
-                                onGenerateRoute: (x) {
-                                  GlobalSnackbar
-                                      .materialAppNavigatorKey.currentState!
-                                      .pushNamed(x.name!,
-                                          arguments: x.arguments);
-                                  return EmptyRoute();
-                                })),
+                            child: ScaffoldMessenger(
+                              child: Navigator(
+                                  pages: const [
+                                    MaterialPage(child: PlayerScreen())
+                                  ],
+                                  onPopPage: (_, __) => false,
+                                  onGenerateRoute: (x) {
+                                    GlobalSnackbar
+                                        .materialAppNavigatorKey.currentState!
+                                        .pushNamed(x.name!,
+                                            arguments: x.arguments);
+                                    return EmptyRoute();
+                                  }),
+                            )),
                       )
                     ]);
               } else {

--- a/lib/components/PlayerScreen/player_split_screen_scaffold.dart
+++ b/lib/components/PlayerScreen/player_split_screen_scaffold.dart
@@ -45,16 +45,24 @@ Widget buildPlayerSplitScreenScaffold(BuildContext context, Widget? widget) {
                         child: child!),
                     child: widget,
                   ),
-                  HeroControllerScope(
-                      controller: HeroController(),
-                      child: Navigator(
-                          pages: const [MaterialPage(child: PlayerScreen())],
-                          onPopPage: (_, __) => false,
-                          onGenerateRoute: (x) {
-                            GlobalSnackbar.materialAppNavigatorKey.currentState!
-                                .pushNamed(x.name!, arguments: x.arguments);
-                            return EmptyRoute();
-                          }))
+                  MediaQuery(
+                    data: MediaQuery.of(context).copyWith(
+                        size: Size(
+                            size.width *
+                                (1.0 - (_controller.weights[0] ?? 1.0)),
+                            size.height)),
+                    child: HeroControllerScope(
+                        controller: HeroController(),
+                        child: Navigator(
+                            pages: const [MaterialPage(child: PlayerScreen())],
+                            onPopPage: (_, __) => false,
+                            onGenerateRoute: (x) {
+                              GlobalSnackbar
+                                  .materialAppNavigatorKey.currentState!
+                                  .pushNamed(x.name!, arguments: x.arguments);
+                              return EmptyRoute();
+                            })),
+                  )
                 ]);
           } else {
             _inSplitScreen = false;

--- a/lib/components/album_image.dart
+++ b/lib/components/album_image.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_blurhash/flutter_blurhash.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:octo_image/octo_image.dart';
 
@@ -13,23 +14,19 @@ typedef ImageProviderCallback = void Function(ImageProvider? imageProvider);
 /// through [AlbumImageProvider.init].
 class AlbumImage extends ConsumerWidget {
   const AlbumImage({
-    Key? key,
+    super.key,
     this.item,
     this.imageListenable,
-    this.imageProviderCallback,
     this.borderRadius,
     this.placeholderBuilder,
     this.disabled = false,
     this.autoScale = true,
-  }) : super(key: key);
+  });
 
   /// The item to get an image for.
   final BaseItemDto? item;
 
-  final ProviderListenable<AsyncValue<ImageProvider?>>? imageListenable;
-
-  /// A callback to get the image provider once it has been fetched.
-  final ImageProviderCallback? imageProviderCallback;
+  final ProviderListenable<ImageProvider?>? imageListenable;
 
   final BorderRadius? borderRadius;
 
@@ -48,10 +45,6 @@ class AlbumImage extends ConsumerWidget {
 
     assert(item == null || imageListenable == null);
     if ((item == null || item!.imageId == null) && imageListenable == null) {
-      if (imageProviderCallback != null) {
-        imageProviderCallback!(null);
-      }
-
       return ClipRRect(
         borderRadius: borderRadius,
         child: const AspectRatio(
@@ -88,9 +81,12 @@ class AlbumImage extends ConsumerWidget {
                   maxWidth: physicalWidth,
                   maxHeight: physicalHeight,
                 )),
-            imageProviderCallback: imageProviderCallback,
-            placeholderBuilder:
-                placeholderBuilder ?? BareAlbumImage.defaultPlaceholderBuilder,
+            placeholderBuilder: placeholderBuilder ??
+                (item?.blurHash != null
+                    ? (_) => BlurHash(
+                          hash: item!.blurHash!,
+                        )
+                    : BareAlbumImage.defaultPlaceholderBuilder),
           );
           return disabled
               ? Opacity(
@@ -111,15 +107,13 @@ class BareAlbumImage extends ConsumerWidget {
   const BareAlbumImage({
     Key? key,
     required this.imageListenable,
-    this.imageProviderCallback,
     this.errorBuilder = defaultErrorBuilder,
     this.placeholderBuilder = defaultPlaceholderBuilder,
   }) : super(key: key);
 
-  final ProviderListenable<AsyncValue<ImageProvider?>> imageListenable;
+  final ProviderListenable<ImageProvider?> imageListenable;
   final WidgetBuilder placeholderBuilder;
   final OctoErrorBuilder errorBuilder;
-  final ImageProviderCallback? imageProviderCallback;
 
   static Widget defaultPlaceholderBuilder(BuildContext context) {
     return Container(color: Theme.of(context).cardColor);
@@ -131,29 +125,17 @@ class BareAlbumImage extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    AsyncValue<ImageProvider?> image = ref.watch(imageListenable);
+    ImageProvider? image = ref.watch(imageListenable);
 
-    if (image.hasValue && image.value != null) {
-      if (imageProviderCallback != null) {
-        imageProviderCallback!(image.value);
-      }
+    if (image != null) {
       return OctoImage(
-        image: image.value!,
+        image: image,
+        fadeOutDuration: const Duration(milliseconds: 400),
+        fadeInDuration: const Duration(milliseconds: 200),
         fit: BoxFit.contain,
         placeholderBuilder: placeholderBuilder,
         errorBuilder: errorBuilder,
       );
-    }
-
-    if (image.hasError) {
-      if (imageProviderCallback != null) {
-        imageProviderCallback!(null);
-      }
-      return const _AlbumImageErrorPlaceholder();
-    }
-
-    if (imageProviderCallback != null) {
-      imageProviderCallback!(null);
     }
 
     return Builder(builder: placeholderBuilder);

--- a/lib/components/album_image.dart
+++ b/lib/components/album_image.dart
@@ -130,8 +130,8 @@ class BareAlbumImage extends ConsumerWidget {
     if (image != null) {
       return OctoImage(
         image: image,
-        fadeOutDuration: const Duration(milliseconds: 400),
-        fadeInDuration: const Duration(milliseconds: 200),
+        fadeOutDuration: const Duration(milliseconds: 0),
+        fadeInDuration: const Duration(milliseconds: 0),
         fit: BoxFit.contain,
         placeholderBuilder: placeholderBuilder,
         errorBuilder: errorBuilder,

--- a/lib/components/album_image.dart
+++ b/lib/components/album_image.dart
@@ -1,3 +1,9 @@
+import 'dart:io';
+import 'dart:math';
+
+import 'package:finamp/components/PlayerScreen/player_split_screen_scaffold.dart';
+import 'package:finamp/models/finamp_models.dart';
+import 'package:finamp/services/finamp_settings_helper.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_blurhash/flutter_blurhash.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
@@ -72,6 +78,17 @@ class AlbumImage extends ConsumerWidget {
                 (constraints.maxWidth * mediaQuery.devicePixelRatio).toInt();
             physicalHeight =
                 (constraints.maxHeight * mediaQuery.devicePixelRatio).toInt();
+            // If using grid music screen view without fixed size tiles, and if the view is resizable due
+            // to being on desktop and using split screen, then clamp album size to reduce server requests when resizing.
+            if ((!(Platform.isIOS || Platform.isAndroid) ||
+                    usingPlayerSplitScreen) &&
+                !FinampSettingsHelper.finampSettings.useFixedSizeGridTiles &&
+                FinampSettingsHelper.finampSettings.contentViewType ==
+                    ContentViewType.grid) {
+              physicalWidth = exp((log(physicalWidth) * 3).ceil() / 3).toInt();
+              physicalHeight =
+                  exp((log(physicalHeight) * 3).ceil() / 3).toInt();
+            }
           }
 
           var image = BareAlbumImage(

--- a/lib/components/now_playing_bar.dart
+++ b/lib/components/now_playing_bar.dart
@@ -1,3 +1,5 @@
+import 'dart:math';
+
 import 'package:audio_service/audio_service.dart';
 import 'package:finamp/color_schemes.g.dart';
 import 'package:finamp/components/favourite_button.dart';
@@ -19,6 +21,7 @@ import '../services/finamp_settings_helper.dart';
 import '../services/media_state_stream.dart';
 import '../services/music_player_background_task.dart';
 import '../services/process_artist.dart';
+import 'PlayerScreen/player_split_screen_scaffold.dart';
 import 'album_image.dart';
 
 class NowPlayingBar extends ConsumerWidget {
@@ -260,12 +263,14 @@ class NowPlayingBar extends ConsumerWidget {
                                                 width: (screenSize.width -
                                                         2 * horizontalPadding -
                                                         albumImageSize) *
-                                                    (playbackPosition!
-                                                            .inMilliseconds /
+                                                    (max(
+                                                            playbackPosition!
+                                                                .inMilliseconds,
+                                                            0) /
                                                         (mediaState.mediaItem
                                                                     ?.duration ??
                                                                 const Duration(
-                                                                    seconds: 0))
+                                                                    seconds: 1))
                                                             .inMilliseconds),
                                                 height: 70.0,
                                                 decoration: ShapeDecoration(
@@ -506,7 +511,8 @@ class NowPlayingBar extends ConsumerWidget {
                   return buildLoadingQueueBar(
                       context, queueService.retryQueueLoad);
                 } else if (snapshot.hasData &&
-                    snapshot.data!.currentTrack != null) {
+                    snapshot.data!.currentTrack != null &&
+                    !usingPlayerSplitScreen) {
                   return buildNowPlayingBar(
                       context, snapshot.data!.currentTrack!);
                 } else {

--- a/lib/components/now_playing_bar.dart
+++ b/lib/components/now_playing_bar.dart
@@ -504,10 +504,12 @@ class NowPlayingBar extends ConsumerWidget {
               initialData: queueService.getQueue(),
               builder: (context, snapshot) {
                 if (snapshot.hasData &&
-                    snapshot.data!.saveState == SavedQueueState.loading) {
+                    snapshot.data!.saveState == SavedQueueState.loading &&
+                    !usingPlayerSplitScreen) {
                   return buildLoadingQueueBar(context, null);
                 } else if (snapshot.hasData &&
-                    snapshot.data!.saveState == SavedQueueState.failed) {
+                    snapshot.data!.saveState == SavedQueueState.failed &&
+                    !usingPlayerSplitScreen) {
                   return buildLoadingQueueBar(
                       context, queueService.retryQueueLoad);
                 } else if (snapshot.hasData &&

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -1252,5 +1252,9 @@
   "redownloadSubtitle": "Automatically redownload songs which are expected to be at a different quality due to parent collection changes.",
   "@redownloadSubtitle": {
     "description": "subtitle for download transcode setting which redownloads songs with higher allowed qualities"
+  },
+  "defaultDownloadLocationButton": "Set as default download location.  Disable to select per download.",
+  "@defaultDownloadLocationButton": {
+    "description": "Tooltip for button that sets a download location as the default."
   }
 }

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -1268,5 +1268,7 @@
       }
     },
     "description": "Localized names of fixed size grid tile sizes."
-  }
+  },
+  "allowSplitScreenTitle": "Allow SplitScreen Mode",
+  "allowSplitScreenSubtitle": "The player will be displayed alongside other views on wider displays."
 }

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -1256,5 +1256,17 @@
   "defaultDownloadLocationButton": "Set as default download location.  Disable to select per download.",
   "@defaultDownloadLocationButton": {
     "description": "Tooltip for button that sets a download location as the default."
+  },
+  "fixedGridSizeSwitchTitle": "Use fixed size grid tiles",
+  "fixedGridSizeSwitchSubtitle": "Grid tile sizes will not respond to window/screen size.",
+  "fixedGridSizeTitle": "Grid Tile Size",
+  "fixedGridTileSizeEnum": "{size, select, small{Small} medium{Medium} large{Large} veryLarge{Very Large} other{???}}",
+  "@fixedGridTileSizeEnum": {
+    "placeholders": {
+      "size": {
+        "type": "String"
+      }
+    },
+    "description": "Localized names of fixed size grid tile sizes."
   }
 }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -32,6 +32,7 @@ import 'package:uuid/uuid.dart';
 
 import 'components/LogsScreen/copy_logs_button.dart';
 import 'components/LogsScreen/share_logs_button.dart';
+import 'components/PlayerScreen/player_split_screen_scaffold.dart';
 import 'components/global_snackbar.dart';
 import 'models/finamp_models.dart';
 import 'models/jellyfin_models.dart';
@@ -377,6 +378,7 @@ class Finamp extends StatelessWidget {
                         const LanguageSelectionScreen(),
                   },
                   initialRoute: SplashScreen.routeName,
+                  builder: buildPlayerSplitScreenScaffold,
                   theme: ThemeData(
                     brightness: Brightness.light,
                     colorScheme: lightColorScheme,

--- a/lib/models/finamp_models.dart
+++ b/lib/models/finamp_models.dart
@@ -149,7 +149,7 @@ class FinampSettings {
     this.useFixedSizeGridTiles = false,
     this.fixedGridTileSize = _fixedGridTileSizeDefault,
     this.allowSplitScreen = true,
-    this.splitScreenWeight = _defaultSplitScreenWeight,
+    this.splitScreenPlayerWidth = _defaultSplitScreenWeight,
   });
 
   @HiveField(0, defaultValue: _isOfflineDefault)
@@ -321,7 +321,7 @@ class FinampSettings {
   bool allowSplitScreen;
 
   @HiveField(51, defaultValue: _defaultSplitScreenWeight)
-  double splitScreenWeight;
+  double splitScreenPlayerWidth;
 
   static Future<FinampSettings> create() async {
     final downloadLocation = await DownloadLocation.create(

--- a/lib/models/finamp_models.dart
+++ b/lib/models/finamp_models.dart
@@ -89,6 +89,7 @@ const _autoLoadLastQueueOnStartup = true;
 const _shouldTranscodeDownloadsDefault = TranscodeDownloadsSetting.never;
 const _shouldRedownloadTranscodesDefault = false;
 const _defaultResyncOnStartup = true;
+const _fixedGridTileSizeDefault = 150;
 
 @HiveType(typeId: 28)
 class FinampSettings {
@@ -144,6 +145,8 @@ class FinampSettings {
     this.shouldTranscodeDownloads = _shouldTranscodeDownloadsDefault,
     this.shouldRedownloadTranscodes = _shouldRedownloadTranscodesDefault,
     this.swipeInsertQueueNext = _swipeInsertQueueNext,
+    this.useFixedSizeGridTiles = false,
+    this.fixedGridTileSize = _fixedGridTileSizeDefault,
   });
 
   @HiveField(0, defaultValue: _isOfflineDefault)
@@ -305,6 +308,12 @@ class FinampSettings {
   @HiveField(47, defaultValue: null)
   String? defaultDownloadLocation;
 
+  @HiveField(48, defaultValue: false)
+  bool useFixedSizeGridTiles;
+
+  @HiveField(49, defaultValue: _fixedGridTileSizeDefault)
+  int fixedGridTileSize;
+
   static Future<FinampSettings> create() async {
     final downloadLocation = await DownloadLocation.create(
       name: "Internal Storage",
@@ -324,6 +333,7 @@ class FinampSettings {
       downloadLocationsMap: {downloadLocation.id: downloadLocation},
       tabSortBy: {},
       tabSortOrder: {},
+      useFixedSizeGridTiles: !(Platform.isIOS || Platform.isAndroid),
     );
   }
 

--- a/lib/models/finamp_models.dart
+++ b/lib/models/finamp_models.dart
@@ -90,6 +90,7 @@ const _shouldTranscodeDownloadsDefault = TranscodeDownloadsSetting.never;
 const _shouldRedownloadTranscodesDefault = false;
 const _defaultResyncOnStartup = true;
 const _fixedGridTileSizeDefault = 150;
+const _defaultSplitScreenWeight = 0.5;
 
 @HiveType(typeId: 28)
 class FinampSettings {
@@ -147,6 +148,8 @@ class FinampSettings {
     this.swipeInsertQueueNext = _swipeInsertQueueNext,
     this.useFixedSizeGridTiles = false,
     this.fixedGridTileSize = _fixedGridTileSizeDefault,
+    this.allowSplitScreen = true,
+    this.splitScreenWeight = _defaultSplitScreenWeight,
   });
 
   @HiveField(0, defaultValue: _isOfflineDefault)
@@ -313,6 +316,12 @@ class FinampSettings {
 
   @HiveField(49, defaultValue: _fixedGridTileSizeDefault)
   int fixedGridTileSize;
+
+  @HiveField(50, defaultValue: true)
+  bool allowSplitScreen;
+
+  @HiveField(51, defaultValue: _defaultSplitScreenWeight)
+  double splitScreenWeight;
 
   static Future<FinampSettings> create() async {
     final downloadLocation = await DownloadLocation.create(

--- a/lib/models/finamp_models.dart
+++ b/lib/models/finamp_models.dart
@@ -90,7 +90,7 @@ const _shouldTranscodeDownloadsDefault = TranscodeDownloadsSetting.never;
 const _shouldRedownloadTranscodesDefault = false;
 const _defaultResyncOnStartup = true;
 const _fixedGridTileSizeDefault = 150;
-const _defaultSplitScreenWeight = 0.5;
+const _defaultSplitScreenPlayerWidth = 400.0;
 
 @HiveType(typeId: 28)
 class FinampSettings {
@@ -149,7 +149,7 @@ class FinampSettings {
     this.useFixedSizeGridTiles = false,
     this.fixedGridTileSize = _fixedGridTileSizeDefault,
     this.allowSplitScreen = true,
-    this.splitScreenPlayerWidth = _defaultSplitScreenWeight,
+    this.splitScreenPlayerWidth = _defaultSplitScreenPlayerWidth,
   });
 
   @HiveField(0, defaultValue: _isOfflineDefault)
@@ -320,7 +320,7 @@ class FinampSettings {
   @HiveField(50, defaultValue: true)
   bool allowSplitScreen;
 
-  @HiveField(51, defaultValue: _defaultSplitScreenWeight)
+  @HiveField(51, defaultValue: _defaultSplitScreenPlayerWidth)
   double splitScreenPlayerWidth;
 
   static Future<FinampSettings> create() async {

--- a/lib/models/finamp_models.g.dart
+++ b/lib/models/finamp_models.g.dart
@@ -146,6 +146,8 @@ class FinampSettingsAdapter extends TypeAdapter<FinampSettings> {
       shouldRedownloadTranscodes:
           fields[46] == null ? false : fields[46] as bool,
       swipeInsertQueueNext: fields[26] == null ? true : fields[26] as bool,
+      useFixedSizeGridTiles: fields[48] == null ? false : fields[48] as bool,
+      fixedGridTileSize: fields[49] == null ? 150 : fields[49] as int,
     )
       ..disableGesture = fields[19] == null ? false : fields[19] as bool
       ..showFastScroller = fields[25] == null ? true : fields[25] as bool
@@ -155,7 +157,7 @@ class FinampSettingsAdapter extends TypeAdapter<FinampSettings> {
   @override
   void write(BinaryWriter writer, FinampSettings obj) {
     writer
-      ..writeByte(48)
+      ..writeByte(50)
       ..writeByte(0)
       ..write(obj.isOffline)
       ..writeByte(1)
@@ -251,7 +253,11 @@ class FinampSettingsAdapter extends TypeAdapter<FinampSettings> {
       ..writeByte(46)
       ..write(obj.shouldRedownloadTranscodes)
       ..writeByte(47)
-      ..write(obj.defaultDownloadLocation);
+      ..write(obj.defaultDownloadLocation)
+      ..writeByte(48)
+      ..write(obj.useFixedSizeGridTiles)
+      ..writeByte(49)
+      ..write(obj.fixedGridTileSize);
   }
 
   @override

--- a/lib/models/finamp_models.g.dart
+++ b/lib/models/finamp_models.g.dart
@@ -148,6 +148,8 @@ class FinampSettingsAdapter extends TypeAdapter<FinampSettings> {
       swipeInsertQueueNext: fields[26] == null ? true : fields[26] as bool,
       useFixedSizeGridTiles: fields[48] == null ? false : fields[48] as bool,
       fixedGridTileSize: fields[49] == null ? 150 : fields[49] as int,
+      allowSplitScreen: fields[50] == null ? true : fields[50] as bool,
+      splitScreenWeight: fields[51] == null ? 0.5 : fields[51] as double,
     )
       ..disableGesture = fields[19] == null ? false : fields[19] as bool
       ..showFastScroller = fields[25] == null ? true : fields[25] as bool
@@ -157,7 +159,7 @@ class FinampSettingsAdapter extends TypeAdapter<FinampSettings> {
   @override
   void write(BinaryWriter writer, FinampSettings obj) {
     writer
-      ..writeByte(50)
+      ..writeByte(52)
       ..writeByte(0)
       ..write(obj.isOffline)
       ..writeByte(1)
@@ -257,7 +259,11 @@ class FinampSettingsAdapter extends TypeAdapter<FinampSettings> {
       ..writeByte(48)
       ..write(obj.useFixedSizeGridTiles)
       ..writeByte(49)
-      ..write(obj.fixedGridTileSize);
+      ..write(obj.fixedGridTileSize)
+      ..writeByte(50)
+      ..write(obj.allowSplitScreen)
+      ..writeByte(51)
+      ..write(obj.splitScreenWeight);
   }
 
   @override

--- a/lib/models/finamp_models.g.dart
+++ b/lib/models/finamp_models.g.dart
@@ -148,13 +148,14 @@ class FinampSettingsAdapter extends TypeAdapter<FinampSettings> {
       swipeInsertQueueNext: fields[26] == null ? true : fields[26] as bool,
     )
       ..disableGesture = fields[19] == null ? false : fields[19] as bool
-      ..showFastScroller = fields[25] == null ? true : fields[25] as bool;
+      ..showFastScroller = fields[25] == null ? true : fields[25] as bool
+      ..defaultDownloadLocation = fields[47] as String?;
   }
 
   @override
   void write(BinaryWriter writer, FinampSettings obj) {
     writer
-      ..writeByte(47)
+      ..writeByte(48)
       ..writeByte(0)
       ..write(obj.isOffline)
       ..writeByte(1)
@@ -248,7 +249,9 @@ class FinampSettingsAdapter extends TypeAdapter<FinampSettings> {
       ..writeByte(45)
       ..write(obj.downloadTranscodeBitrate)
       ..writeByte(46)
-      ..write(obj.shouldRedownloadTranscodes);
+      ..write(obj.shouldRedownloadTranscodes)
+      ..writeByte(47)
+      ..write(obj.defaultDownloadLocation);
   }
 
   @override
@@ -1363,6 +1366,8 @@ class DownloadLocationTypeAdapter extends TypeAdapter<DownloadLocationType> {
         return DownloadLocationType.none;
       case 5:
         return DownloadLocationType.migrated;
+      case 6:
+        return DownloadLocationType.cache;
       default:
         return DownloadLocationType.internalDocuments;
     }
@@ -1388,6 +1393,9 @@ class DownloadLocationTypeAdapter extends TypeAdapter<DownloadLocationType> {
         break;
       case DownloadLocationType.migrated:
         writer.writeByte(5);
+        break;
+      case DownloadLocationType.cache:
+        writer.writeByte(6);
         break;
     }
   }

--- a/lib/models/finamp_models.g.dart
+++ b/lib/models/finamp_models.g.dart
@@ -149,7 +149,7 @@ class FinampSettingsAdapter extends TypeAdapter<FinampSettings> {
       useFixedSizeGridTiles: fields[48] == null ? false : fields[48] as bool,
       fixedGridTileSize: fields[49] == null ? 150 : fields[49] as int,
       allowSplitScreen: fields[50] == null ? true : fields[50] as bool,
-      splitScreenWeight: fields[51] == null ? 0.5 : fields[51] as double,
+      splitScreenPlayerWidth: fields[51] == null ? 0.5 : fields[51] as double,
     )
       ..disableGesture = fields[19] == null ? false : fields[19] as bool
       ..showFastScroller = fields[25] == null ? true : fields[25] as bool
@@ -263,7 +263,7 @@ class FinampSettingsAdapter extends TypeAdapter<FinampSettings> {
       ..writeByte(50)
       ..write(obj.allowSplitScreen)
       ..writeByte(51)
-      ..write(obj.splitScreenWeight);
+      ..write(obj.splitScreenPlayerWidth);
   }
 
   @override

--- a/lib/screens/blurred_player_screen_background.dart
+++ b/lib/screens/blurred_player_screen_background.dart
@@ -22,47 +22,51 @@ class BlurredPlayerScreenBackground extends ConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final imageProvider =
-        customImageProvider ?? ref.watch(currentAlbumImageProvider).value;
+        customImageProvider ?? ref.watch(currentAlbumImageProvider);
 
-    return ColorFiltered(
-      // Force total opacity to always be 100%
-      colorFilter: const ColorFilter.matrix(<double>[
-        1, 0, 0, 0, 0, // R
-        0, 1, 0, 0, 0, // G
-        0, 0, 1, 0, 0, // B
-        0, 0, 0, 2, 0, // A
-      ]),
-      child: AnimatedSwitcher(
-          duration: const Duration(milliseconds: 1000),
-          child: ClipRect(
-            // Don't transition between images with identical files/urls
-            key: ValueKey(imageProvider.toString()),
-            child: imageProvider == null
-                ? const SizedBox.shrink()
-                : OctoImage(
-                    image: imageProvider,
-                    fit: BoxFit.cover,
-                    placeholderBuilder: (_) => const SizedBox.shrink(),
-                    errorBuilder: (_, __, ___) => const SizedBox.shrink(),
-                    imageBuilder: (context, child) => ColorFiltered(
-                      colorFilter: ColorFilter.mode(
-                          Theme.of(context).brightness == Brightness.dark
-                              ? Colors.black.withOpacity(
-                                  clampDouble(0.675 * opacityFactor, 0.0, 1.0))
-                              : Colors.white.withOpacity(
-                                  clampDouble(0.75 * opacityFactor, 0.0, 1.0)),
-                          BlendMode.srcOver),
-                      child: ImageFiltered(
-                        imageFilter: ImageFilter.blur(
-                          sigmaX: 85,
-                          sigmaY: 85,
-                          tileMode: TileMode.mirror,
+    return Positioned.fill(
+      child: ColorFiltered(
+        // Force total opacity to always be 100%
+        colorFilter: const ColorFilter.matrix(<double>[
+          1, 0, 0, 0, 0, // R
+          0, 1, 0, 0, 0, // G
+          0, 0, 1, 0, 0, // B
+          0, 0, 0, 2, 0, // A
+        ]),
+        child: AnimatedSwitcher(
+            duration: const Duration(milliseconds: 1000),
+            child: ClipRect(
+              // Don't transition between images with identical files/urls
+              key: ValueKey(imageProvider.toString()),
+              child: imageProvider == null
+                  ? const SizedBox.shrink()
+                  : OctoImage(
+                      image: imageProvider,
+                      fit: BoxFit.cover,
+                      fadeInDuration: const Duration(seconds: 0),
+                      fadeOutDuration: const Duration(seconds: 0),
+                      placeholderBuilder: (_) => const SizedBox.shrink(),
+                      errorBuilder: (_, __, ___) => const SizedBox.shrink(),
+                      imageBuilder: (context, child) => ColorFiltered(
+                        colorFilter: ColorFilter.mode(
+                            Theme.of(context).brightness == Brightness.dark
+                                ? Colors.black.withOpacity(clampDouble(
+                                    0.675 * opacityFactor, 0.0, 1.0))
+                                : Colors.white.withOpacity(clampDouble(
+                                    0.75 * opacityFactor, 0.0, 1.0)),
+                            BlendMode.srcOver),
+                        child: ImageFiltered(
+                          imageFilter: ImageFilter.blur(
+                            sigmaX: 85,
+                            sigmaY: 85,
+                            tileMode: TileMode.mirror,
+                          ),
+                          child: SizedBox.expand(child: child),
                         ),
-                        child: SizedBox.expand(child: child),
                       ),
                     ),
-                  ),
-          )),
+            )),
+      ),
     );
   }
 }

--- a/lib/screens/downloads_screen.dart
+++ b/lib/screens/downloads_screen.dart
@@ -23,23 +23,21 @@ class DownloadsScreen extends StatelessWidget {
           DownloadErrorScreenButton()
         ],
       ),
-      body: Scrollbar(
-        child: CustomScrollView(
-          slivers: [
-            SliverList(
-              delegate: SliverChildListDelegate([
-                const Padding(
-                  // We don't have bottom padding here since the divider already provides bottom padding
-                  padding: EdgeInsets.fromLTRB(8, 8, 8, 0),
-                  child: DownloadsOverview(),
-                ),
-                const Divider(),
-              ]),
-            ),
-            const DownloadedItemsList(),
-            // CurrentDownloadsList(),
-          ],
-        ),
+      body: CustomScrollView(
+        slivers: [
+          SliverList(
+            delegate: SliverChildListDelegate([
+              const Padding(
+                // We don't have bottom padding here since the divider already provides bottom padding
+                padding: EdgeInsets.fromLTRB(8, 8, 8, 0),
+                child: DownloadsOverview(),
+              ),
+              const Divider(),
+            ]),
+          ),
+          const DownloadedItemsList(),
+          // CurrentDownloadsList(),
+        ],
       ),
     );
   }

--- a/lib/screens/layout_settings_screen.dart
+++ b/lib/screens/layout_settings_screen.dart
@@ -37,6 +37,7 @@ class LayoutSettingsScreen extends StatelessWidget {
                   const FixedGridTileSizeDropdownListTile(),
                 const ShowTextOnGridViewSelector(),
                 const ShowCoverAsPlayerBackgroundSelector(),
+                const AllowSplitScreenSwitch(),
                 const HideSongArtistsIfSameAsAlbumArtistsSelector(),
                 const ThemeSelector(),
                 const Divider(),
@@ -75,6 +76,35 @@ class FixedSizeGridSwitch extends StatelessWidget {
                   FinampSettings finampSettingsTemp =
                       box.get("FinampSettings")!;
                   finampSettingsTemp.useFixedSizeGridTiles = value;
+                  box.put("FinampSettings", finampSettingsTemp);
+                },
+        );
+      },
+    );
+  }
+}
+
+class AllowSplitScreenSwitch extends StatelessWidget {
+  const AllowSplitScreenSwitch({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return ValueListenableBuilder<Box<FinampSettings>>(
+      valueListenable: FinampSettingsHelper.finampSettingsListener,
+      builder: (context, box, child) {
+        bool? allowSplitScreen = box.get("FinampSettings")?.allowSplitScreen;
+
+        return SwitchListTile.adaptive(
+          title: Text(AppLocalizations.of(context)!.allowSplitScreenTitle),
+          subtitle:
+              Text(AppLocalizations.of(context)!.allowSplitScreenSubtitle),
+          value: allowSplitScreen ?? true,
+          onChanged: allowSplitScreen == null
+              ? null
+              : (value) {
+                  FinampSettings finampSettingsTemp =
+                      box.get("FinampSettings")!;
+                  finampSettingsTemp.allowSplitScreen = value;
                   box.put("FinampSettings", finampSettingsTemp);
                 },
         );

--- a/lib/screens/layout_settings_screen.dart
+++ b/lib/screens/layout_settings_screen.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
+import 'package:hive/hive.dart';
 
 import '../components/LayoutSettingsScreen/content_grid_view_cross_axis_count_list_tile.dart';
 import '../components/LayoutSettingsScreen/content_view_type_dropdown_list_tile.dart';
@@ -7,6 +8,8 @@ import '../components/LayoutSettingsScreen/hide_song_artists_if_same_as_album_ar
 import '../components/LayoutSettingsScreen/show_cover_as_player_background_selector.dart';
 import '../components/LayoutSettingsScreen/show_text_on_grid_view_selector.dart';
 import '../components/LayoutSettingsScreen/theme_selector.dart';
+import '../models/finamp_models.dart';
+import '../services/finamp_settings_helper.dart';
 import 'tabs_settings_screen.dart';
 
 class LayoutSettingsScreen extends StatelessWidget {
@@ -16,28 +19,122 @@ class LayoutSettingsScreen extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return Scaffold(
-      appBar: AppBar(
-        title: Text(AppLocalizations.of(context)!.layoutAndTheme),
-      ),
-      body: ListView(
-        children: [
-          const ContentViewTypeDropdownListTile(),
-          for (final type in ContentGridViewCrossAxisCountType.values)
-            ContentGridViewCrossAxisCountListTile(type: type),
-          const ShowTextOnGridViewSelector(),
-          const ShowCoverAsPlayerBackgroundSelector(),
-          const HideSongArtistsIfSameAsAlbumArtistsSelector(),
-          const ThemeSelector(),
-          const Divider(),
-          ListTile(
-            leading: const Icon(Icons.tab),
-            title: Text(AppLocalizations.of(context)!.tabs),
-            onTap: () =>
-                Navigator.of(context).pushNamed(TabsSettingsScreen.routeName),
-          ),
-        ],
-      ),
+    return ValueListenableBuilder<Box<FinampSettings>>(
+        valueListenable: FinampSettingsHelper.finampSettingsListener,
+        builder: (context, box, child) {
+          return Scaffold(
+            appBar: AppBar(
+              title: Text(AppLocalizations.of(context)!.layoutAndTheme),
+            ),
+            body: ListView(
+              children: [
+                const ContentViewTypeDropdownListTile(),
+                const FixedSizeGridSwitch(),
+                if (!FinampSettingsHelper.finampSettings.useFixedSizeGridTiles)
+                  for (final type in ContentGridViewCrossAxisCountType.values)
+                    ContentGridViewCrossAxisCountListTile(type: type),
+                if (FinampSettingsHelper.finampSettings.useFixedSizeGridTiles)
+                  const FixedGridTileSizeDropdownListTile(),
+                const ShowTextOnGridViewSelector(),
+                const ShowCoverAsPlayerBackgroundSelector(),
+                const HideSongArtistsIfSameAsAlbumArtistsSelector(),
+                const ThemeSelector(),
+                const Divider(),
+                ListTile(
+                  leading: const Icon(Icons.tab),
+                  title: Text(AppLocalizations.of(context)!.tabs),
+                  onTap: () => Navigator.of(context)
+                      .pushNamed(TabsSettingsScreen.routeName),
+                ),
+              ],
+            ),
+          );
+        });
+  }
+}
+
+class FixedSizeGridSwitch extends StatelessWidget {
+  const FixedSizeGridSwitch({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return ValueListenableBuilder<Box<FinampSettings>>(
+      valueListenable: FinampSettingsHelper.finampSettingsListener,
+      builder: (context, box, child) {
+        bool? useFixedSizeGridTiles =
+            box.get("FinampSettings")?.useFixedSizeGridTiles;
+
+        return SwitchListTile.adaptive(
+          title: Text(AppLocalizations.of(context)!.fixedGridSizeSwitchTitle),
+          subtitle:
+              Text(AppLocalizations.of(context)!.fixedGridSizeSwitchSubtitle),
+          value: useFixedSizeGridTiles ?? false,
+          onChanged: useFixedSizeGridTiles == null
+              ? null
+              : (value) {
+                  FinampSettings finampSettingsTemp =
+                      box.get("FinampSettings")!;
+                  finampSettingsTemp.useFixedSizeGridTiles = value;
+                  box.put("FinampSettings", finampSettingsTemp);
+                },
+        );
+      },
     );
   }
+}
+
+class FixedGridTileSizeDropdownListTile extends StatelessWidget {
+  const FixedGridTileSizeDropdownListTile({Key? key}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return ValueListenableBuilder<Box<FinampSettings>>(
+      valueListenable: FinampSettingsHelper.finampSettingsListener,
+      builder: (_, box, __) {
+        return ListTile(
+          title: Text(AppLocalizations.of(context)!.fixedGridSizeTitle),
+          trailing: DropdownButton<FixedGridTileSize>(
+            value: FixedGridTileSize.fromInt(
+                FinampSettingsHelper.finampSettings.fixedGridTileSize),
+            items: FixedGridTileSize.values
+                .map((e) => DropdownMenuItem<FixedGridTileSize>(
+                      value: e,
+                      child: Text(AppLocalizations.of(context)!
+                          .fixedGridTileSizeEnum(e.name)),
+                    ))
+                .toList(),
+            onChanged: (value) {
+              if (value != null) {
+                FinampSettings finampSettingsTemp = box.get("FinampSettings")!;
+                finampSettingsTemp.fixedGridTileSize = value.toInt;
+                box.put("FinampSettings", finampSettingsTemp);
+              }
+            },
+          ),
+        );
+      },
+    );
+  }
+}
+
+enum FixedGridTileSize {
+  small,
+  medium,
+  large,
+  veryLarge;
+
+  static FixedGridTileSize fromInt(int size) => switch (size) {
+        100 => small,
+        150 => medium,
+        230 => large,
+        360 => veryLarge,
+        _ => medium
+      };
+
+  int get toInt => switch (this) {
+        small => 100,
+        medium => 150,
+        large => 230,
+        veryLarge => 360
+      };
 }

--- a/lib/screens/player_screen.dart
+++ b/lib/screens/player_screen.dart
@@ -1,11 +1,15 @@
 import 'dart:io';
+import 'dart:math';
 
+import 'package:balanced_text/balanced_text.dart';
 import 'package:finamp/color_schemes.g.dart';
 import 'package:finamp/components/PlayerScreen/player_screen_appbar_title.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_to_airplay/flutter_to_airplay.dart';
 import 'package:flutter_vibrate/flutter_vibrate.dart';
+import 'package:get_it/get_it.dart';
 import 'package:simple_gesture_detector/simple_gesture_detector.dart';
 
 import '../components/PlayerScreen/control_area.dart';
@@ -14,14 +18,16 @@ import '../components/PlayerScreen/queue_button.dart';
 import '../components/PlayerScreen/queue_list.dart';
 import '../components/PlayerScreen/song_info.dart';
 import '../components/finamp_app_bar_button.dart';
+import '../models/finamp_models.dart';
 import '../services/finamp_settings_helper.dart';
 import '../services/player_screen_theme_provider.dart';
+import '../services/queue_service.dart';
 import 'blurred_player_screen_background.dart';
 
 const _toolbarHeight = 52.0;
 
 class PlayerScreen extends ConsumerWidget {
-  const PlayerScreen({Key? key}) : super(key: key);
+  const PlayerScreen({super.key});
 
   static const routeName = "/nowplaying";
 
@@ -29,9 +35,10 @@ class PlayerScreen extends ConsumerWidget {
   Widget build(BuildContext context, WidgetRef ref) {
     final imageTheme =
         ref.watch(playerScreenThemeProvider(Theme.of(context).brightness));
+    final queueService = GetIt.instance<QueueService>();
 
     return AnimatedTheme(
-      duration: const Duration(milliseconds: 500),
+      duration: const Duration(milliseconds: 1000),
       data: ThemeData(
         colorScheme: imageTheme.copyWith(
           brightness: Theme.of(context).brightness,
@@ -40,9 +47,76 @@ class PlayerScreen extends ConsumerWidget {
               color: imageTheme.primary,
             ),
       ),
-      child: const _PlayerScreenContent(),
+      child: StreamBuilder<FinampQueueInfo?>(
+          stream: queueService.getQueueStream(),
+          initialData: queueService.getQueue(),
+          builder: (context, snapshot) {
+            if (snapshot.hasData &&
+                snapshot.data!.saveState == SavedQueueState.loading) {
+              return buildLoadingScreen(context, null);
+            } else if (snapshot.hasData &&
+                snapshot.data!.saveState == SavedQueueState.failed) {
+              return buildLoadingScreen(context, queueService.retryQueueLoad);
+            } else if (snapshot.hasData &&
+                snapshot.data!.currentTrack != null) {
+              return const _PlayerScreenContent();
+            } else {
+              return const SizedBox.shrink();
+            }
+          }),
     );
   }
+}
+
+Widget buildLoadingScreen(BuildContext context, Function()? retryCallback) {
+  double imageSize = min(MediaQuery.of(context).size.width,
+          MediaQuery.of(context).size.height) /
+      2;
+
+  return SimpleGestureDetector(
+    onTap: retryCallback,
+    child: Scaffold(
+      backgroundColor: Color.alphaBlend(
+          Theme.of(context).brightness == Brightness.dark
+              ? IconTheme.of(context).color!.withOpacity(0.35)
+              : IconTheme.of(context).color!.withOpacity(0.5),
+          Theme.of(context).brightness == Brightness.dark
+              ? Colors.black
+              : Colors.white),
+      // Required for sleep timer input
+      resizeToAvoidBottomInset: false,
+      extendBodyBehindAppBar: true,
+      body: SafeArea(
+        minimum: const EdgeInsets.only(top: _toolbarHeight),
+        child: SizedBox.expand(
+          child:
+              Column(crossAxisAlignment: CrossAxisAlignment.center, children: [
+            const Spacer(),
+            (retryCallback != null)
+                ? Icon(
+                    Icons.refresh,
+                    size: imageSize,
+                  )
+                : SizedBox(
+                    width: imageSize,
+                    height: imageSize,
+                    child: const CircularProgressIndicator.adaptive()),
+            const Spacer(),
+            BalancedText(
+                (retryCallback != null)
+                    ? AppLocalizations.of(context)!.queueRetryMessage
+                    : AppLocalizations.of(context)!.queueLoadingMessage,
+                textAlign: TextAlign.center,
+                style: const TextStyle(
+                  fontSize: 20,
+                  height: 26 / 20,
+                )),
+            const Spacer(flex: 2),
+          ]),
+        ),
+      ),
+    ),
+  );
 }
 
 class _PlayerScreenContent extends StatelessWidget {

--- a/lib/screens/player_screen.dart
+++ b/lib/screens/player_screen.dart
@@ -9,6 +9,7 @@ import 'package:flutter_vibrate/flutter_vibrate.dart';
 import 'package:simple_gesture_detector/simple_gesture_detector.dart';
 
 import '../components/PlayerScreen/control_area.dart';
+import '../components/PlayerScreen/player_split_screen_scaffold.dart';
 import '../components/PlayerScreen/queue_button.dart';
 import '../components/PlayerScreen/queue_list.dart';
 import '../components/PlayerScreen/song_info.dart';
@@ -68,9 +69,11 @@ class _PlayerScreenContent extends StatelessWidget {
           centerTitle: true,
           toolbarHeight: _toolbarHeight,
           title: const PlayerScreenAppBarTitle(),
-          leading: FinampAppBarButton(
-            onPressed: () => Navigator.of(context).pop(),
-          ),
+          leading: usingPlayerSplitScreen
+              ? null
+              : FinampAppBarButton(
+                  onPressed: () => Navigator.of(context).pop(),
+                ),
           actions: [
             if (Platform.isIOS)
               Padding(

--- a/lib/services/album_image_provider.dart
+++ b/lib/services/album_image_provider.dart
@@ -36,9 +36,9 @@ class AlbumImageRequest {
   int get hashCode => Object.hash(item.id, maxHeight, maxWidth);
 }
 
-final AutoDisposeFutureProviderFamily<ImageProvider?, AlbumImageRequest>
-    albumImageProvider = FutureProvider.autoDispose
-        .family<ImageProvider?, AlbumImageRequest>((ref, request) async {
+final AutoDisposeProviderFamily<ImageProvider?, AlbumImageRequest>
+    albumImageProvider = Provider.autoDispose
+        .family<ImageProvider?, AlbumImageRequest>((ref, request) {
   if (request.item.imageId == null) {
     return null;
   }
@@ -46,12 +46,8 @@ final AutoDisposeFutureProviderFamily<ImageProvider?, AlbumImageRequest>
   final jellyfinApiHelper = GetIt.instance<JellyfinApiHelper>();
   final isardownloader = GetIt.instance<DownloadsService>();
 
-  DownloadItem? downloadedImage;
-  try {
-    downloadedImage = await isardownloader.getImageDownload(item: request.item);
-  } catch (e) {
-    albumImageProviderLogger.warning("Couldn't get the offline image for track '${request.item.name}' because it's missing a blurhash");
-  }
+  DownloadItem? downloadedImage =
+      isardownloader.getImageDownload(item: request.item);
 
   if (downloadedImage?.file == null) {
     if (FinampSettingsHelper.finampSettings.isOffline) {

--- a/lib/services/current_album_image_provider.dart
+++ b/lib/services/current_album_image_provider.dart
@@ -1,39 +1,36 @@
-import 'dart:async';
-
 import 'package:finamp/models/finamp_models.dart';
 import 'package:finamp/models/jellyfin_models.dart';
 import 'package:finamp/services/queue_service.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:get_it/get_it.dart';
+
 import 'album_image_provider.dart';
 
 /// Provider to handle syncing up the current playing item's image provider.
 /// Used on the player screen to sync up loading the blurred background.
-final currentAlbumImageProvider = FutureProvider<ImageProvider?>((ref) async {
+final currentAlbumImageProvider = Provider<ImageProvider?>((ref) {
   final List<FinampQueueItem> precacheItems =
       GetIt.instance<QueueService>().getNextXTracksInQueue(3, reverse: 1);
   ImageStream? stream;
   ImageStreamListener? listener;
   // Set up onDispose function before crossing async boundary
   ref.onDispose(() {
-    if(stream!=null&&listener!=null){
-      stream?.removeListener(listener!);
+    if (stream != null && listener != null) {
+      stream.removeListener(listener);
     }
   });
   for (final itemToPrecache in precacheItems) {
     BaseItemDto? base = itemToPrecache.baseItem;
     if (base != null) {
       final request = AlbumImageRequest(item: base);
-      unawaited(ref.read(albumImageProvider(request).future).then((value) {
-        if (value != null) {
-          // Cache the returned image
-          stream =
-              value.resolve(const ImageConfiguration(devicePixelRatio: 1.0));
-          listener = ImageStreamListener((image, synchronousCall) {});
-          stream!.addListener(listener!);
-        }
-      }));
+      var image = ref.read(albumImageProvider(request));
+      if (image != null) {
+        // Cache the returned image
+        stream = image.resolve(const ImageConfiguration(devicePixelRatio: 1.0));
+        listener = ImageStreamListener((image, synchronousCall) {});
+        stream.addListener(listener);
+      }
     }
   }
 
@@ -42,7 +39,7 @@ final currentAlbumImageProvider = FutureProvider<ImageProvider?>((ref) async {
     final request = AlbumImageRequest(
       item: currentTrack,
     );
-    return ref.read(albumImageProvider(request).future);
+    return ref.read(albumImageProvider(request));
   }
   return null;
 });

--- a/lib/services/downloads_service_backend.dart
+++ b/lib/services/downloads_service_backend.dart
@@ -1437,7 +1437,7 @@ class DownloadsSyncService {
             "Media source info for ${item.id} returned null, filename may be weird.");
       }
       subDirectory =
-          path_helper.join("finamp", _filesystemSafe(item.albumArtist));
+          path_helper.join("Finamp", _filesystemSafe(item.albumArtist));
       // We use a regex to filter out bad characters from song/album names.
       fileName = _filesystemSafe(
           "${item.album} - ${item.indexNumber ?? 0} - ${item.name}.$container")!;
@@ -1446,7 +1446,7 @@ class DownloadsSyncService {
       subDirectory = "songs";
     }
 
-    if (downloadLocation.baseDirectory.needsPath) {
+    if (downloadLocation.baseDirectory.baseDirectory == BaseDirectory.root) {
       subDirectory =
           path_helper.join(downloadLocation.currentPath, subDirectory);
     }
@@ -1493,12 +1493,12 @@ class DownloadsSyncService {
     String subDirectory;
     if (downloadLocation.useHumanReadableNames) {
       subDirectory =
-          path_helper.join("finamp", _filesystemSafe(item.albumArtist));
+          path_helper.join("Finamp", _filesystemSafe(item.albumArtist));
     } else {
       subDirectory = "images";
     }
 
-    if (downloadLocation.baseDirectory.needsPath) {
+    if (downloadLocation.baseDirectory.baseDirectory == BaseDirectory.root) {
       subDirectory =
           path_helper.join(downloadLocation.currentPath, subDirectory);
     }

--- a/lib/services/finamp_logs_helper.dart
+++ b/lib/services/finamp_logs_helper.dart
@@ -14,10 +14,11 @@ class FinampLogsHelper {
   final List<LogRecord> logs = [];
   IOSink? _logFileWriter;
 
-  // Logging to a file is currently disabled.
   Future<void> openLog() async {
     WidgetsFlutterBinding.ensureInitialized();
-    final basePath = await getApplicationDocumentsDirectory();
+    final basePath = (Platform.isAndroid || Platform.isIOS)
+        ? await getApplicationDocumentsDirectory()
+        : await getApplicationSupportDirectory();
     final logFile = File(path_helper.join(basePath.path, "finamp-logs.txt"));
     if (logFile.existsSync() && logFile.lengthSync() >= 1024 * 1024 * 10) {
       logFile
@@ -65,7 +66,9 @@ class FinampLogsHelper {
     tempFile.createSync();
 
     if (_logFileWriter != null) {
-      final basePath = await getApplicationDocumentsDirectory();
+      final basePath = (Platform.isAndroid || Platform.isIOS)
+          ? await getApplicationDocumentsDirectory()
+          : await getApplicationSupportDirectory();
       var oldLogs =
           File(path_helper.join(basePath.path, "finamp-logs-old.txt"));
       var newLogs = File(path_helper.join(basePath.path, "finamp-logs.txt"));

--- a/lib/services/jellyfin_api_helper.dart
+++ b/lib/services/jellyfin_api_helper.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 import 'dart:convert';
+import 'dart:io';
 import 'dart:isolate';
 
 import 'package:chopper/chopper.dart';
@@ -52,7 +53,9 @@ class JellyfinApiHelper {
     BackgroundIsolateBinaryMessenger.ensureInitialized(input.$2);
     ReceivePort requestPort = ReceivePort();
     input.$1.send(requestPort.sendPort);
-    final dir = await getApplicationDocumentsDirectory();
+    final dir = (Platform.isAndroid || Platform.isIOS)
+        ? await getApplicationDocumentsDirectory()
+        : await getApplicationSupportDirectory();
     final isar = await Isar.open(
       [DownloadItemSchema, IsarTaskDataSchema, FinampUserSchema],
       directory: dir.path,
@@ -119,7 +122,8 @@ class JellyfinApiHelper {
     }
     assert(!FinampSettingsHelper.finampSettings.isOffline);
     assert(itemIds == null || parentItem == null);
-    fields ??= defaultFields; // explicitly set the default fields, if we pass `null` to [JellyfinAPI.getItems] it will **not** apply the default fields, since the argument *is* provided.
+    fields ??=
+        defaultFields; // explicitly set the default fields, if we pass `null` to [JellyfinAPI.getItems] it will **not** apply the default fields, since the argument *is* provided.
     if (parentItem != null) {
       _jellyfinApiHelperLogger.fine("Getting children of ${parentItem.name}");
     } else if (itemIds != null) {
@@ -416,7 +420,8 @@ class JellyfinApiHelper {
   /// Updates player progress so that Jellyfin can track what we're listening to
   Future<void> updatePlaybackProgress(
       PlaybackProgressInfo playbackProgressInfo) async {
-    final response = await jellyfinApi.playbackStatusUpdate(playbackProgressInfo);
+    final response =
+        await jellyfinApi.playbackStatusUpdate(playbackProgressInfo);
     if (response.toString().isNotEmpty) {
       throw response;
     }
@@ -425,7 +430,8 @@ class JellyfinApiHelper {
   /// Tells Jellyfin that we've stopped listening to music (called when the audio service is stopped)
   Future<void> stopPlaybackProgress(
       PlaybackProgressInfo playbackProgressInfo) async {
-    final response = await jellyfinApi.playbackStatusStopped(playbackProgressInfo);
+    final response =
+        await jellyfinApi.playbackStatusStopped(playbackProgressInfo);
     if (response.toString().isNotEmpty) {
       throw response;
     }
@@ -449,7 +455,8 @@ class JellyfinApiHelper {
   Future<BaseItemDto?> getItemByIdBatched(String itemId,
       [String? fields]) async {
     assert(!FinampSettingsHelper.finampSettings.isOffline);
-    fields ??= defaultFields; // explicitly set the default fields, if we pass `null` to [JellyfinAPI.getItems] it will **not** apply the default fields, since the argument *is* provided.
+    fields ??=
+        defaultFields; // explicitly set the default fields, if we pass `null` to [JellyfinAPI.getItems] it will **not** apply the default fields, since the argument *is* provided.
     _getItemByIdBatchedRequests.add(itemId);
     _getItemByIdBatchedFuture ??=
         Future.delayed(const Duration(milliseconds: 250), () async {
@@ -511,7 +518,8 @@ class JellyfinApiHelper {
     /// changed values.
     required BaseItemDto newItem,
   }) async {
-    final response = await jellyfinApi.updateItem(itemId: itemId, newItem: newItem);
+    final response =
+        await jellyfinApi.updateItem(itemId: itemId, newItem: newItem);
     if (response.toString().isNotEmpty) {
       throw response;
     }

--- a/lib/services/offline_listen_helper.dart
+++ b/lib/services/offline_listen_helper.dart
@@ -17,7 +17,9 @@ class OfflineListenLogHelper {
 
   Future<Directory> get _logDirectory async {
     if (!Platform.isAndroid) {
-      return await getApplicationDocumentsDirectory();
+      return Platform.isIOS
+          ? await getApplicationDocumentsDirectory()
+          : await getApplicationSupportDirectory();
     }
 
     final List<Directory>? dirs =
@@ -82,12 +84,9 @@ class OfflineListenLogHelper {
 
   /// Share the offline listens log file
   Future<void> shareOfflineListens() async {
-
     final file = await _logFile;
     final xFile = XFile(file.path, mimeType: "application/json");
 
     await Share.shareXFiles([xFile]);
-
   }
-  
 }

--- a/lib/services/player_screen_theme_provider.dart
+++ b/lib/services/player_screen_theme_provider.dart
@@ -46,7 +46,7 @@ final AutoDisposeProviderFamily<ColorScheme, Brightness>
 final AutoDisposeFutureProviderFamily<ColorScheme?, Brightness>
     playerScreenThemeNullableProvider = FutureProvider.family
         .autoDispose<ColorScheme?, Brightness>((ref, brightness) async {
-  ImageProvider? image = await ref.watch(currentAlbumImageProvider.future);
+  ImageProvider? image = ref.watch(currentAlbumImageProvider);
   if (image == null) {
     return null;
   }
@@ -57,7 +57,7 @@ final AutoDisposeFutureProviderFamily<ColorScheme?, Brightness>
       image.resolve(const ImageConfiguration(devicePixelRatio: 1.0));
   ImageStreamListener? listener;
 
-  listener = ImageStreamListener((image, synchronousCall) async {
+  listener = ImageStreamListener((image, synchronousCall) {
     stream.removeListener(listener!);
     completer.complete(getColorSchemeForImage(image.image, brightness));
   }, onError: (_, __) {

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -1264,10 +1264,11 @@ packages:
   split_view:
     dependency: "direct main"
     description:
-      name: split_view
-      sha256: "7ad0e1c40703901aa1175fd465dec5e965b55324f9cc8e51526479a4a96d01a4"
-      url: "https://pub.dev"
-    source: hosted
+      path: "."
+      ref: "8b2b0f0e1c8470183cb2df40815a05bfdb3fe219"
+      resolved-ref: "8b2b0f0e1c8470183cb2df40815a05bfdb3fe219"
+      url: "https://github.com/odriverobotics/split_view.git"
+    source: git
     version: "3.2.1"
   sqflite:
     dependency: transitive

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -1253,6 +1253,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.10.0"
+  split_view:
+    dependency: "direct main"
+    description:
+      name: split_view
+      sha256: "7ad0e1c40703901aa1175fd465dec5e965b55324f9cc8e51526479a4a96d01a4"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.2.1"
   sqflite:
     dependency: transitive
     description:

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -446,6 +446,14 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
+  flutter_blurhash:
+    dependency: "direct main"
+    description:
+      name: flutter_blurhash
+      sha256: "5e67678e479ac639069d7af1e133f4a4702311491188ff3e0227486430db0c06"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.8.2"
   flutter_cache_manager:
     dependency: transitive
     description:
@@ -871,6 +879,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.1.0"
+  modal_bottom_sheet:
+    dependency: "direct main"
+    description:
+      name: modal_bottom_sheet
+      sha256: eac66ef8cb0461bf069a38c5eb0fa728cee525a531a8304bd3f7b2185407c67e
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.0.0"
   msix:
     dependency: "direct dev"
     description:

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -109,10 +109,10 @@ packages:
     dependency: "direct main"
     description:
       name: background_downloader
-      sha256: "3ad49c6de1ffb505b7014cee482bb79fc6a262cae83525c49fd90c1ddee9382e"
+      sha256: ce5c03e948392e800dfe0daa57480fc79ab3da1046a19d526fe89f7090079090
       url: "https://pub.dev"
     source: hosted
-    version: "8.4.0"
+    version: "8.4.1"
   balanced_text:
     dependency: "direct main"
     description:
@@ -421,10 +421,10 @@ packages:
     dependency: "direct main"
     description:
       name: file_picker
-      sha256: caa6bc229eab3e32eb2f37b53a5f9d22a6981474afd210c512a7546c1e1a04f6
+      sha256: "1bbf65dd997458a08b531042ec3794112a6c39c07c37ff22113d2e7e4f81d4e4"
       url: "https://pub.dev"
     source: hosted
-    version: "6.2.0"
+    version: "6.2.1"
   file_sizes:
     dependency: "direct main"
     description:
@@ -1180,10 +1180,10 @@ packages:
     dependency: transitive
     description:
       name: share_plus_platform_interface
-      sha256: df08bc3a07d01f5ea47b45d03ffcba1fa9cd5370fb44b3f38c70e42cced0f956
+      sha256: "251eb156a8b5fa9ce033747d73535bf53911071f8d3b6f4f0b578505ce0d4496"
       url: "https://pub.dev"
     source: hosted
-    version: "3.3.1"
+    version: "3.4.0"
   shelf:
     dependency: transitive
     description:

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -109,10 +109,10 @@ packages:
     dependency: "direct main"
     description:
       name: background_downloader
-      sha256: "9e1497b149717fa6d5981804c58fb699ebc5f6b2692d983f45ae0f43e818577d"
+      sha256: "3ad49c6de1ffb505b7014cee482bb79fc6a262cae83525c49fd90c1ddee9382e"
       url: "https://pub.dev"
     source: hosted
-    version: "8.3.0"
+    version: "8.4.0"
   balanced_text:
     dependency: "direct main"
     description:
@@ -325,26 +325,26 @@ packages:
     dependency: "direct dev"
     description:
       name: custom_lint
-      sha256: "445242371d91d2e24bd7b82e3583a2c05610094ba2d0575262484ad889c8f981"
+      sha256: "7c0aec12df22f9082146c354692056677f1e70bc43471644d1fdb36c6fdda799"
       url: "https://pub.dev"
     source: hosted
-    version: "0.6.2"
+    version: "0.6.4"
   custom_lint_builder:
     dependency: transitive
     description:
       name: custom_lint_builder
-      sha256: "4c0aed2a3491096e91cf1281923ba1b6814993f16dde0fd60f697925225bbbd6"
+      sha256: d7dc41e709dde223806660268678be7993559e523eb3164e2a1425fd6f7615a9
       url: "https://pub.dev"
     source: hosted
-    version: "0.6.2"
+    version: "0.6.4"
   custom_lint_core:
     dependency: transitive
     description:
       name: custom_lint_core
-      sha256: ce5d6215f4e143f7780ce53f73dfa6fc503f39d2d30bef76c48be9ac1a09d9a6
+      sha256: a85e8f78f4c52f6c63cdaf8c872eb573db0231dcdf3c3a5906d493c1f8bc20e6
       url: "https://pub.dev"
     source: hosted
-    version: "0.6.2"
+    version: "0.6.3"
   dart_style:
     dependency: transitive
     description:
@@ -527,10 +527,10 @@ packages:
     dependency: "direct main"
     description:
       name: flutter_tabler_icons
-      sha256: bf068252388ff377d41fbd7b876edf42ca067bc6e056e2b6ac5a1ec2af5d22f2
+      sha256: bc7c5d44c3dd1621e086337dcb823567ba6de026375da0ed9c125b119921ee60
       url: "https://pub.dev"
     source: hosted
-    version: "1.22.0"
+    version: "1.25.0"
   flutter_test:
     dependency: "direct dev"
     description: flutter
@@ -747,7 +747,7 @@ packages:
     description:
       path: "."
       ref: HEAD
-      resolved-ref: "42b59e32763e349f860537389b79ea320a232b63"
+      resolved-ref: cbae0008fe90998f7127618efb368d9e5b05b4a1
       url: "https://github.com/Chaphasilor/just_audio_media_kit.git"
     source: git
     version: "2.0.1"
@@ -1012,10 +1012,10 @@ packages:
     dependency: transitive
     description:
       name: permission_handler_apple
-      sha256: bdafc6db74253abb63907f4e357302e6bb786ab41465e8635f362ee71fd8707b
+      sha256: "8c90be7f8244eeb2bbfa4248221d38a66ca3e3cc3ab967a25a2529d86eee7c45"
       url: "https://pub.dev"
     source: hosted
-    version: "9.4.0"
+    version: "9.4.1"
   permission_handler_html:
     dependency: transitive
     description:
@@ -1282,10 +1282,10 @@ packages:
     dependency: transitive
     description:
       name: sqflite_common
-      sha256: "28d8c66baee4968519fb8bd6cdbedad982d6e53359091f0b74544a9f32ec72d5"
+      sha256: "3da423ce7baf868be70e2c0976c28a1bb2f73644268b7ffa7d2e08eab71f16a4"
       url: "https://pub.dev"
     source: hosted
-    version: "2.5.3"
+    version: "2.5.4"
   stack_trace:
     dependency: transitive
     description:

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -879,14 +879,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.1.0"
-  modal_bottom_sheet:
-    dependency: "direct main"
-    description:
-      name: modal_bottom_sheet
-      sha256: eac66ef8cb0461bf069a38c5eb0fa728cee525a531a8304bd3f7b2185407c67e
-      url: "https://pub.dev"
-    source: hosted
-    version: "3.0.0"
   msix:
     dependency: "direct dev"
     description:

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -1012,10 +1012,10 @@ packages:
     dependency: transitive
     description:
       name: permission_handler_apple
-      sha256: "8c90be7f8244eeb2bbfa4248221d38a66ca3e3cc3ab967a25a2529d86eee7c45"
+      sha256: "92861b0f0c2443dd8898398c2baa4f1ae925109b5909ae4a17d0108a6a788932"
       url: "https://pub.dev"
     source: hosted
-    version: "9.4.1"
+    version: "9.4.2"
   permission_handler_html:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -85,6 +85,8 @@ dependencies:
   balanced_text: ^0.0.3
   flutter_to_airplay: ^2.0.4
   audio_service_mpris: ^0.1.3
+  flutter_blurhash: ^0.8.2
+  modal_bottom_sheet: ^3.0.0
 
 dev_dependencies:
   flutter_test:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -58,7 +58,12 @@ dependencies:
   device_info_plus: ^9.0.3
   package_info_plus: ^5.0.1
   octo_image: ^2.0.0
-  split_view: ^3.2.1
+  # Main split view package does not seem actively maintained.  Use fork with ability to specify
+  # handle visual vs grabbable sizes separately.
+  split_view:
+    git:
+      url: https://github.com/odriverobotics/split_view.git
+      ref: 8b2b0f0e1c8470183cb2df40815a05bfdb3fe219
   share_plus: ^7.1.0
   isar: ^3.1.0
   isar_flutter_libs: ^3.1.0

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -58,6 +58,7 @@ dependencies:
   device_info_plus: ^9.0.3
   package_info_plus: ^5.0.1
   octo_image: ^2.0.0
+  split_view: ^3.2.1
   share_plus: ^7.1.0
   isar: ^3.1.0
   isar_flutter_libs: ^3.1.0

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -86,7 +86,6 @@ dependencies:
   flutter_to_airplay: ^2.0.4
   audio_service_mpris: ^0.1.3
   flutter_blurhash: ^0.8.2
-  modal_bottom_sheet: ^3.0.0
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
Added splitscreen mode when window is wide enough.  The player/queue will be shown on the right, all other screens show up on the left.  Probably works on tablets too.  Additionally, I've tried to make the song menu modal behave a bit better with a mouse.  I've messed with album image loading with blurhashes, and added a variant of the music screen grid mode that doesn't make a crazy amount of image requests when the window gets resized.  Built on top of https://github.com/jmshrv/finamp/pull/636.

![Screenshot 2024-03-16 204542](https://github.com/jmshrv/finamp/assets/45665554/a493dafc-cb0e-452f-b3af-5c1f6afaadc7)
