### PR TITLE
[Redesign] Skip theme transition animation if app was in background

### DIFF
--- a/lib/components/now_playing_bar.dart
+++ b/lib/components/now_playing_bar.dart
@@ -513,10 +513,7 @@ class NowPlayingBar extends ConsumerWidget {
         tag: "nowplaying",
         createRectTween: (from, to) => RectTween(begin: from, end: from),
         child: AnimatedTheme(
-          // immediately apply new theme if in background to avoid showing wrong theme during transition
-          duration: ModalRoute.of(context)!.isCurrent
-              ? const Duration(milliseconds: 1000)
-              : const Duration(milliseconds: 0),
+          duration: getThemeTransitionDuration(context),
           data: ThemeData(
             colorScheme: imageTheme.copyWith(
               brightness: Theme.of(context).brightness,

--- a/lib/screens/blurred_player_screen_background.dart
+++ b/lib/screens/blurred_player_screen_background.dart
@@ -6,6 +6,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:octo_image/octo_image.dart';
 
 import '../services/current_album_image_provider.dart';
+import '../services/player_screen_theme_provider.dart';
 
 /// Same as [_PlayerScreenAlbumImage], but with a BlurHash instead. We also
 /// filter the BlurHash so that it works as a background image.
@@ -26,7 +27,7 @@ class BlurredPlayerScreenBackground extends ConsumerWidget {
         customImageProvider ?? ref.watch(currentAlbumImageProvider).value;
 
     return AnimatedSwitcher(
-        duration: const Duration(milliseconds: 1000),
+        duration: getThemeTransitionDuration(context),
         switchOutCurve: const Threshold(0.0),
         child: imageProvider == null
             ? const SizedBox.shrink()

--- a/lib/screens/player_screen.dart
+++ b/lib/screens/player_screen.dart
@@ -49,7 +49,7 @@ class PlayerScreen extends ConsumerWidget {
     });
 
     return AnimatedTheme(
-      duration: const Duration(milliseconds: 1000),
+      duration: getThemeTransitionDuration(context),
       data: ThemeData(
         colorScheme: imageTheme.copyWith(
           brightness: Theme.of(context).brightness,

--- a/lib/services/player_screen_theme_provider.dart
+++ b/lib/services/player_screen_theme_provider.dart
@@ -3,8 +3,10 @@ import 'dart:math';
 import 'dart:ui';
 
 import 'package:finamp/at_contrast.dart';
+import 'package:finamp/services/queue_service.dart';
 import 'package:flutter/material.dart' hide Image;
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:get_it/get_it.dart';
 import 'package:logging/logging.dart';
 import 'package:palette_generator/palette_generator.dart';
 
@@ -134,3 +136,35 @@ Color shadeColor(Color color, double factor) => Color.fromRGBO(
     shadeValue(color.green, factor),
     shadeValue(color.blue, factor),
     1);
+
+_ThemeTransitionCalculator? _calculator;
+
+Duration getThemeTransitionDuration(BuildContext context) =>
+    (_calculator ??= _ThemeTransitionCalculator())
+        .getThemeTransitionDuration(context);
+
+/// Skip track change transition animations if app or route is in background
+class _ThemeTransitionCalculator {
+  _ThemeTransitionCalculator() {
+    AppLifecycleListener(onShow: () {
+      // Continue skipping until we get a foreground track change.
+      _skipAllTransitions = true;
+    }, onHide: () {
+      _skipAllTransitions = true;
+    });
+    GetIt.instance<QueueService>().getCurrentTrackStream().listen((value) {
+      _skipAllTransitions = false;
+    });
+  }
+
+  bool _skipAllTransitions = false;
+
+  Duration getThemeTransitionDuration(BuildContext context) {
+    if (_skipAllTransitions) {
+      return const Duration(milliseconds: 0);
+    }
+    return ModalRoute.of(context)!.isCurrent
+        ? const Duration(milliseconds: 1000)
+        : const Duration(milliseconds: 0);
+  }
+}


### PR DESCRIPTION
If the app changed theme while in the background, do not animate from the last foreground theme to the current theme when returning to foreground.  Just switch to the latest theme as quickly as possible.