### PR TITLE
[Redesign] Download orphan tracks with library

### DIFF
--- a/lib/components/DownloadsScreen/item_file_size.dart
+++ b/lib/components/DownloadsScreen/item_file_size.dart
@@ -22,10 +22,11 @@ class ItemFileSize extends ConsumerWidget {
         ref.watch(isarDownloader.itemProvider(stub).future).then((item) {
       switch (item?.state) {
         case DownloadItemState.notDownloaded:
-          if (isarDownloader.getStatus(item!, null).isRequired) {
-            return Future.value(syncingText);
-          } else {
+          if (isarDownloader.getStatus(item!, null) ==
+              DownloadItemStatus.notNeeded) {
             return Future.value(deletingText);
+          } else {
+            return Future.value(syncingText);
           }
         case DownloadItemState.syncFailed:
           return Future.value(syncingText);

--- a/lib/components/MusicScreen/music_screen_tab_view.dart
+++ b/lib/components/MusicScreen/music_screen_tab_view.dart
@@ -1,11 +1,10 @@
 import 'dart:async';
 import 'dart:math';
 
-import 'package:collection/collection.dart';
 import 'package:Finamp/services/finamp_user_helper.dart';
+import 'package:collection/collection.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter/src/rendering/sliver.dart';
-import 'package:flutter/src/rendering/sliver_grid.dart';
+import 'package:flutter/rendering.dart';
 import 'package:get_it/get_it.dart';
 import 'package:hive/hive.dart';
 import 'package:infinite_scroll_pagination/infinite_scroll_pagination.dart';
@@ -182,7 +181,7 @@ class _MusicScreenTabViewState extends State<MusicScreenTabView>
             Rect.fromLTRB(0, 0, 0, MediaQuery.of(context).padding.bottom),
         axis: Axis.vertical);
     _refreshStream = _isarDownloader.offlineDeletesStream.listen((event) {
-      _pagingController.refresh();
+      _refresh();
     });
     super.initState();
   }

--- a/lib/models/finamp_models.dart
+++ b/lib/models/finamp_models.dart
@@ -1057,7 +1057,8 @@ class DownloadItem extends DownloadStub {
   DownloadItem? copyWith(
       {BaseItemDto? item,
       List<DownloadStub>? orderedChildItems,
-      String? viewId}) {
+      String? viewId,
+      required bool forceCopy}) {
     String? json;
     if (type == DownloadItemType.image) {
       // Images do not have any attributes we might want to update
@@ -1074,17 +1075,19 @@ class DownloadItem extends DownloadStub {
       // overwrite with null if the new item does not have them.
       item.mediaSources ??= baseItem?.mediaSources;
       item.mediaStreams ??= baseItem?.mediaStreams;
-      item.childCount ??= baseItem?.childCount;
+      item.sortName ??= baseItem?.sortName;
     }
     assert(item == null ||
         ((item.mediaSources == null || item.mediaSources!.isNotEmpty) &&
             (item.mediaStreams == null || item.mediaStreams!.isNotEmpty)));
     var orderedChildren = orderedChildItems?.map((e) => e.isarId).toList();
-    if (viewId == null || viewId == this.viewId) {
-      if (item == null || baseItem!.mostlyEqual(item)) {
-        var equal = const DeepCollectionEquality().equals;
-        if (equal(orderedChildren, this.orderedChildren)) {
-          return null;
+    if (!forceCopy) {
+      if (viewId == null || viewId == this.viewId) {
+        if (item == null || baseItem!.mostlyEqual(item)) {
+          var equal = const DeepCollectionEquality().equals;
+          if (equal(orderedChildren, this.orderedChildren)) {
+            return null;
+          }
         }
       }
     }

--- a/lib/models/jellyfin_models.dart
+++ b/lib/models/jellyfin_models.dart
@@ -7,8 +7,8 @@
 ///
 /// These classes should be correct with Jellyfin 10.7.5
 
-import 'package:collection/collection.dart';
 import 'package:Finamp/models/finamp_models.dart';
+import 'package:collection/collection.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:hive/hive.dart';
@@ -2277,6 +2277,7 @@ class BaseItemDto with RunTimeTickDuration {
         equal(other.artists, artists) &&
         other.albumArtist == albumArtist &&
         other.childCount == childCount &&
+        other.imageId == imageId &&
         other.mediaSources?.length == mediaSources?.length &&
         other.mediaStreams?.length == mediaStreams?.length &&
         other.normalizationGain == normalizationGain &&

--- a/lib/models/jellyfin_models.dart
+++ b/lib/models/jellyfin_models.dart
@@ -2278,6 +2278,9 @@ class BaseItemDto with RunTimeTickDuration {
         other.albumArtist == albumArtist &&
         other.childCount == childCount &&
         other.imageId == imageId &&
+        // imageId does not necessarily change when the image is updated, so
+        // we must compare blurHashes as well.
+        other.blurHash == blurHash &&
         other.mediaSources?.length == mediaSources?.length &&
         other.mediaStreams?.length == mediaStreams?.length &&
         other.normalizationGain == normalizationGain &&

--- a/lib/services/downloads_service.dart
+++ b/lib/services/downloads_service.dart
@@ -2,10 +2,10 @@ import 'dart:async';
 import 'dart:collection';
 import 'dart:io';
 
-import 'package:background_downloader/background_downloader.dart';
-import 'package:collection/collection.dart';
 import 'package:Finamp/components/global_snackbar.dart';
 import 'package:Finamp/services/jellyfin_api_helper.dart';
+import 'package:background_downloader/background_downloader.dart';
+import 'package:collection/collection.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';

--- a/lib/services/downloads_service_backend.dart
+++ b/lib/services/downloads_service_backend.dart
@@ -13,6 +13,7 @@ import 'package:isar/isar.dart';
 import 'package:json_annotation/json_annotation.dart';
 import 'package:logging/logging.dart';
 import 'package:path/path.dart' as path_helper;
+import 'package:uuid/uuid.dart';
 
 import '../models/finamp_models.dart';
 import '../models/jellyfin_models.dart';
@@ -1592,9 +1593,8 @@ class DownloadsSyncService {
           path_helper.join(downloadLocation.currentPath, subDirectory);
     }
 
-    // We still use imageIds for filenames despite switching to blurhashes as
-    // blurhashes can include characters that filesystems don't support
-    final fileName = "${_filesystemSafe(item.imageId)!}.image";
+    // Always use a new, unique filename when creating image downloads
+    final fileName = "${const Uuid().v4()}.image";
 
     _isar.writeTxnSync(() {
       DownloadItem? canonItem =

--- a/lib/services/jellyfin_api_helper.dart
+++ b/lib/services/jellyfin_api_helper.dart
@@ -106,6 +106,7 @@ class JellyfinApiHelper {
     List<String>? itemIds,
     String? filters,
     String? fields,
+    bool? recursive,
 
     /// The record index to start at. All items with a lower index will be
     /// dropped from the results.
@@ -127,6 +128,8 @@ class JellyfinApiHelper {
     assert(itemIds == null || parentItem == null);
     fields ??=
         defaultFields; // explicitly set the default fields, if we pass `null` to [JellyfinAPI.getItems] it will **not** apply the default fields, since the argument *is* provided.
+    recursive ??= true;
+
     if (parentItem != null) {
       _jellyfinApiHelperLogger.fine("Getting children of ${parentItem.name}");
     } else if (itemIds != null) {
@@ -148,14 +151,14 @@ class JellyfinApiHelper {
           userId: currentUserId,
           parentId: parentItem.id,
           includeItemTypes: includeItemTypes,
-          recursive: true,
+          recursive: recursive,
           fields: fields,
         );
       } else if (includeItemTypes == "MusicArtist") {
         // For artists, we need to use a different endpoint
         response = await api.getAlbumArtists(
           parentId: parentItem?.id,
-          recursive: true,
+          recursive: recursive,
           sortBy: sortBy,
           sortOrder: sortOrder,
           searchTerm: searchTerm,
@@ -172,7 +175,7 @@ class JellyfinApiHelper {
           userId: currentUserId,
           albumArtistIds: parentItem?.id,
           includeItemTypes: includeItemTypes,
-          recursive: true,
+          recursive: recursive,
           sortBy: sortBy,
           sortOrder: sortOrder,
           searchTerm: searchTerm,
@@ -195,7 +198,7 @@ class JellyfinApiHelper {
           userId: currentUserId,
           genreIds: parentItem?.id,
           includeItemTypes: includeItemTypes,
-          recursive: true,
+          recursive: recursive,
           sortBy: sortBy,
           sortOrder: sortOrder,
           searchTerm: searchTerm,
@@ -211,7 +214,7 @@ class JellyfinApiHelper {
           userId: currentUserId,
           parentId: parentItem?.id,
           includeItemTypes: includeItemTypes,
-          recursive: true,
+          recursive: recursive,
           sortBy: sortBy,
           sortOrder: sortOrder,
           searchTerm: searchTerm,


### PR DESCRIPTION
Download orphan tracks which are not contained in any album when downloading library.  Actual functionality not yet tested as I don't have any orphan tracks.

Also forces full metadata refresh during download repair, adds some comments, cleans up unneeded childCount references, fixes showing deleting instead of syncing on subitems on the downloads screen, update playlist image on sync, and properly remove syncFailed state.