### PR TITLE
[Desktop Beta] Cleanup scrollbars

### DIFF
--- a/lib/components/AddToPlaylistScreen/add_to_playlist_list.dart
+++ b/lib/components/AddToPlaylistScreen/add_to_playlist_list.dart
@@ -3,8 +3,8 @@ import 'dart:async';
 import 'package:finamp/models/finamp_models.dart';
 import 'package:finamp/services/downloads_service.dart';
 import 'package:flutter/material.dart';
-import 'package:get_it/get_it.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
+import 'package:get_it/get_it.dart';
 
 import '../../models/jellyfin_models.dart';
 import '../../services/jellyfin_api_helper.dart';
@@ -42,46 +42,43 @@ class _AddToPlaylistListState extends State<AddToPlaylistList> {
       future: addToPlaylistListFuture,
       builder: (context, snapshot) {
         if (snapshot.hasData) {
-          return Scrollbar(
-            child: ListView.builder(
-              itemCount: snapshot.data!.length,
-              itemBuilder: (context, index) {
-                return AlbumItem(
-                  album: snapshot.data![index],
-                  parentType: snapshot.data![index].type,
-                  isPlaylist: true,
-                  onTap: () async {
-                    try {
-                      await jellyfinApiHelper.addItemstoPlaylist(
-                        playlistId: snapshot.data![index].id,
-                        ids: [widget.itemToAddId],
-                      );
-                      final downloadsService =
-                          GetIt.instance<DownloadsService>();
-                      unawaited(downloadsService.resync(
-                          DownloadStub.fromItem(
-                              type: DownloadItemType.collection,
-                              item: snapshot.data![index]),
-                          null,
-                          keepSlow: true));
+          return ListView.builder(
+            itemCount: snapshot.data!.length,
+            itemBuilder: (context, index) {
+              return AlbumItem(
+                album: snapshot.data![index],
+                parentType: snapshot.data![index].type,
+                isPlaylist: true,
+                onTap: () async {
+                  try {
+                    await jellyfinApiHelper.addItemstoPlaylist(
+                      playlistId: snapshot.data![index].id,
+                      ids: [widget.itemToAddId],
+                    );
+                    final downloadsService = GetIt.instance<DownloadsService>();
+                    unawaited(downloadsService.resync(
+                        DownloadStub.fromItem(
+                            type: DownloadItemType.collection,
+                            item: snapshot.data![index]),
+                        null,
+                        keepSlow: true));
 
-                      if (!mounted) return;
-                      GlobalSnackbar.message(
-                          (scaffold) => AppLocalizations.of(context)!
-                              .confirmAddedToPlaylist,
-                          isConfirmation: true);
-                      Navigator.pop(context);
-                    } catch (e) {
-                      errorSnackbar(e, context);
-                      return;
-                    }
-                  },
-                );
-              },
-            ),
+                    if (!context.mounted) return;
+                    GlobalSnackbar.message(
+                        (scaffold) => AppLocalizations.of(context)!
+                            .confirmAddedToPlaylist,
+                        isConfirmation: true);
+                    Navigator.pop(context);
+                  } catch (e) {
+                    GlobalSnackbar.error(e);
+                    return;
+                  }
+                },
+              );
+            },
           );
         } else if (snapshot.hasError) {
-          errorSnackbar(snapshot.error, context);
+          GlobalSnackbar.error(snapshot.error);
           return const Center(
             child: Icon(Icons.error, size: 64),
           );

--- a/lib/components/AddToPlaylistScreen/new_playlist_dialog.dart
+++ b/lib/components/AddToPlaylistScreen/new_playlist_dialog.dart
@@ -73,8 +73,7 @@ class _NewPlaylistDialogState extends State<NewPlaylistDialog> {
       _formKey.currentState!.save();
 
       try {
-        final newPlaylistResponse =
-            await _jellyfinApiHelper.createNewPlaylist(NewPlaylist(
+        await _jellyfinApiHelper.createNewPlaylist(NewPlaylist(
           name: _name,
           ids: [widget.itemToAdd],
           userId: _finampUserHelper.currentUser!.id,
@@ -92,15 +91,14 @@ class _NewPlaylistDialogState extends State<NewPlaylistDialog> {
 
         final downloadsService = GetIt.instance<DownloadsService>();
         unawaited(downloadsService.resync(
-            DownloadStub.fromId(
-                id: "All Playlists",
-                type: DownloadItemType.finampCollection,
-                name: AppLocalizations.of(context)!
-                    .finampCollectionNames("allPlaylists")),
+            DownloadStub.fromFinampCollection(
+                collection:
+                    FinampCollection(type: FinampCollectionType.allPlaylists),
+                name: null),
             null,
             keepSlow: true));
       } catch (e) {
-        errorSnackbar(e, context);
+        GlobalSnackbar.error(e);
         setState(() {
           _isSubmitting = false;
         });

--- a/lib/components/AlbumScreen/preset_chip.dart
+++ b/lib/components/AlbumScreen/preset_chip.dart
@@ -1,6 +1,8 @@
 import 'dart:math';
-import 'package:flutter/material.dart';
+import 'dart:ui';
+
 import 'package:finamp/services/queue_service.dart';
+import 'package:flutter/material.dart';
 import 'package:get_it/get_it.dart';
 
 const _radius = Radius.circular(4);
@@ -14,7 +16,7 @@ enum PresetTypes {
 
 class PresetChips extends StatefulWidget {
   const PresetChips({
-    Key? key,
+    super.key,
     required this.type,
     required this.values,
     required this.activeValue,
@@ -23,7 +25,7 @@ class PresetChips extends StatefulWidget {
     this.onPresetSelected,
     this.chipWidth = 64.0,
     this.chipHeight = 44.0,
-  }) : super(key: key);
+  });
 
   final PresetTypes type;
 
@@ -41,11 +43,10 @@ class PresetChips extends StatefulWidget {
 
 class _PresetChipsState extends State<PresetChips> {
   final _queueService = GetIt.instance<QueueService>();
-  final _controller = ScrollController();
-  bool scrolledAlready = false;
+  ScrollController? _controller;
 
   void scrollToActivePreset(double currentValue, double maxWidth) {
-    if (!_controller.hasClients) return;
+    if (_controller != null && !_controller!.hasClients) return;
     var offset = widget.chipWidth * widget.values.indexOf(currentValue) +
         widget.chipWidth / 2 -
         maxWidth / 2 -
@@ -54,24 +55,21 @@ class _PresetChipsState extends State<PresetChips> {
     offset = min(max(0, offset),
         widget.chipWidth * (widget.values.length) - maxWidth - _spacing);
 
-    _controller.animateTo(
-      offset,
-      duration: Duration(milliseconds: 350),
-      curve: Curves.easeOutCubic,
-    );
+    if (_controller == null) {
+      _controller = ScrollController(initialScrollOffset: offset);
+    } else {
+      _controller!.animateTo(
+        offset,
+        duration: const Duration(milliseconds: 500),
+        curve: Curves.easeOutCubic,
+      );
+    }
   }
 
   PresetChip generatePresetChip(value, BoxConstraints constraints) {
     // Scroll to the active preset
     if (value == widget.activeValue) {
-      if (scrolledAlready) {
-        scrollToActivePreset(value, constraints.maxWidth);
-      } else {
-        Future.delayed(Duration(milliseconds: 200), () {
-          scrollToActivePreset(value, constraints.maxWidth);
-        });
-        scrolledAlready = true;
-      }
+      scrollToActivePreset(value, constraints.maxWidth);
     }
 
     final stringValue = "x$value";
@@ -99,23 +97,31 @@ class _PresetChipsState extends State<PresetChips> {
   @override
   Widget build(BuildContext context) {
     return LayoutBuilder(builder: (context, constraints) {
-      return SingleChildScrollView(
-        controller: _controller,
-        scrollDirection: Axis.horizontal,
-        child: Wrap(
-          spacing: _spacing,
-          crossAxisAlignment: WrapCrossAlignment.center,
-          children: List.generate(widget.values.length,
-              (index) => generatePresetChip(widget.values[index], constraints)),
-        ),
-      );
+      // Create preset list to before scrollView to allow the scrollController
+      // initial offset to be calculated first.
+      var list = List.generate(widget.values.length,
+          (index) => generatePresetChip(widget.values[index], constraints));
+      assert(_controller != null);
+      // Allow drag scrolling on desktop
+      return ScrollConfiguration(
+          behavior: ScrollConfiguration.of(context)
+              .copyWith(dragDevices: PointerDeviceKind.values.toSet()),
+          child: SingleChildScrollView(
+            controller: _controller,
+            scrollDirection: Axis.horizontal,
+            child: Wrap(
+              spacing: _spacing,
+              crossAxisAlignment: WrapCrossAlignment.center,
+              children: list,
+            ),
+          ));
     });
   }
 }
 
 class PresetChip extends StatelessWidget {
   const PresetChip({
-    Key? key,
+    super.key,
     required this.width,
     required this.height,
     this.value = "",
@@ -123,7 +129,7 @@ class PresetChip extends StatelessWidget {
     this.backgroundColour,
     this.isSelected,
     this.isPresetDefault,
-  }) : super(key: key);
+  });
 
   final double width;
   final double height;

--- a/lib/components/AlbumScreen/preset_chip.dart
+++ b/lib/components/AlbumScreen/preset_chip.dart
@@ -60,7 +60,7 @@ class _PresetChipsState extends State<PresetChips> {
     } else {
       _controller!.animateTo(
         offset,
-        duration: const Duration(milliseconds: 500),
+        duration: Duration(milliseconds: 350),
         curve: Curves.easeOutCubic,
       );
     }

--- a/lib/components/AlbumScreen/speed_menu.dart
+++ b/lib/components/AlbumScreen/speed_menu.dart
@@ -1,15 +1,15 @@
 import 'dart:async';
 import 'dart:math';
 import 'dart:ui';
+
 import 'package:finamp/services/feedback_helper.dart';
+import 'package:finamp/services/queue_service.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter/widgets.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:flutter_tabler_icons/flutter_tabler_icons.dart';
 import 'package:flutter_vibrate/flutter_vibrate.dart';
 import 'package:get_it/get_it.dart';
 
-import 'package:finamp/services/queue_service.dart';
 import '../../services/finamp_settings_helper.dart';
 import 'preset_chip.dart';
 
@@ -22,10 +22,10 @@ const speedButtonStep = 0.10;
 
 class SpeedSlider extends StatefulWidget {
   const SpeedSlider({
-    Key? key,
+    super.key,
     required this.iconColor,
     required this.saveSpeedInput,
-  }) : super(key: key);
+  });
 
   final Color iconColor;
   final Function saveSpeedInput;
@@ -108,10 +108,10 @@ class _SpeedSliderState extends State<SpeedSlider> {
 
 class SpeedMenu extends StatefulWidget {
   const SpeedMenu({
-    Key? key,
+    super.key,
     required this.iconColor,
     this.scrollFunction,
-  }) : super(key: key);
+  });
 
   final Color iconColor;
   final Function()? scrollFunction;
@@ -166,7 +166,7 @@ class _SpeedMenuState extends State<SpeedMenu> {
         borderRadius: BorderRadius.circular(10),
         color: widget.iconColor.withOpacity(0.1),
       ),
-      margin: EdgeInsets.symmetric(horizontal: 10.0, vertical: 10.0),
+      margin: const EdgeInsets.symmetric(horizontal: 10.0, vertical: 10.0),
       child: Padding(
         padding: const EdgeInsets.only(top: 10.0, bottom: 10.0),
         child: ValueListenableBuilder(

--- a/lib/components/LanguageSelectionScreen/language_list.dart
+++ b/lib/components/LanguageSelectionScreen/language_list.dart
@@ -1,7 +1,6 @@
 import 'dart:collection';
 
 import 'package:flutter/material.dart';
-
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:locale_names/locale_names.dart';
 
@@ -25,41 +24,39 @@ class _LanguageListState extends State<LanguageList> {
 
   @override
   Widget build(BuildContext context) {
-    return Scrollbar(
-      // We have a ValueListenableBuilder here to rebuild all the ListTiles when
-      // the language changes
-      child: ValueListenableBuilder(
-        valueListenable: LocaleHelper.localeListener,
-        builder: (_, __, ___) {
-          return CustomScrollView(
-            slivers: [
-              // For some reason, setting the null (system) LanguageListTile to
-              // const stops it from switching when going to/from the same
-              // language as the system language (e.g., system to English on a
-              // device set to English)
+    // We have a ValueListenableBuilder here to rebuild all the ListTiles when
+    // the language changes
+    return ValueListenableBuilder(
+      valueListenable: LocaleHelper.localeListener,
+      builder: (_, __, ___) {
+        return CustomScrollView(
+          slivers: [
+            // For some reason, setting the null (system) LanguageListTile to
+            // const stops it from switching when going to/from the same
+            // language as the system language (e.g., system to English on a
+            // device set to English)
+            // ignore: prefer_const_constructors
+            SliverList(
               // ignore: prefer_const_constructors
-              SliverList(
+              delegate: SliverChildListDelegate.fixed([
                 // ignore: prefer_const_constructors
-                delegate: SliverChildListDelegate.fixed([
-                  // ignore: prefer_const_constructors
-                  LanguageListTile(),
-                  const Divider(),
-                ]),
-              ),
-              SliverList(
-                delegate: SliverChildBuilderDelegate(
-                  (context, index) {
-                    final locale = locales.values.elementAt(index);
+                LanguageListTile(),
+                const Divider(),
+              ]),
+            ),
+            SliverList(
+              delegate: SliverChildBuilderDelegate(
+                (context, index) {
+                  final locale = locales.values.elementAt(index);
 
-                    return LanguageListTile(locale: locale);
-                  },
-                  childCount: locales.length,
-                ),
-              )
-            ],
-          );
-        },
-      ),
+                  return LanguageListTile(locale: locale);
+                },
+                childCount: locales.length,
+              ),
+            )
+          ],
+        );
+      },
     );
   }
 }

--- a/lib/components/MusicScreen/alphabet_item_list.dart
+++ b/lib/components/MusicScreen/alphabet_item_list.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 
+import 'package:finamp/main.dart';
 import 'package:finamp/models/finamp_models.dart';
 import 'package:finamp/models/jellyfin_models.dart';
 import 'package:finamp/services/feedback_helper.dart';
@@ -19,12 +20,14 @@ class AlphabetList extends StatefulWidget {
   final SortOrder sortOrder;
 
   final Widget child;
+  final ScrollController scrollController;
 
   const AlphabetList(
       {super.key,
       required this.callback,
       required this.sortOrder,
-      required this.child});
+      required this.child,
+      required this.scrollController});
 
   @override
   State<AlphabetList> createState() => _AlphabetListState();
@@ -104,41 +107,56 @@ class _AlphabetListState extends State<AlphabetList> {
     // while dragging on alphabet, but still allows all gestures on main content.
     // I don't know why this works, there's weird interactions between the listener,
     // gestureDetecters, and the stack.-
-    
+
+    var mediaQuery = MediaQuery.of(context);
+
     return GestureDetector(
       onVerticalDragStart: (_) {},
-      child: Stack(
-        children: [
-          widget.child,
-          if (_currentSelected != null && _displayPreview)
-            Positioned(
-              left: 20,
-              top: 20,
-              child: Container(
-                width: MediaQuery.sizeOf(context).width / 3,
-                height: MediaQuery.sizeOf(context).width / 3,
-                decoration: BoxDecoration(
-                    color: Theme.of(context).cardColor.withOpacity(0.85),
-                    borderRadius: BorderRadius.circular(20)),
-                child: FittedBox(
-                    child: Text(_currentSelected!,
-                        style: const TextStyle(fontSize: 120))),
-              ),
-            ),
-          Directionality.of(context) == TextDirection.rtl
-              ? Positioned(
-                  left: 0,
-                  top: -10,
-                  bottom: -10,
-                  child: alphabetList,
-                )
-              : Positioned(
-                  right: 0,
-                  top: -10,
-                  bottom: -10,
-                  child: alphabetList,
+      // Draw scrollbar on top of fast scroller to enable interaction and improve
+      // visibility
+      child: Scrollbar(
+        controller: widget.scrollController,
+        child: Stack(
+          children: [
+            // Disable default scrollbar
+            ScrollConfiguration(
+                behavior: const FinampScrollBehavior(scrollbars: false),
+                child: MediaQuery(
+                  data: mediaQuery.copyWith(
+                      padding: mediaQuery.padding.copyWith(
+                          right: mediaQuery.padding.right + _letterHeight)),
+                  child: widget.child,
+                )),
+            if (_currentSelected != null && _displayPreview)
+              Positioned(
+                left: 20,
+                top: 20,
+                child: Container(
+                  width: MediaQuery.sizeOf(context).width / 3,
+                  height: MediaQuery.sizeOf(context).width / 3,
+                  decoration: BoxDecoration(
+                      color: Theme.of(context).cardColor.withOpacity(0.85),
+                      borderRadius: BorderRadius.circular(20)),
+                  child: FittedBox(
+                      child: Text(_currentSelected!,
+                          style: const TextStyle(fontSize: 120))),
                 ),
-        ],
+              ),
+            Directionality.of(context) == TextDirection.rtl
+                ? Positioned(
+                    left: 0,
+                    top: -10,
+                    bottom: -10,
+                    child: alphabetList,
+                  )
+                : Positioned(
+                    right: 0,
+                    top: -10,
+                    bottom: -10,
+                    child: alphabetList,
+                  ),
+          ],
+        ),
       ),
     );
   }

--- a/lib/components/MusicScreen/music_screen_tab_view.dart
+++ b/lib/components/MusicScreen/music_screen_tab_view.dart
@@ -322,24 +322,31 @@ class _MusicScreenTabViewState extends State<MusicScreenTabView>
                       ScrollViewKeyboardDismissBehavior.onDrag,
                   builderDelegate: PagedChildBuilderDelegate<BaseItemDto>(
                     itemBuilder: (context, item, index) {
-                      return AutoScrollTag(
-                        key: ValueKey(index),
-                        controller: controller,
-                        index: index,
-                        child: widget.tabContentType == TabContentType.songs
-                            ? SongListTile(
-                                key: ValueKey(item.id),
-                                item: item,
-                                isSong: true,
-                                index: Future.value(index),
-                                isShownInSearch: widget.searchTerm != null,
-                              )
-                            : AlbumItem(
-                                key: ValueKey(item.id),
-                                album: item,
-                                isPlaylist: widget.tabContentType ==
-                                    TabContentType.playlists,
-                              ),
+                      // Use right padding inherited from fast scroller minus
+                      // built-in icon padding
+                      return Padding(
+                        padding: EdgeInsets.only(
+                            right: max(
+                                0, MediaQuery.paddingOf(context).right - 20)),
+                        child: AutoScrollTag(
+                          key: ValueKey(index),
+                          controller: controller,
+                          index: index,
+                          child: widget.tabContentType == TabContentType.songs
+                              ? SongListTile(
+                                  key: ValueKey(item.id),
+                                  item: item,
+                                  isSong: true,
+                                  index: Future.value(index),
+                                  isShownInSearch: widget.searchTerm != null,
+                                )
+                              : AlbumItem(
+                                  key: ValueKey(item.id),
+                                  album: item,
+                                  isPlaylist: widget.tabContentType ==
+                                      TabContentType.playlists,
+                                ),
+                        ),
                       );
                     },
                     firstPageProgressIndicatorBuilder: (_) =>
@@ -395,18 +402,15 @@ class _MusicScreenTabViewState extends State<MusicScreenTabView>
 
           return RefreshIndicator(
             onRefresh: () async => _refresh,
-            child: Scrollbar(
-              controller: controller,
-              child: box.get("FinampSettings")!.showFastScroller &&
-                      settings.tabSortBy[widget.tabContentType] ==
-                          SortBy.sortName
-                  ? AlphabetList(
-                      callback: scrollToLetter,
-                      sortOrder: settings.tabSortOrder[widget.tabContentType] ??
-                          SortOrder.ascending,
-                      child: tabContent)
-                  : tabContent,
-            ),
+            child: box.get("FinampSettings")!.showFastScroller &&
+                    settings.tabSortBy[widget.tabContentType] == SortBy.sortName
+                ? AlphabetList(
+                    callback: scrollToLetter,
+                    scrollController: controller,
+                    sortOrder: settings.tabSortOrder[widget.tabContentType] ??
+                        SortOrder.ascending,
+                    child: tabContent)
+                : tabContent,
           );
         });
   }

--- a/lib/components/PlayerScreen/queue_list.dart
+++ b/lib/components/PlayerScreen/queue_list.dart
@@ -5,6 +5,7 @@ import 'package:finamp/components/AlbumScreen/song_menu.dart';
 import 'package:finamp/components/Buttons/simple_button.dart';
 import 'package:finamp/components/favourite_button.dart';
 import 'package:finamp/components/global_snackbar.dart';
+import 'package:finamp/main.dart';
 import 'package:finamp/models/finamp_models.dart';
 import 'package:finamp/screens/blurred_player_screen_background.dart';
 import 'package:finamp/services/feedback_helper.dart';
@@ -242,14 +243,11 @@ class _QueueListState extends State<QueueList> {
           thickness: MaterialStateProperty.all(12.0),
           // thumbVisibility: MaterialStateProperty.all(true),
           trackVisibility: MaterialStateProperty.all(false)),
-      child: Scrollbar(
+      child: CustomScrollView(
         controller: widget.scrollController,
-        interactive: true,
-        child: CustomScrollView(
-          controller: widget.scrollController,
-          physics: const BouncingScrollPhysics(),
-          slivers: _contents,
-        ),
+        scrollBehavior: const FinampScrollBehavior(interactive: true),
+        physics: const BouncingScrollPhysics(),
+        slivers: _contents,
       ),
     );
   }

--- a/lib/components/ViewSelector/no_music_libraries_message.dart
+++ b/lib/components/ViewSelector/no_music_libraries_message.dart
@@ -12,26 +12,24 @@ class NoMusicLibrariesMessage extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Center(
-      child: Scrollbar(
-        child: SingleChildScrollView(
-          child: Padding(
-            padding: const EdgeInsets.all(8),
-            child: Column(
-              children: [
-                Text(
-                  AppLocalizations.of(context)!.noMusicLibrariesTitle,
-                  style: Theme.of(context).textTheme.titleLarge,
-                  textAlign: TextAlign.center,
-                ),
-                Text(
-                  AppLocalizations.of(context)!.noMusicLibrariesBody,
-                  textAlign: TextAlign.center,
-                ),
-                ElevatedButton(
-                    onPressed: onRefresh,
-                    child: Text(AppLocalizations.of(context)!.refresh))
-              ],
-            ),
+      child: SingleChildScrollView(
+        child: Padding(
+          padding: const EdgeInsets.all(8),
+          child: Column(
+            children: [
+              Text(
+                AppLocalizations.of(context)!.noMusicLibrariesTitle,
+                style: Theme.of(context).textTheme.titleLarge,
+                textAlign: TextAlign.center,
+              ),
+              Text(
+                AppLocalizations.of(context)!.noMusicLibrariesBody,
+                textAlign: TextAlign.center,
+              ),
+              ElevatedButton(
+                  onPressed: onRefresh,
+                  child: Text(AppLocalizations.of(context)!.refresh))
+            ],
           ),
         ),
       ),

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -515,9 +515,18 @@ class ErrorScreen extends StatelessWidget {
 
 // Show scrollbars on all vertically scrolling widgets by default
 class FinampScrollBehavior extends MaterialScrollBehavior {
+  const FinampScrollBehavior(
+      {this.interactive = false, this.scrollbars = true});
+
+  final bool interactive;
+  final bool scrollbars;
+
   @override
   Widget buildScrollbar(
       BuildContext context, Widget child, ScrollableDetails details) {
+    if (!scrollbars) {
+      return child;
+    }
     switch (axisDirectionToAxis(details.direction)) {
       case Axis.horizontal:
         return child;
@@ -525,6 +534,7 @@ class FinampScrollBehavior extends MaterialScrollBehavior {
         assert(details.controller != null);
         return Scrollbar(
           controller: details.controller,
+          interactive: interactive,
           child: child,
         );
     }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -46,20 +46,20 @@ import 'screens/add_to_playlist_screen.dart';
 import 'screens/album_screen.dart';
 import 'screens/artist_screen.dart';
 import 'screens/audio_service_settings_screen.dart';
-import 'screens/downloads_location_screen.dart';
 import 'screens/customization_settings_screen.dart';
+import 'screens/downloads_location_screen.dart';
 import 'screens/downloads_screen.dart';
 import 'screens/language_selection_screen.dart';
 import 'screens/layout_settings_screen.dart';
 import 'screens/logs_screen.dart';
 import 'screens/music_screen.dart';
 import 'screens/player_screen.dart';
-import 'screens/volume_normalization_settings_screen.dart';
 import 'screens/settings_screen.dart';
 import 'screens/splash_screen.dart';
 import 'screens/tabs_settings_screen.dart';
 import 'screens/transcoding_settings_screen.dart';
 import 'screens/view_selector.dart';
+import 'screens/volume_normalization_settings_screen.dart';
 import 'services/audio_service_helper.dart';
 import 'services/jellyfin_api_helper.dart';
 import 'services/locale_helper.dart';
@@ -202,7 +202,6 @@ Future<void> setupHive() async {
   Hive.registerAdapter(LyricMetadataAdapter());
   Hive.registerAdapter(LyricLineAdapter());
   Hive.registerAdapter(LyricDtoAdapter());
-
 
   final dir = (Platform.isAndroid || Platform.isIOS)
       ? await getApplicationDocumentsDirectory()
@@ -362,7 +361,8 @@ class Finamp extends StatelessWidget {
                     ArtistScreen.routeName: (context) => const ArtistScreen(),
                     AddToPlaylistScreen.routeName: (context) =>
                         const AddToPlaylistScreen(),
-                    PlayerScreen.routeName: (context) => const PlayerScreen(),
+                    PlayerScreen.routeName: (context) => const PlayerScreen(
+                        key: ValueKey(PlayerScreen.routeName)),
                     DownloadsScreen.routeName: (context) =>
                         const DownloadsScreen(),
                     ActiveDownloadsScreen.routeName: (context) =>
@@ -441,6 +441,7 @@ class Finamp extends StatelessWidget {
                       dismissDirection: DismissDirection.horizontal,
                     ),
                   ),
+                  scrollBehavior: FinampScrollBehavior(),
                   themeMode: box.get("ThemeMode"),
                   localizationsDelegates: const [
                     AppLocalizations.delegate,
@@ -509,5 +510,23 @@ class ErrorScreen extends StatelessWidget {
         children: [ShareLogsButton(), CopyLogsButton()],
       ),
     );
+  }
+}
+
+// Show scrollbars on all vertically scrolling widgets by default
+class FinampScrollBehavior extends MaterialScrollBehavior {
+  @override
+  Widget buildScrollbar(
+      BuildContext context, Widget child, ScrollableDetails details) {
+    switch (axisDirectionToAxis(details.direction)) {
+      case Axis.horizontal:
+        return child;
+      case Axis.vertical:
+        assert(details.controller != null);
+        return Scrollbar(
+          controller: details.controller,
+          child: child,
+        );
+    }
   }
 }

--- a/lib/screens/audio_service_settings_screen.dart
+++ b/lib/screens/audio_service_settings_screen.dart
@@ -7,8 +7,8 @@ import '../components/AudioServiceSettingsScreen/buffer_duration_list_tile.dart'
 import '../components/AudioServiceSettingsScreen/loadQueueOnStartup_selector.dart';
 import '../components/AudioServiceSettingsScreen/periodic_playback_session_update_frequency_editor.dart';
 import '../components/AudioServiceSettingsScreen/report_queue_to_server_toggle.dart';
-import '../components/AudioServiceSettingsScreen/stop_foreground_selector.dart';
 import '../components/AudioServiceSettingsScreen/song_shuffle_item_count_editor.dart';
+import '../components/AudioServiceSettingsScreen/stop_foreground_selector.dart';
 
 class AudioServiceSettingsScreen extends StatelessWidget {
   const AudioServiceSettingsScreen({Key? key}) : super(key: key);
@@ -21,17 +21,15 @@ class AudioServiceSettingsScreen extends StatelessWidget {
       appBar: AppBar(
         title: Text(AppLocalizations.of(context)!.audioService),
       ),
-      body: Scrollbar(
-        child: ListView(
-          children: [
-            if (Platform.isAndroid) const StopForegroundSelector(),
-            const SongShuffleItemCountEditor(),
-            const BufferDurationListTile(),
-            const LoadQueueOnStartupSelector(),
-            const PeriodicPlaybackSessionUpdateFrequencyEditor(),
-            const ReportQueueToServerToggle(),
-          ],
-        ),
+      body: ListView(
+        children: [
+          if (Platform.isAndroid) const StopForegroundSelector(),
+          const SongShuffleItemCountEditor(),
+          const BufferDurationListTile(),
+          const LoadQueueOnStartupSelector(),
+          const PeriodicPlaybackSessionUpdateFrequencyEditor(),
+          const ReportQueueToServerToggle(),
+        ],
       ),
     );
   }

--- a/lib/screens/customization_settings_screen.dart
+++ b/lib/screens/customization_settings_screen.dart
@@ -3,8 +3,6 @@ import 'package:finamp/services/finamp_settings_helper.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 
-import '../components/LayoutSettingsScreen/TabsSettingsScreen/hide_tab_toggle.dart';
-
 class CustomizationSettingsScreen extends StatefulWidget {
   const CustomizationSettingsScreen({Key? key}) : super(key: key);
 
@@ -34,12 +32,10 @@ class _CustomizationSettingsScreenState
           )
         ],
       ),
-      body: Scrollbar(
-        child: ListView(
-          children: [
-            const PlaybackSpeedControlVisibilityDropdownListTile(),
-          ],
-        ),
+      body: ListView(
+        children: const [
+          PlaybackSpeedControlVisibilityDropdownListTile(),
+        ],
       ),
     );
   }

--- a/lib/screens/interaction_settings_screen.dart
+++ b/lib/screens/interaction_settings_screen.dart
@@ -1,12 +1,10 @@
-import 'dart:io';
-
 import 'package:flutter/material.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 
-import '../components/InteractionSettingsScreen/swipe_insert_queue_next_selector.dart';
 import '../components/InteractionSettingsScreen/FastScrollSelector.dart';
 import '../components/InteractionSettingsScreen/disable_gestures.dart';
 import '../components/InteractionSettingsScreen/disable_vibration.dart';
+import '../components/InteractionSettingsScreen/swipe_insert_queue_next_selector.dart';
 
 class InteractionSettingsScreen extends StatelessWidget {
   const InteractionSettingsScreen({Key? key}) : super(key: key);
@@ -19,15 +17,13 @@ class InteractionSettingsScreen extends StatelessWidget {
       appBar: AppBar(
         title: Text(AppLocalizations.of(context)!.interactions),
       ),
-      body: Scrollbar(
-        child: ListView(
-          children: [
-            const SwipeInsertQueueNextSelector(),
-            const FastScrollSelector(),
-            const DisableGestureSelector(),
-            const DisableVibrationSelector(),
-          ],
-        ),
+      body: ListView(
+        children: const [
+          SwipeInsertQueueNextSelector(),
+          FastScrollSelector(),
+          DisableGestureSelector(),
+          DisableVibrationSelector(),
+        ],
       ),
     );
   }

--- a/lib/screens/player_screen.dart
+++ b/lib/screens/player_screen.dart
@@ -345,7 +345,7 @@ class _PlayerScreenContent extends ConsumerWidget {
         final tweenExit = Tween(begin: beginExit, end: endExit);
         final curvedAnimation = CurvedAnimation(
           parent: animation,
-          curve: curve,
+          curve: curve.flipped,
         );
 
         return Stack(

--- a/lib/screens/player_screen.dart
+++ b/lib/screens/player_screen.dart
@@ -4,15 +4,14 @@ import 'dart:math';
 
 import 'package:balanced_text/balanced_text.dart';
 import 'package:finamp/color_schemes.g.dart';
-import 'package:finamp/components/Buttons/simple_button.dart';
 import 'package:finamp/components/AlbumScreen/song_menu.dart';
+import 'package:finamp/components/Buttons/simple_button.dart';
 import 'package:finamp/components/PlayerScreen/player_screen_appbar_title.dart';
+import 'package:finamp/models/finamp_models.dart';
 import 'package:finamp/screens/lyrics_screen.dart';
 import 'package:finamp/services/current_track_metadata_provider.dart';
-import 'package:finamp/models/finamp_models.dart';
 import 'package:finamp/services/feedback_helper.dart';
 import 'package:finamp/services/finamp_settings_helper.dart';
-import 'package:finamp/services/metadata_provider.dart';
 import 'package:finamp/services/queue_service.dart';
 import 'package:finamp/services/theme_provider.dart';
 import 'package:flutter/material.dart';
@@ -101,7 +100,8 @@ class PlayerScreen extends ConsumerWidget {
               return _PlayerScreenContent(
                   airplayTheme: imageTheme.primary,
                   toolbarHeight: toolbarHeight,
-                  maxToolbarLines: maxToolbarLines);
+                  maxToolbarLines: maxToolbarLines,
+                  playerScreen: this);
             } else {
               return const SizedBox.shrink();
             }
@@ -167,11 +167,13 @@ class _PlayerScreenContent extends ConsumerWidget {
       {super.key,
       required this.airplayTheme,
       required this.toolbarHeight,
-      required this.maxToolbarLines});
+      required this.maxToolbarLines,
+      required this.playerScreen});
 
   final Color airplayTheme;
   final double toolbarHeight;
   final int maxToolbarLines;
+  final Widget playerScreen;
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
@@ -202,7 +204,7 @@ class _PlayerScreenContent extends ConsumerWidget {
         if (direction == SwipeDirection.left && isLyricsAvailable) {
           if (!FinampSettingsHelper.finampSettings.disableGesture) {
             Navigator.of(context).push(_buildSlideRouteTransition(
-                this, const LyricsScreen(),
+                playerScreen, const LyricsScreen(),
                 routeSettings:
                     const RouteSettings(name: LyricsScreen.routeName)));
           }
@@ -323,6 +325,7 @@ class _PlayerScreenContent extends ConsumerWidget {
     );
   }
 
+  // This causes the source widget to blink if it does not have a key set.
   PageRouteBuilder _buildSlideRouteTransition(
     Widget sourceWidget,
     Widget targetWidget, {
@@ -400,7 +403,7 @@ class _PlayerScreenContent extends ConsumerWidget {
                     icon: getLyricsIcon(),
                     onPressed: () {
                       Navigator.of(context).push(_buildSlideRouteTransition(
-                          this, const LyricsScreen(),
+                          playerScreen, const LyricsScreen(),
                           routeSettings: const RouteSettings(
                               name: LyricsScreen.routeName)));
                     },

--- a/lib/screens/queue_restore_screen.dart
+++ b/lib/screens/queue_restore_screen.dart
@@ -22,15 +22,13 @@ class QueueRestoreScreen extends StatelessWidget {
       appBar: AppBar(
         title: Text(AppLocalizations.of(context)!.queuesScreen),
       ),
-      body: Scrollbar(
-        child: ListView.builder(
-          padding: const EdgeInsets.only(
-              left: 0.0, right: 0.0, top: 30.0, bottom: 45.0),
-          itemCount: queueList.length,
-          itemBuilder: (context, index) {
-            return QueueRestoreTile(info: queueList.elementAt(index));
-          },
-        ),
+      body: ListView.builder(
+        padding: const EdgeInsets.only(
+            left: 0.0, right: 0.0, top: 30.0, bottom: 45.0),
+        itemCount: queueList.length,
+        itemBuilder: (context, index) {
+          return QueueRestoreTile(info: queueList.elementAt(index));
+        },
       ),
     );
   }

--- a/lib/screens/settings_screen.dart
+++ b/lib/screens/settings_screen.dart
@@ -11,9 +11,9 @@ import 'audio_service_settings_screen.dart';
 import 'downloads_settings_screen.dart';
 import 'language_selection_screen.dart';
 import 'layout_settings_screen.dart';
-import 'volume_normalization_settings_screen.dart';
 import 'transcoding_settings_screen.dart';
 import 'view_selector.dart';
+import 'volume_normalization_settings_screen.dart';
 
 class SettingsScreen extends StatelessWidget {
   const SettingsScreen({Key? key}) : super(key: key);
@@ -43,68 +43,65 @@ class SettingsScreen extends StatelessWidget {
           )
         ],
       ),
-      body: Scrollbar(
-        child: ListView(
-          children: [
-            ListTile(
-              leading: const Icon(Icons.compress),
-              title: Text(AppLocalizations.of(context)!.transcoding),
-              onTap: () => Navigator.of(context)
-                  .pushNamed(TranscodingSettingsScreen.routeName),
-            ),
-            ListTile(
-              leading: const Icon(Icons.download),
-              title: Text(AppLocalizations.of(context)!.downloadSettings),
-              onTap: () => Navigator.of(context)
-                  .pushNamed(DownloadsSettingsScreen.routeName),
-            ),
-            ListTile(
-              leading: const Icon(Icons.music_note),
-              title: Text(AppLocalizations.of(context)!.audioService),
-              onTap: () => Navigator.of(context)
-                  .pushNamed(AudioServiceSettingsScreen.routeName),
-            ),
-            ListTile(
-              leading: const Icon(Icons.equalizer_rounded),
-              title: Text(AppLocalizations.of(context)!
-                  .volumeNormalizationSettingsTitle),
-              onTap: () => Navigator.of(context)
-                  .pushNamed(VolumeNormalizationSettingsScreen.routeName),
-            ),
-            ListTile(
-              leading: const Icon(Icons.gesture),
-              title: Text(AppLocalizations.of(context)!.interactions),
-              onTap: () => Navigator.of(context)
-                  .pushNamed(InteractionSettingsScreen.routeName),
-            ),
-            ListTile(
-              leading: const Icon(Icons.widgets),
-              title: Text(AppLocalizations.of(context)!.layoutAndTheme),
-              onTap: () => Navigator.of(context)
-                  .pushNamed(LayoutSettingsScreen.routeName),
-            ),
-            ListTile(
-              leading: const Icon(Icons.library_music),
-              title: Text(AppLocalizations.of(context)!.selectMusicLibraries),
-              subtitle: FinampSettingsHelper.finampSettings.isOffline
-                  ? Text(
-                      AppLocalizations.of(context)!.notAvailableInOfflineMode)
-                  : null,
-              enabled: !FinampSettingsHelper.finampSettings.isOffline,
-              onTap: () =>
-                  Navigator.of(context).pushNamed(ViewSelector.routeName),
-            ),
-            ListTile(
-              leading: const Icon(Icons.language),
-              title: Text(AppLocalizations.of(context)!.language),
-              subtitle: Text(LocaleHelper.locale?.nativeDisplayLanguage ??
-                  AppLocalizations.of(context)!.system),
-              onTap: () => Navigator.of(context)
-                  .pushNamed(LanguageSelectionScreen.routeName),
-            ),
-            const LogoutListTile(),
-          ],
-        ),
+      body: ListView(
+        children: [
+          ListTile(
+            leading: const Icon(Icons.compress),
+            title: Text(AppLocalizations.of(context)!.transcoding),
+            onTap: () => Navigator.of(context)
+                .pushNamed(TranscodingSettingsScreen.routeName),
+          ),
+          ListTile(
+            leading: const Icon(Icons.download),
+            title: Text(AppLocalizations.of(context)!.downloadSettings),
+            onTap: () => Navigator.of(context)
+                .pushNamed(DownloadsSettingsScreen.routeName),
+          ),
+          ListTile(
+            leading: const Icon(Icons.music_note),
+            title: Text(AppLocalizations.of(context)!.audioService),
+            onTap: () => Navigator.of(context)
+                .pushNamed(AudioServiceSettingsScreen.routeName),
+          ),
+          ListTile(
+            leading: const Icon(Icons.equalizer_rounded),
+            title: Text(
+                AppLocalizations.of(context)!.volumeNormalizationSettingsTitle),
+            onTap: () => Navigator.of(context)
+                .pushNamed(VolumeNormalizationSettingsScreen.routeName),
+          ),
+          ListTile(
+            leading: const Icon(Icons.gesture),
+            title: Text(AppLocalizations.of(context)!.interactions),
+            onTap: () => Navigator.of(context)
+                .pushNamed(InteractionSettingsScreen.routeName),
+          ),
+          ListTile(
+            leading: const Icon(Icons.widgets),
+            title: Text(AppLocalizations.of(context)!.layoutAndTheme),
+            onTap: () =>
+                Navigator.of(context).pushNamed(LayoutSettingsScreen.routeName),
+          ),
+          ListTile(
+            leading: const Icon(Icons.library_music),
+            title: Text(AppLocalizations.of(context)!.selectMusicLibraries),
+            subtitle: FinampSettingsHelper.finampSettings.isOffline
+                ? Text(AppLocalizations.of(context)!.notAvailableInOfflineMode)
+                : null,
+            enabled: !FinampSettingsHelper.finampSettings.isOffline,
+            onTap: () =>
+                Navigator.of(context).pushNamed(ViewSelector.routeName),
+          ),
+          ListTile(
+            leading: const Icon(Icons.language),
+            title: Text(AppLocalizations.of(context)!.language),
+            subtitle: Text(LocaleHelper.locale?.nativeDisplayLanguage ??
+                AppLocalizations.of(context)!.system),
+            onTap: () => Navigator.of(context)
+                .pushNamed(LanguageSelectionScreen.routeName),
+          ),
+          const LogoutListTile(),
+        ],
       ),
     );
   }

--- a/lib/screens/tabs_settings_screen.dart
+++ b/lib/screens/tabs_settings_screen.dart
@@ -31,41 +31,36 @@ class _TabsSettingsScreenState extends State<TabsSettingsScreen> {
           )
         ],
       ),
-      body: Scrollbar(
-        child: ReorderableListView.builder(
-          // buildDefaultDragHandles: false,
-          itemCount: FinampSettingsHelper.finampSettings.tabOrder.length,
-          itemBuilder: (context, index) {
-            return HideTabToggle(
-              tabContentType:
-                  FinampSettingsHelper.finampSettings.tabOrder[index],
-              key:
-                  ValueKey(FinampSettingsHelper.finampSettings.tabOrder[index]),
-              index: index,
-            );
-          },
-          onReorder: (oldIndex, newIndex) {
-            // It's a bit of a hack to call setState with no actual widget
-            // state, but it saves us from using listeners
-            setState(() {
-              // For some weird reason newIndex is one above what it should be
-              // when oldIndex is lower. This if statement is in Flutter's
-              // ReorderableListView documentation.
-              if (oldIndex < newIndex) {
-                newIndex -= 1;
-              }
+      body: ReorderableListView.builder(
+        // buildDefaultDragHandles: false,
+        itemCount: FinampSettingsHelper.finampSettings.tabOrder.length,
+        itemBuilder: (context, index) {
+          return HideTabToggle(
+            tabContentType: FinampSettingsHelper.finampSettings.tabOrder[index],
+            key: ValueKey(FinampSettingsHelper.finampSettings.tabOrder[index]),
+            index: index,
+          );
+        },
+        onReorder: (oldIndex, newIndex) {
+          // It's a bit of a hack to call setState with no actual widget
+          // state, but it saves us from using listeners
+          setState(() {
+            // For some weird reason newIndex is one above what it should be
+            // when oldIndex is lower. This if statement is in Flutter's
+            // ReorderableListView documentation.
+            if (oldIndex < newIndex) {
+              newIndex -= 1;
+            }
 
-              var currentTabOrder =
-                  FinampSettingsHelper.finampSettings.tabOrder;
+            var currentTabOrder = FinampSettingsHelper.finampSettings.tabOrder;
 
-              // move all values below newIndex down by one
-              final oldTab = currentTabOrder[oldIndex];
-              currentTabOrder.removeAt(oldIndex);
-              currentTabOrder.insert(newIndex, oldTab);
-              FinampSettingsHelper.setTabOrder(currentTabOrder);
-            });
-          },
-        ),
+            // move all values below newIndex down by one
+            final oldTab = currentTabOrder[oldIndex];
+            currentTabOrder.removeAt(oldIndex);
+            currentTabOrder.insert(newIndex, oldTab);
+            FinampSettingsHelper.setTabOrder(currentTabOrder);
+          });
+        },
       ),
     );
   }

--- a/lib/screens/transcoding_settings_screen.dart
+++ b/lib/screens/transcoding_settings_screen.dart
@@ -20,24 +20,22 @@ class TranscodingSettingsScreen extends StatelessWidget {
       appBar: AppBar(
         title: Text(AppLocalizations.of(context)!.transcoding),
       ),
-      body: Scrollbar(
-        child: ListView(
-          children: [
-            const TranscodeSwitch(),
-            const BitrateSelector(),
-            Padding(
-              padding: const EdgeInsets.all(8.0),
-              child: Text(
-                AppLocalizations.of(context)!.jellyfinUsesAACForTranscoding,
-                style: Theme.of(context).textTheme.bodySmall,
-                textAlign: TextAlign.center,
-              ),
+      body: ListView(
+        children: [
+          const TranscodeSwitch(),
+          const BitrateSelector(),
+          Padding(
+            padding: const EdgeInsets.all(8.0),
+            child: Text(
+              AppLocalizations.of(context)!.jellyfinUsesAACForTranscoding,
+              style: Theme.of(context).textTheme.bodySmall,
+              textAlign: TextAlign.center,
             ),
-            const DownloadTranscodeEnableDropdownListTile(),
-            const DownloadTranscodeCodecDropdownListTile(),
-            const DownloadBitrateSelector(),
-          ],
-        ),
+          ),
+          const DownloadTranscodeEnableDropdownListTile(),
+          const DownloadTranscodeCodecDropdownListTile(),
+          const DownloadBitrateSelector(),
+        ],
       ),
     );
   }

--- a/lib/screens/view_selector.dart
+++ b/lib/screens/view_selector.dart
@@ -3,11 +3,11 @@ import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:get_it/get_it.dart';
 
 import '../components/ViewSelector/no_music_libraries_message.dart';
-import '../services/finamp_user_helper.dart';
-import 'music_screen.dart';
-import '../services/jellyfin_api_helper.dart';
-import '../models/jellyfin_models.dart';
 import '../components/global_snackbar.dart';
+import '../models/jellyfin_models.dart';
+import '../services/finamp_user_helper.dart';
+import '../services/jellyfin_api_helper.dart';
+import 'music_screen.dart';
 
 class ViewSelector extends StatefulWidget {
   const ViewSelector({Key? key}) : super(key: key);
@@ -80,31 +80,29 @@ class _ViewSelectorState extends State<ViewSelector> {
                     child: const Icon(Icons.check),
                   )
                 : null,
-            body: Scrollbar(
-              child: ListView.builder(
-                itemCount: _views.length,
-                itemBuilder: (context, index) {
-                  final isSelected = _views.values.elementAt(index);
-                  final view = _views.keys.elementAt(index);
+            body: ListView.builder(
+              itemCount: _views.length,
+              itemBuilder: (context, index) {
+                final isSelected = _views.values.elementAt(index);
+                final view = _views.keys.elementAt(index);
 
-                  return CheckboxListTile(
-                    value: isSelected,
-                    enabled: view.collectionType == "music",
-                    title: Text(_views.keys.elementAt(index).name ??
-                        AppLocalizations.of(context)!.unknownName),
-                    onChanged: (value) {
-                      setState(() {
-                        _views[_views.keys.elementAt(index)] = value!;
-                        isSubmitButtonEnabled = _views.values.contains(true);
-                      });
-                    },
-                  );
-                },
-              ),
+                return CheckboxListTile(
+                  value: isSelected,
+                  enabled: view.collectionType == "music",
+                  title: Text(_views.keys.elementAt(index).name ??
+                      AppLocalizations.of(context)!.unknownName),
+                  onChanged: (value) {
+                    setState(() {
+                      _views[_views.keys.elementAt(index)] = value!;
+                      isSubmitButtonEnabled = _views.values.contains(true);
+                    });
+                  },
+                );
+              },
             ),
           );
         } else if (snapshot.hasError) {
-          errorSnackbar(snapshot.error, context);
+          GlobalSnackbar.error(snapshot.error);
           // TODO: Let the user refresh the page
           return const Center(child: Icon(Icons.error));
         } else {
@@ -129,7 +127,7 @@ class _ViewSelectorState extends State<ViewSelector> {
         Future.microtask(() => Navigator.of(context)
             .pushNamedAndRemoveUntil(MusicScreen.routeName, (route) => false));
       } catch (e) {
-        errorSnackbar(e, context);
+        GlobalSnackbar.error(e);
       }
     }
   }

--- a/lib/screens/volume_normalization_settings_screen.dart
+++ b/lib/screens/volume_normalization_settings_screen.dart
@@ -4,8 +4,8 @@ import 'package:flutter/material.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 
 import '../components/VolumeNormalizationSettingsScreen/volume_normalization_ios_base_gain_editor.dart';
-import '../components/VolumeNormalizationSettingsScreen/volume_normalization_switch.dart';
 import '../components/VolumeNormalizationSettingsScreen/volume_normalization_mode_selector.dart';
+import '../components/VolumeNormalizationSettingsScreen/volume_normalization_switch.dart';
 
 class VolumeNormalizationSettingsScreen extends StatelessWidget {
   const VolumeNormalizationSettingsScreen({Key? key}) : super(key: key);
@@ -19,15 +19,12 @@ class VolumeNormalizationSettingsScreen extends StatelessWidget {
         title: Text(
             AppLocalizations.of(context)!.volumeNormalizationSettingsTitle),
       ),
-      body: Scrollbar(
-        child: ListView(
-          children: [
-            const VolumeNormalizationSwitch(),
-            if (!Platform.isAndroid)
-              const VolumeNormalizationIOSBaseGainEditor(),
-            const VolumeNormalizationModeSelector(),
-          ],
-        ),
+      body: ListView(
+        children: [
+          const VolumeNormalizationSwitch(),
+          if (!Platform.isAndroid) const VolumeNormalizationIOSBaseGainEditor(),
+          const VolumeNormalizationModeSelector(),
+        ],
       ),
     );
   }

--- a/lib/services/jellyfin_api_helper.dart
+++ b/lib/services/jellyfin_api_helper.dart
@@ -536,9 +536,8 @@ class JellyfinApiHelper {
 
     final downloadsService = GetIt.instance<DownloadsService>();
     unawaited(downloadsService.resync(
-        DownloadStub.fromId(
-            id: "Favorites",
-            type: DownloadItemType.finampCollection,
+        DownloadStub.fromFinampCollection(
+            collection: FinampCollection(type: FinampCollectionType.favorites),
             name: null),
         null,
         keepSlow: true));
@@ -553,9 +552,8 @@ class JellyfinApiHelper {
 
     final downloadsService = GetIt.instance<DownloadsService>();
     unawaited(downloadsService.resync(
-        DownloadStub.fromId(
-            id: "Favorites",
-            type: DownloadItemType.finampCollection,
+        DownloadStub.fromFinampCollection(
+            collection: FinampCollection(type: FinampCollectionType.favorites),
             name: null),
         null,
         keepSlow: true));


### PR DESCRIPTION
Due to an error when scrolling on desktop, I previously removed the Scrollbar widgets from many lists.  However, it seems that while scrollbars are still shown on desktop, they are not on mobile.  This corrects that and shows scrollbars on mobile while also cleaning up the remaining Scrollbar widgets with no explicit ScrollController.  Also, I noticed some blinking on the lyrics screen slide transition, so I fixed that.