### PR TITLE
Add desktop entry m4 template

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -47,3 +47,13 @@ The biggest main piece of work being done on Finamp at the moment is the redesig
 Finamp uses Weblate to manage translations: **https://hosted.weblate.org/engage/finamp/**
 
 Feel free to add new languages if yours isn't there yet. If you have any questions, such as the context of a string, you can ask in the [Translation Discussions](https://github.com/jmshrv/finamp/discussions/categories/translations).
+
+## Packaging
+
+### Linux
+
+Linux packaging might vary depending on distribution and type of installation.
+Please follow the guidelines of your distribution if you would like to package Finamp for it.
+The repo contains a [desktop file template](assets/finamp.desktop.m4) and
+pre-generated icons following the XDG Icon Theme Specification
+in the [assets folder](assets/icon/linux).

--- a/assets/finamp.desktop.m4
+++ b/assets/finamp.desktop.m4
@@ -1,3 +1,4 @@
+dnl Desktop file entry for Finamp on Linux. Use m4 to generate the final file.
 [Desktop Entry]
 Type=Application
 Name=Finamp
@@ -6,4 +7,4 @@ Icon=finamp
 Exec=__INSTALL_PATH__/finamp
 Terminal=false
 Categories=AudioVideo;Audio;Player;Music;
-Comment=A Jellyfin music client for mobile and desktop
+Comment=An open source Jellyfin music player

--- a/assets/finamp.desktop.m4
+++ b/assets/finamp.desktop.m4
@@ -1,0 +1,9 @@
+[Desktop Entry]
+Type=Application
+Name=Finamp
+GenericName=Music Player
+Icon=finamp
+Exec=__INSTALL_PATH__/finamp
+Terminal=false
+Categories=AudioVideo;Audio;Player;Music;
+Comment=A Jellyfin music client for mobile and desktop


### PR DESCRIPTION
Instead of making packagers ship this themselves, this should be a predefined template in the upstream repo.