### PR TITLE
Enable drag handle for items in tabs list

### DIFF
--- a/lib/components/MusicScreen/music_screen_tab_view.dart
+++ b/lib/components/MusicScreen/music_screen_tab_view.dart
@@ -321,7 +321,8 @@ class _MusicScreenTabViewState extends State<MusicScreenTabView>
               settings.tabSortOrder[widget.tabContentType],
               settings.onlyShowFullyDownloaded,
               widget.view?.id,
-              settings.isOffline);
+              settings.isOffline,
+              settings.tabOrder,);
           if (refreshHash == null) {
             refreshHash = newRefreshHash;
           } else if (refreshHash != newRefreshHash) {

--- a/lib/components/TabsSettingsScreen/hide_tab_toggle.dart
+++ b/lib/components/TabsSettingsScreen/hide_tab_toggle.dart
@@ -19,7 +19,7 @@ class HideTabToggle extends StatelessWidget {
       builder: (_, box, __) {
         return SwitchListTile.adaptive(
           title: Text(tabContentType.toLocalisedString(context)),
-          // secondary: const Icon(Icons.drag_handle),
+          secondary: const Icon(Icons.drag_handle),
           // This should never be null, but it gets set to true if it is.
           value: FinampSettingsHelper.finampSettings.showTabs[tabContentType] ??
               true,

--- a/lib/components/TabsSettingsScreen/hide_tab_toggle.dart
+++ b/lib/components/TabsSettingsScreen/hide_tab_toggle.dart
@@ -7,10 +7,12 @@ import '../../models/finamp_models.dart';
 class HideTabToggle extends StatelessWidget {
   const HideTabToggle({
     Key? key,
+    required this.index,
     required this.tabContentType,
   }) : super(key: key);
 
   final TabContentType tabContentType;
+  final int index;
 
   @override
   Widget build(BuildContext context) {
@@ -19,7 +21,10 @@ class HideTabToggle extends StatelessWidget {
       builder: (_, box, __) {
         return SwitchListTile.adaptive(
           title: Text(tabContentType.toLocalisedString(context)),
-          secondary: const Icon(Icons.drag_handle),
+          secondary: ReorderableDragStartListener(
+            index: index,
+            child: const Icon(Icons.drag_handle),
+          ),
           // This should never be null, but it gets set to true if it is.
           value: FinampSettingsHelper.finampSettings.showTabs[tabContentType] ??
               true,

--- a/lib/screens/tabs_settings_screen.dart
+++ b/lib/screens/tabs_settings_screen.dart
@@ -55,13 +55,14 @@ class _TabsSettingsScreenState extends State<TabsSettingsScreen> {
                 newIndex -= 1;
               }
 
-              final oldValue =
-                  FinampSettingsHelper.finampSettings.tabOrder[oldIndex];
-              final newValue =
-                  FinampSettingsHelper.finampSettings.tabOrder[newIndex];
+              final currentTabOrder = FinampSettingsHelper.finampSettings.tabOrder;
 
-              FinampSettingsHelper.setTabOrder(oldIndex, newValue);
-              FinampSettingsHelper.setTabOrder(newIndex, oldValue);
+              // move all values below newIndex down by one
+              final oldTab = currentTabOrder[oldIndex];
+              currentTabOrder.removeAt(oldIndex);
+              currentTabOrder.insert(newIndex, oldTab);
+              FinampSettingsHelper.setTabOrder(currentTabOrder);
+
             });
           },
         ),

--- a/lib/screens/tabs_settings_screen.dart
+++ b/lib/screens/tabs_settings_screen.dart
@@ -41,6 +41,7 @@ class _TabsSettingsScreenState extends State<TabsSettingsScreen> {
                   FinampSettingsHelper.finampSettings.tabOrder[index],
               key:
                   ValueKey(FinampSettingsHelper.finampSettings.tabOrder[index]),
+              index: index,
             );
           },
           onReorder: (oldIndex, newIndex) {

--- a/lib/services/finamp_settings_helper.dart
+++ b/lib/services/finamp_settings_helper.dart
@@ -285,9 +285,9 @@ class FinampSettingsHelper {
         .put("FinampSettings", finampSettingsTemp);
   }
 
-  static void setTabOrder(int index, TabContentType tabContentType) {
+  static void setTabOrder(List<TabContentType> newTabOrder) {
     FinampSettings finampSettingsTemp = finampSettings;
-    finampSettingsTemp.tabOrder[index] = tabContentType;
+    finampSettingsTemp.tabOrder = newTabOrder;
     Hive.box<FinampSettings>("FinampSettings")
         .put("FinampSettings", finampSettingsTemp);
   }


### PR DESCRIPTION
Hi! First of all, thank you for building this awesome app and making it open source!

This PR contains just a tiny change that makes the drag handle icon visible for the items in the Tabs list.
Since there was no drag handle on the items of the tabs list, I was not aware of the possibility to reorder the tabs, and I wanted to implement it. But taking a look at the code, I saw that the feature was already there. So I just uncommented one line to make the handle visible.
I do not know if that line was left commented out because it caused other issues or for other reasons, but from my (not extended) tests I did not notice any issue.

Hope this can help!