### PR TITLE
[Redesign] Transcoded downloads tweaks

### DIFF
--- a/lib/models/finamp_models.dart
+++ b/lib/models/finamp_models.dart
@@ -1560,7 +1560,7 @@ enum DownloadLocationType {
 @HiveType(typeId: 65)
 enum FinampTranscodingCodec {
   @HiveField(0)
-  aac("m4a", true, 1.2),
+  aac("aac", true, 1.2),
   @HiveField(1)
   mp3("mp3", true, 1.0),
   @HiveField(2)

--- a/lib/screens/transcoding_settings_screen.dart
+++ b/lib/screens/transcoding_settings_screen.dart
@@ -143,7 +143,6 @@ class DownloadTranscodeCodecDropdownListTile extends StatelessWidget {
         return ListTile(
           title:
               Text(AppLocalizations.of(context)!.downloadTranscodeCodecTitle),
-          subtitle: Text("AAC does not work until jellyfin 10.9"),
           trailing: DropdownButton<FinampTranscodingCodec>(
             value: finampSettings.downloadTranscodingProfile.codec,
             items: FinampTranscodingCodec.values

--- a/lib/services/downloads_service_backend.dart
+++ b/lib/services/downloads_service_backend.dart
@@ -1425,7 +1425,7 @@ class DownloadsSyncService {
                 "${_jellyfinApiData.defaultFields},MediaSources,SortName"))
             ?.mediaSources;
 
-    String container = downloadItem.fileTranscodingProfile?.codec.container ??
+    String container = downloadItem.syncTranscodingProfile?.codec.container ??
         mediaSources?[0].container ??
         'song';
 


### PR DESCRIPTION
Switch AAC transcodes to use .aac container.  It seems to already work fine with jellyfin 10.8, and I think it works with iOS?  And we know that AAC in .m4a actually doesn't seem to work.  It also seems to scrub properly on android, unlike m4a.  Also, now uses correct file extension on local paths.