### PR TITLE
Fix fast scroller tripping over accented characters

### DIFF
--- a/lib/components/MusicScreen/music_screen_tab_view.dart
+++ b/lib/components/MusicScreen/music_screen_tab_view.dart
@@ -199,6 +199,7 @@ class _MusicScreenTabViewState extends State<MusicScreenTabView>
       return;
     } else {
       //TODO use binary search to improve performance for already loaded pages
+      bool reversed = FinampSettingsHelper.finampSettings.tabSortOrder[widget.tabContentType] == SortOrder.descending;
       for (var i = 0; i < _pagingController.itemList!.length; i++) {
         var itemFirstLetter =
             _pagingController.itemList![i].nameForSorting![0];
@@ -208,10 +209,22 @@ class _MusicScreenTabViewState extends State<MusicScreenTabView>
           await controller.scrollToIndex(i,
               duration: scrollDuration,
               preferPosition: AutoScrollPosition.begin);
+          
+          letterToSearch = null;
+          return;
+        } else if (reversed ? comparisonResult > 0 : comparisonResult < 0) {
+          // If the letter is before the current item, there was no previous match (letter doesn't seem to exist in library)
+          // scroll to the previous item instead
+          timer?.cancel();
+          await controller.scrollToIndex((i - 1).clamp(0, (_pagingController.itemList?.length ?? 1) - 1),
+              duration: scrollDuration,
+              preferPosition: AutoScrollPosition.begin);
+
           letterToSearch = null;
           return;
         }
       }
+
     }
 
     timer?.cancel();

--- a/lib/components/MusicScreen/music_screen_tab_view.dart
+++ b/lib/components/MusicScreen/music_screen_tab_view.dart
@@ -194,7 +194,7 @@ class _MusicScreenTabViewState extends State<MusicScreenTabView>
 
     if (letter == '#') {
       await controller.scrollToIndex(0,
-        duration: scrollDuration,
+        duration: _getAnimationDurationForOffsetToIndex(0),
         preferPosition: AutoScrollPosition.begin);
       return;
     } else {
@@ -207,7 +207,7 @@ class _MusicScreenTabViewState extends State<MusicScreenTabView>
         if (comparisonResult == 0) {
           timer?.cancel();
           await controller.scrollToIndex(i,
-              duration: scrollDuration,
+                duration: _getAnimationDurationForOffsetToIndex(i),
               preferPosition: AutoScrollPosition.begin);
           
           letterToSearch = null;
@@ -241,6 +241,16 @@ class _MusicScreenTabViewState extends State<MusicScreenTabView>
     }
     await controller.animateTo(controller.position.maxScrollExtent,
         duration: const Duration(milliseconds: 500), curve: Curves.ease);
+  }
+
+  Duration _getAnimationDurationForOffsetToIndex(int index) {
+    final renderedIndices = controller.tagMap.keys;
+    final medianIndex = renderedIndices.elementAt(renderedIndices.length ~/ 2);
+
+    final duration = Duration(
+      milliseconds: ((medianIndex - index).abs() / 50 * 300).clamp(200, 7500).round(),
+    );
+    return duration;
   }
 
   @override


### PR DESCRIPTION
- Use Dart's built-in `compareTo` function to compare the sort order of current vs. selected letter
  - This should handle stuff like accented characters for us, in a way that is logical to users
- Simplify logic a bit
- The target offset of the animation doesn't always match up with the final item offset, resulting in a sudden jump/jerk at the end. That seems to be a library bug

I also tried somehow calculating the animation duration based on the distance that needs to be scrolled to reduce lagging, but I couldn't get it to work (only in a few random cases that I couldn't reproduce). The idea was dividing the offset from current position to target position by the viewport height, and then multiplying that by 200ms (or something similar), clamping to a minimum and maximum value.  
My logic was based on `_offsetToRevealInViewport()` from `scroll_to_index`, but `controller.tagMap` never seemed to contain the needed index. Here's the (non-working) code:

```dart
Duration _getAnimationDurationForOffsetToIndex(int index) {
  final ctx = controller.tagMap[index]?.context;
  if (ctx == null) {
    return const Duration(milliseconds: 1250);
  }

  final renderBox = ctx.findRenderObject()!;
  final RenderAbstractViewport viewport = RenderAbstractViewport.of(renderBox);
  final revealedOffset = viewport.getOffsetToReveal(renderBox, 0.1);

  final viewportHeight = MediaQuery.of(context).size.height;

  final duration = Duration(
    milliseconds: ((revealedOffset.offset.abs() / viewportHeight) * 200).clamp(200, 5000).round(),
  );
  return duration;
}
```