### PR TITLE
[Redesign] Fix non-transcoded downloads + tweaks

### DIFF
--- a/lib/components/AlbumScreen/song_menu.dart
+++ b/lib/components/AlbumScreen/song_menu.dart
@@ -202,7 +202,7 @@ class _SongMenuState extends State<SongMenu> {
         return DraggableScrollableSheet(
           snap: true,
           initialChildSize: size,
-          minChildSize: size * 0.9,
+          minChildSize: size * 0.75,
           expand: false,
           builder: (context, scrollController) {
             return Stack(

--- a/lib/components/AlbumScreen/song_menu.dart
+++ b/lib/components/AlbumScreen/song_menu.dart
@@ -216,7 +216,6 @@ class _SongMenuState extends State<SongMenu> {
                               : 1.0),
                 CustomScrollView(
                   controller: scrollController,
-                  physics: const ClampingScrollPhysics(),
                   slivers: [
                     SliverPersistentHeader(
                       delegate: SongMenuSliverAppBar(

--- a/lib/components/MusicScreen/music_screen_tab_view.dart
+++ b/lib/components/MusicScreen/music_screen_tab_view.dart
@@ -3,7 +3,6 @@ import 'dart:math';
 
 import 'package:collection/collection.dart';
 import 'package:finamp/services/finamp_user_helper.dart';
-import 'package:finamp/services/jellyfin_api.dart';
 import 'package:flutter/material.dart';
 import 'package:get_it/get_it.dart';
 import 'package:hive/hive.dart';
@@ -85,7 +84,9 @@ class _MusicScreenTabViewState extends State<MusicScreenTabView>
       final newItems = await _jellyfinApiHelper.getItems(
         // starting with Jellyfin 10.9, only automatically created playlists will have a specific library as parent. user-created playlists will not be returned anymore
         // this condition fixes this by not providing a parentId when fetching playlists
-        parentItem: widget.tabContentType.itemType == BaseItemDtoType.playlist ? null : widget.view,
+        parentItem: widget.tabContentType.itemType == BaseItemDtoType.playlist
+            ? null
+            : widget.view,
         includeItemTypes: widget.tabContentType.itemType.idString,
 
         // If we're on the songs tab, sort by "Album,SortName". This is what the
@@ -153,8 +154,9 @@ class _MusicScreenTabViewState extends State<MusicScreenTabView>
 
     var items = offlineItems.map((e) => e.baseItem).whereNotNull().toList();
 
-    items = sortItems(items, settings.tabSortBy[widget.tabContentType], settings.tabSortOrder[widget.tabContentType]);
-    
+    items = sortItems(items, settings.tabSortBy[widget.tabContentType],
+        settings.tabSortOrder[widget.tabContentType]);
+
     // Skip appending page if a refresh triggered while processing
     if (localRefreshCount == refreshCount && mounted) {
       _pagingController.appendLastPage(items);
@@ -192,6 +194,9 @@ class _MusicScreenTabViewState extends State<MusicScreenTabView>
 
     letterToSearch = letter;
     var letterCodePoint = letterToSearch!.toLowerCase().codeUnitAt(0);
+    // Max code point is lower case z to increase the chance of seeing a character
+    // past the target but below the ignore point
+    var maxCodePoint = 'z'.codeUnitAt(0);
 
     if (letter == '#') {
       letterCodePoint = 0;
@@ -200,7 +205,9 @@ class _MusicScreenTabViewState extends State<MusicScreenTabView>
       var itemCodePoint =
           _pagingController.itemList![i].nameForSorting!.codeUnitAt(0);
       var diff = itemCodePoint - letterCodePoint;
-      if (reversed ? diff <= 0 : diff >= 0) {
+      // Ignore accented characters with indexes beyond z which are sorted with
+      // their base letters.
+      if (reversed ? diff <= 0 : diff >= 0 && itemCodePoint <= maxCodePoint) {
         timer?.cancel();
         if (reversed ? diff < 0 : diff > 0) {
           await controller.scrollToIndex(i,
@@ -252,14 +259,15 @@ class _MusicScreenTabViewState extends State<MusicScreenTabView>
           // This also means we don't redo a search unless we actaully need to.
           var settings = box.get("FinampSettings")!;
           var newRefreshHash = Object.hash(
-              widget.searchTerm,
-              settings.onlyShowFavourite,
-              settings.tabSortBy[widget.tabContentType],
-              settings.tabSortOrder[widget.tabContentType],
-              settings.onlyShowFullyDownloaded,
-              widget.view?.id,
-              settings.isOffline,
-              settings.tabOrder,);
+            widget.searchTerm,
+            settings.onlyShowFavourite,
+            settings.tabSortBy[widget.tabContentType],
+            settings.tabSortOrder[widget.tabContentType],
+            settings.onlyShowFullyDownloaded,
+            widget.view?.id,
+            settings.isOffline,
+            settings.tabOrder,
+          );
           if (refreshHash == null) {
             refreshHash = newRefreshHash;
           } else if (refreshHash != newRefreshHash) {
@@ -376,58 +384,59 @@ class _MusicScreenTabViewState extends State<MusicScreenTabView>
   }
 }
 
-List<BaseItemDto> sortItems(List<BaseItemDto> itemsToSort, SortBy? sortBy, SortOrder? sortOrder) {
-
-    itemsToSort.sort((a, b) {
-      switch (sortBy ?? SortBy.sortName) {
-        case SortBy.sortName:
-          if (a.nameForSorting == null || b.nameForSorting == null) {
-            // Returning 0 is the same as both being the same
-            return 0;
-          } else {
-            return a.nameForSorting!.compareTo(b.nameForSorting!);
-          }
-        case SortBy.albumArtist:
-          if (a.albumArtist == null || b.albumArtist == null) {
-            return 0;
-          } else {
-            return a.albumArtist!.compareTo(b.albumArtist!);
-          }
-        case SortBy.communityRating:
-          if (a.communityRating == null || b.communityRating == null) {
-            return 0;
-          } else {
-            return a.communityRating!.compareTo(b.communityRating!);
-          }
-        case SortBy.criticRating:
-          if (a.criticRating == null || b.criticRating == null) {
-            return 0;
-          } else {
-            return a.criticRating!.compareTo(b.criticRating!);
-          }
-        case SortBy.dateCreated:
-          if (a.dateCreated == null || b.dateCreated == null) {
-            return 0;
-          } else {
-            return a.dateCreated!.compareTo(b.dateCreated!);
-          }
-        case SortBy.premiereDate:
-          if (a.premiereDate == null || b.premiereDate == null) {
-            return 0;
-          } else {
-            return a.premiereDate!.compareTo(b.premiereDate!);
-          }
-        case SortBy.random:
-          // We subtract the result by one so that we can get -1 values
-          // (see comareTo documentation)
-          return Random().nextInt(2) - 1;
-        default:
-          throw UnimplementedError(
-              "Unimplemented offline sort mode $sortBy");
-      }
-    });
-    return sortOrder == SortOrder.descending ? itemsToSort.reversed.toList() : itemsToSort;
-  }
+List<BaseItemDto> sortItems(
+    List<BaseItemDto> itemsToSort, SortBy? sortBy, SortOrder? sortOrder) {
+  itemsToSort.sort((a, b) {
+    switch (sortBy ?? SortBy.sortName) {
+      case SortBy.sortName:
+        if (a.nameForSorting == null || b.nameForSorting == null) {
+          // Returning 0 is the same as both being the same
+          return 0;
+        } else {
+          return a.nameForSorting!.compareTo(b.nameForSorting!);
+        }
+      case SortBy.albumArtist:
+        if (a.albumArtist == null || b.albumArtist == null) {
+          return 0;
+        } else {
+          return a.albumArtist!.compareTo(b.albumArtist!);
+        }
+      case SortBy.communityRating:
+        if (a.communityRating == null || b.communityRating == null) {
+          return 0;
+        } else {
+          return a.communityRating!.compareTo(b.communityRating!);
+        }
+      case SortBy.criticRating:
+        if (a.criticRating == null || b.criticRating == null) {
+          return 0;
+        } else {
+          return a.criticRating!.compareTo(b.criticRating!);
+        }
+      case SortBy.dateCreated:
+        if (a.dateCreated == null || b.dateCreated == null) {
+          return 0;
+        } else {
+          return a.dateCreated!.compareTo(b.dateCreated!);
+        }
+      case SortBy.premiereDate:
+        if (a.premiereDate == null || b.premiereDate == null) {
+          return 0;
+        } else {
+          return a.premiereDate!.compareTo(b.premiereDate!);
+        }
+      case SortBy.random:
+        // We subtract the result by one so that we can get -1 values
+        // (see comareTo documentation)
+        return Random().nextInt(2) - 1;
+      default:
+        throw UnimplementedError("Unimplemented offline sort mode $sortBy");
+    }
+  });
+  return sortOrder == SortOrder.descending
+      ? itemsToSort.reversed.toList()
+      : itemsToSort;
+}
 
 class _DeferredLoadingAlwaysScrollableScrollPhysics
     extends AlwaysScrollableScrollPhysics {

--- a/lib/components/MusicScreen/music_screen_tab_view.dart
+++ b/lib/components/MusicScreen/music_screen_tab_view.dart
@@ -194,9 +194,6 @@ class _MusicScreenTabViewState extends State<MusicScreenTabView>
 
     letterToSearch = letter;
     var letterCodePoint = letterToSearch!.toLowerCase().codeUnitAt(0);
-    // Max code point is lower case z to increase the chance of seeing a character
-    // past the target but below the ignore point
-    var maxCodePoint = 'z'.codeUnitAt(0);
 
     if (letter == '#') {
       letterCodePoint = 0;
@@ -205,9 +202,7 @@ class _MusicScreenTabViewState extends State<MusicScreenTabView>
       var itemCodePoint =
           _pagingController.itemList![i].nameForSorting!.codeUnitAt(0);
       var diff = itemCodePoint - letterCodePoint;
-      // Ignore accented characters with indexes beyond z which are sorted with
-      // their base letters.
-      if (reversed ? diff <= 0 : diff >= 0 && itemCodePoint <= maxCodePoint) {
+      if (reversed ? diff <= 0 : diff >= 0) {
         timer?.cancel();
         if (reversed ? diff < 0 : diff > 0) {
           await controller.scrollToIndex(i,

--- a/lib/components/MusicScreen/music_screen_tab_view.dart
+++ b/lib/components/MusicScreen/music_screen_tab_view.dart
@@ -266,7 +266,7 @@ class _MusicScreenTabViewState extends State<MusicScreenTabView>
             settings.onlyShowFullyDownloaded,
             widget.view?.id,
             settings.isOffline,
-            settings.tabOrder,
+            settings.tabOrder.indexOf(widget.tabContentType),
           );
           if (refreshHash == null) {
             refreshHash = newRefreshHash;

--- a/lib/components/PlayerScreen/player_screen_appbar_title.dart
+++ b/lib/components/PlayerScreen/player_screen_appbar_title.dart
@@ -30,6 +30,9 @@ class _PlayerScreenAppBarTitleState extends State<PlayerScreenAppBarTitle> {
       stream: currentTrackStream,
       initialData: _queueService.getCurrentTrack(),
       builder: (context, snapshot) {
+        if (snapshot.data == null) {
+          return const SizedBox.shrink();
+        }
         final queueItem = snapshot.data!;
 
         return Container(

--- a/lib/components/PlayerScreen/queue_list_item.dart
+++ b/lib/components/PlayerScreen/queue_list_item.dart
@@ -2,10 +2,10 @@ import 'package:finamp/components/AlbumScreen/song_menu.dart';
 import 'package:finamp/components/album_image.dart';
 import 'package:finamp/models/finamp_models.dart';
 import 'package:finamp/models/jellyfin_models.dart' as jellyfin_models;
+import 'package:finamp/services/feedback_helper.dart';
 import 'package:finamp/services/finamp_settings_helper.dart';
 import 'package:finamp/services/process_artist.dart';
 import 'package:finamp/services/queue_service.dart';
-import 'package:finamp/services/feedback_helper.dart';
 import 'package:flutter/material.dart' hide ReorderableList;
 import 'package:flutter_tabler_icons/flutter_tabler_icons.dart';
 import 'package:flutter_vibrate/flutter_vibrate.dart';
@@ -58,7 +58,9 @@ class _QueueListItemState extends State<QueueListItem>
 
     return Dismissible(
       key: Key(widget.item.id),
-      direction: FinampSettingsHelper.finampSettings.disableGesture ? DismissDirection.none : DismissDirection.horizontal,
+      direction: FinampSettingsHelper.finampSettings.disableGesture
+          ? DismissDirection.none
+          : DismissDirection.horizontal,
       onDismissed: (direction) async {
         FeedbackHelper.feedback(FeedbackType.impact);
         await _queueService.removeAtOffset(widget.indexOffset);
@@ -132,12 +134,8 @@ class _QueueListItemState extends State<QueueListItem>
                     ],
                   ),
                   trailing: Container(
-                    alignment: Alignment.centerRight,
                     margin: const EdgeInsets.only(right: 8.0),
                     padding: const EdgeInsets.only(right: 6.0),
-                    width: (widget.allowReorder
-                        ? 72.0
-                        : 42.0) + (FinampSettingsHelper.finampSettings.disableGesture ? 32 : 0), //TODO make this responsive
                     child: Row(
                       mainAxisSize: MainAxisSize.min,
                       mainAxisAlignment: MainAxisAlignment.end,
@@ -162,15 +160,15 @@ class _QueueListItemState extends State<QueueListItem>
                             iconSize: 24.0,
                             onPressed: () async {
                               FeedbackHelper.feedback(FeedbackType.light);
-                              await _queueService.removeAtOffset(widget.indexOffset);
+                              await _queueService
+                                  .removeAtOffset(widget.indexOffset);
                             },
                           ),
                         if (widget.allowReorder)
                           ReorderableDragStartListener(
                             index: widget.listIndex,
                             child: Padding(
-                              padding:
-                                  const EdgeInsets.only(left: 6.0),
+                              padding: const EdgeInsets.only(left: 6.0),
                               child: Icon(
                                 TablerIcons.grip_horizontal,
                                 color: Theme.of(context)

--- a/lib/models/finamp_models.dart
+++ b/lib/models/finamp_models.dart
@@ -1618,13 +1618,14 @@ enum FinampTranscodingCodec {
   @HiveField(2)
   opus("ogg", false, 2.0),
   @HiveField(3)
-  original("song", true, 99999999);
+  // Container is null to fall back to real original container per song
+  original(null, true, 99999999);
 
   const FinampTranscodingCodec(
       this.container, this.iosCompatible, this.quality);
 
   /// The container to use for the given codec
-  final String container;
+  final String? container;
 
   final bool iosCompatible;
 

--- a/lib/screens/player_screen.dart
+++ b/lib/screens/player_screen.dart
@@ -93,7 +93,9 @@ class _PlayerScreenContent extends StatelessWidget {
               Padding(
                 padding: const EdgeInsets.symmetric(horizontal: 8.0),
                 child: AirPlayRoutePickerView(
-                  tintColor: IconTheme.of(context).color ?? Colors.white,
+                  // tintcolor does not change without re-opening player screen
+                  //tintColor: IconTheme.of(context).color ?? Colors.white,
+                  tintColor: Colors.white,
                   activeTintColor: jellyfinBlueColor,
                   onShowPickerView: () =>
                       FeedbackHelper.feedback(FeedbackType.selection),
@@ -250,10 +252,14 @@ class PlayerHideableController {
     _reset();
     // We never want to allocate extra width to album covers while some controls
     // are hidden.
-    var desiredControlsWidth = min(_getSize().width, size.width - size.height);
+    var desiredControlsWidth =
+        min(max(_getSize().width, size.width / 2), size.width - size.height);
 
     // Never expand the controls beyond 65% unless the remaining space is just album padding
-    var maxControlsWidth = max(size.width * 0.65, size.width - size.height);
+    var widthPercent =
+        FinampSettingsHelper.finampSettings.prioritizeCoverFactor * 2 + 49;
+    var maxControlsWidth =
+        max(size.width * (widthPercent / 100), size.width - size.height);
     _updateLayoutFromWidth(maxControlsWidth);
 
     var targetHeight = size.height;
@@ -263,7 +269,9 @@ class PlayerHideableController {
       _visible.remove(PlayerHideable.bigPlayButton);
     }
     // Force controls width to always be at least 50% of screen.
-    var minControlsWidth = max(_getSize().width, size.width / 2);
+    var minPercent =
+        FinampSettingsHelper.finampSettings.prioritizeCoverFactor * 2 + 34;
+    var minControlsWidth = max(_getSize().width, (minPercent / 100));
     // If the minimum and maximum sizes do not form a valid range, prioritize the minimum
     // and shrink the album to avoid the controls clipping.
     double targetWidth = desiredControlsWidth.clamp(

--- a/lib/screens/player_screen.dart
+++ b/lib/screens/player_screen.dart
@@ -40,15 +40,15 @@ class PlayerScreen extends ConsumerWidget {
               color: imageTheme.primary,
             ),
       ),
-      child: const _PlayerScreenContent(),
+      child: _PlayerScreenContent(airplayTheme: imageTheme.primary),
     );
   }
 }
 
 class _PlayerScreenContent extends StatelessWidget {
-  const _PlayerScreenContent({
-    super.key,
-  });
+  const _PlayerScreenContent({super.key, required this.airplayTheme});
+
+  final Color airplayTheme;
 
   @override
   Widget build(BuildContext context) {
@@ -92,13 +92,16 @@ class _PlayerScreenContent extends StatelessWidget {
             if (Platform.isIOS)
               Padding(
                 padding: const EdgeInsets.symmetric(horizontal: 8.0),
-                child: AirPlayRoutePickerView(
-                  // tintcolor does not change without re-opening player screen
-                  //tintColor: IconTheme.of(context).color ?? Colors.white,
-                  tintColor: Colors.white,
-                  activeTintColor: jellyfinBlueColor,
-                  onShowPickerView: () =>
-                      FeedbackHelper.feedback(FeedbackType.selection),
+                child: AnimatedSwitcher(
+                  duration: const Duration(milliseconds: 1000),
+                  switchOutCurve: const Threshold(0.0),
+                  child: AirPlayRoutePickerView(
+                    key: ValueKey(airplayTheme),
+                    tintColor: airplayTheme,
+                    activeTintColor: jellyfinBlueColor,
+                    onShowPickerView: () =>
+                        FeedbackHelper.feedback(FeedbackType.selection),
+                  ),
                 ),
               ),
           ],
@@ -158,6 +161,7 @@ class _PlayerScreenContent extends StatelessWidget {
                               constraints.maxHeight -
                                   controller.getTarget().height,
                               constraints.maxWidth),
+                          width: constraints.maxWidth,
                           child: const PlayerScreenAlbumImage()),
                       SongNameContent(controller),
                       ControlArea(controller),
@@ -223,6 +227,8 @@ class PlayerHideableController {
   /// Update player screen hidden elements based on usable area in portrait mode.
   void updateLayoutPortrait(Size size) {
     _reset();
+    var minAlbumPadding =
+        FinampSettingsHelper.finampSettings.playerScreenCoverMinimumPadding;
 
     var targetWidth = size.width;
     _updateLayoutFromWidth(targetWidth);
@@ -232,10 +238,9 @@ class PlayerHideableController {
     for (var element in verticalHideOrder) {
       // Allow shrinking album by up to (element.maxShrink)% of screen width per side beyond the user specified minimum value
       // if it allows us to show more controls.
-      var maxDesiredPadding =
-          FinampSettingsHelper.finampSettings.playerScreenCoverMinimumPadding +
-              element.maxShrink *
-                  FinampSettingsHelper.finampSettings.prioritizeCoverFactor;
+      var maxDesiredPadding = minAlbumPadding +
+          element.maxShrink *
+              FinampSettingsHelper.finampSettings.prioritizeCoverFactor;
       // Calculate max allowable control height to avoid shrinking album cover beyond maxPadding.
       var targetHeight =
           size.height - size.width * (1 - (maxDesiredPadding / 100.0) * 2);
@@ -244,7 +249,9 @@ class PlayerHideableController {
       }
       _visible.remove(element);
     }
-    _target = Size(targetWidth, _getSize().height);
+    var desiredHeight =
+        size.height - size.width * (1 - (minAlbumPadding / 100.0) * 2);
+    _target = Size(targetWidth, max(_getSize().height, desiredHeight));
   }
 
   /// Update player screen hidden elements based on usable area in landscape mode.

--- a/lib/services/downloads_service_backend.dart
+++ b/lib/services/downloads_service_backend.dart
@@ -1425,9 +1425,9 @@ class DownloadsSyncService {
                 "${_jellyfinApiData.defaultFields},MediaSources,SortName"))
             ?.mediaSources;
 
-    String container = downloadItem.syncTranscodingProfile?.codec.container ??
-        mediaSources?[0].container ??
-        'song';
+    // Container must be accurate because unknown container names break iOS playback
+    String? container = downloadItem.syncTranscodingProfile?.codec.container ??
+        mediaSources?[0].container;
 
     String fileName;
     String subDirectory;
@@ -1442,7 +1442,7 @@ class DownloadsSyncService {
       fileName = _filesystemSafe(
           "${item.album} - ${item.indexNumber ?? 0} - ${item.name}.$container")!;
     } else {
-      fileName = "${item.id}.$container";
+      fileName = "${item.id}${container == null ? '' : ".$container"}";
       subDirectory = "songs";
     }
 

--- a/lib/services/downloads_service_backend.dart
+++ b/lib/services/downloads_service_backend.dart
@@ -1428,6 +1428,7 @@ class DownloadsSyncService {
     // Container must be accurate because unknown container names break iOS playback
     String? container = downloadItem.syncTranscodingProfile?.codec.container ??
         mediaSources?[0].container;
+    String extension = container == null ? "" : ".$container";
 
     String fileName;
     String subDirectory;
@@ -1440,9 +1441,9 @@ class DownloadsSyncService {
           path_helper.join("finamp", _filesystemSafe(item.albumArtist));
       // We use a regex to filter out bad characters from song/album names.
       fileName = _filesystemSafe(
-          "${item.album} - ${item.indexNumber ?? 0} - ${item.name}.$container")!;
+          "${item.album} - ${item.indexNumber ?? 0} - ${item.name}$extension")!;
     } else {
-      fileName = "${item.id}${container == null ? '' : ".$container"}";
+      fileName = "${item.id}$extension";
       subDirectory = "songs";
     }
 

--- a/lib/services/jellyfin_api_helper.dart
+++ b/lib/services/jellyfin_api_helper.dart
@@ -122,7 +122,8 @@ class JellyfinApiHelper {
     }
     assert(!FinampSettingsHelper.finampSettings.isOffline);
     assert(itemIds == null || parentItem == null);
-    fields ??= defaultFields; // explicitly set the default fields, if we pass `null` to [JellyfinAPI.getItems] it will **not** apply the default fields, since the argument *is* provided.
+    fields ??=
+        defaultFields; // explicitly set the default fields, if we pass `null` to [JellyfinAPI.getItems] it will **not** apply the default fields, since the argument *is* provided.
     if (parentItem != null) {
       _jellyfinApiHelperLogger.fine("Getting children of ${parentItem.name}");
     } else if (itemIds != null) {
@@ -419,7 +420,8 @@ class JellyfinApiHelper {
   /// Updates player progress so that Jellyfin can track what we're listening to
   Future<void> updatePlaybackProgress(
       PlaybackProgressInfo playbackProgressInfo) async {
-    final response = await jellyfinApi.playbackStatusUpdate(playbackProgressInfo);
+    final response =
+        await jellyfinApi.playbackStatusUpdate(playbackProgressInfo);
     if (response.toString().isNotEmpty) {
       throw response;
     }
@@ -428,7 +430,8 @@ class JellyfinApiHelper {
   /// Tells Jellyfin that we've stopped listening to music (called when the audio service is stopped)
   Future<void> stopPlaybackProgress(
       PlaybackProgressInfo playbackProgressInfo) async {
-    final response = await jellyfinApi.playbackStatusStopped(playbackProgressInfo);
+    final response =
+        await jellyfinApi.playbackStatusStopped(playbackProgressInfo);
     if (response.toString().isNotEmpty) {
       throw response;
     }
@@ -452,7 +455,8 @@ class JellyfinApiHelper {
   Future<BaseItemDto?> getItemByIdBatched(String itemId,
       [String? fields]) async {
     assert(!FinampSettingsHelper.finampSettings.isOffline);
-    fields ??= defaultFields; // explicitly set the default fields, if we pass `null` to [JellyfinAPI.getItems] it will **not** apply the default fields, since the argument *is* provided.
+    fields ??=
+        defaultFields; // explicitly set the default fields, if we pass `null` to [JellyfinAPI.getItems] it will **not** apply the default fields, since the argument *is* provided.
     _getItemByIdBatchedRequests.add(itemId);
     _getItemByIdBatchedFuture ??=
         Future.delayed(const Duration(milliseconds: 250), () async {
@@ -514,7 +518,8 @@ class JellyfinApiHelper {
     /// changed values.
     required BaseItemDto newItem,
   }) async {
-    final response = await jellyfinApi.updateItem(itemId: itemId, newItem: newItem);
+    final response =
+        await jellyfinApi.updateItem(itemId: itemId, newItem: newItem);
     if (response.toString().isNotEmpty) {
       throw response;
     }
@@ -757,7 +762,7 @@ class JellyfinApiHelper {
       // we could use M4A/AAC.
 
       queryParameters.addAll({
-        "transcodingContainer": transcodingProfile.codec.container,
+        "transcodingContainer": transcodingProfile.codec.container!,
         "audioCodec": transcodingProfile.codec.name,
         "audioBitRate": transcodingProfile.stereoBitrate.toString(),
       });

--- a/lib/services/jellyfin_api_helper.dart
+++ b/lib/services/jellyfin_api_helper.dart
@@ -761,6 +761,8 @@ class JellyfinApiHelper {
       // Jellyfin). Once https://github.com/jellyfin/jellyfin/pull/9192 lands,
       // we could use M4A/AAC.
 
+      assert(transcodingProfile.codec.container != null, "Missing container for codec while trying to download transcoded track!");
+
       queryParameters.addAll({
         "transcodingContainer": transcodingProfile.codec.container!,
         "audioCodec": transcodingProfile.codec.name,


### PR DESCRIPTION
Fixes the .song extension applied to all downloaded original songs, which breaks iOS playback.  Also includes a couple other random tweaks I had in the branch:

- A basic fix to the fast scroller accent issue by just ignoring any items with characters beyond z.
- Queue item padding tweak.
- Apply ''Prioritize cover" player setting to landscape mode as well as portrait.
- Just make airplay button white because it can't change theme when switching songs.

Tell me if you want a cleaner version.