### PR TITLE
Make sure audio handler knows queue from the start

### DIFF
--- a/lib/services/playback_history_service.dart
+++ b/lib/services/playback_history_service.dart
@@ -275,7 +275,8 @@ class PlaybackHistoryService {
         !forceNewTrack && (
           currentTrack == _currentTrack?.item ||
           currentTrack.item.id == "" ||
-          currentTrack.id == _currentTrack?.item.id
+          currentTrack.id == _currentTrack?.item.id ||
+          !_audioService.playbackState.value.playing
         )
       ) {
       // current track hasn't changed

--- a/lib/services/queue_service.dart
+++ b/lib/services/queue_service.dart
@@ -62,10 +62,8 @@ class QueueService {
   // external queue state
 
   // the audio source used by the player. The first X items of all internal queues are merged together into this source, so that all player features, like gapless playback, are supported
-  ConcatenatingAudioSource _queueAudioSource = ConcatenatingAudioSource(
-    children: [],
-  );
-  late ShuffleOrder _shuffleOrder;
+  late final ShuffleOrder _shuffleOrder;
+  late final ConcatenatingAudioSource _queueAudioSource;
   int _queueAudioSourceIndex = 0;
 
   // Flags for saving and loading saved queues
@@ -88,6 +86,7 @@ class QueueService {
       children: [],
       shuffleOrder: _shuffleOrder,
     );
+    _audioHandler.initializeAudioSource(_queueAudioSource);
 
     _audioHandler.playbackState.listen((event) async {
       // int indexDifference = (event.currentIndex ?? 0) - _queueAudioSourceIndex;


### PR DESCRIPTION
If we swipe to add to the queue after launching the app (when no queue exists), the new audio source will temporarily be added to the `_queueAudioSource`, but since the `_audioHandler` doesn't know this queue yet, `_queueFromConcatenatingAudioSource` will still see an empty queue, and thus ignore the new element. Immediately registering the audio source to the audio handler resolves this issue. Furthermore, since the two elements are only written once, they can be final.