### PR TITLE
[Redesign] Fix syncing legacy FinampCollections.

### DIFF
--- a/lib/components/AlbumScreen/download_dialog.dart
+++ b/lib/components/AlbumScreen/download_dialog.dart
@@ -43,13 +43,13 @@ class DownloadDialog extends StatefulWidget {
       viewId = finampUserHelper.currentUser!.currentViewId;
     }
     bool needTranscode = FinampSettingsHelper
-                .finampSettings.shouldTranscodeDownloads ==
-            TranscodeDownloadsSetting.ask &&
-        // Skip asking for transcode for image only collection
-        (item.finampCollection?.type != FinampCollectionType.libraryImages ||
-            // Skip asking for transcode for metadata +image collection
-            item.finampCollection?.type !=
-                FinampCollectionType.allPlaylistsMetadata);
+                    .finampSettings.shouldTranscodeDownloads ==
+                TranscodeDownloadsSetting.ask &&
+            // Skip asking for transcode for image only collection
+            item.finampCollection?.type != FinampCollectionType.libraryImages ||
+        // Skip asking for transcode for metadata +image collection
+        item.finampCollection?.type !=
+            FinampCollectionType.allPlaylistsMetadata;
     String? downloadLocation =
         FinampSettingsHelper.finampSettings.defaultDownloadLocation;
     if (!FinampSettingsHelper.finampSettings.downloadLocationsMap

--- a/lib/components/AlbumScreen/download_dialog.dart
+++ b/lib/components/AlbumScreen/download_dialog.dart
@@ -42,14 +42,14 @@ class DownloadDialog extends StatefulWidget {
       final finampUserHelper = GetIt.instance<FinampUserHelper>();
       viewId = finampUserHelper.currentUser!.currentViewId;
     }
-    bool needTranscode = FinampSettingsHelper
-                    .finampSettings.shouldTranscodeDownloads ==
+    bool needTranscode =
+        FinampSettingsHelper.finampSettings.shouldTranscodeDownloads ==
                 TranscodeDownloadsSetting.ask &&
             // Skip asking for transcode for image only collection
-            item.finampCollection?.type != FinampCollectionType.libraryImages ||
-        // Skip asking for transcode for metadata +image collection
-        item.finampCollection?.type !=
-            FinampCollectionType.allPlaylistsMetadata;
+            item.finampCollection?.type != FinampCollectionType.libraryImages &&
+            // Skip asking for transcode for metadata +image collection
+            item.finampCollection?.type !=
+                FinampCollectionType.allPlaylistsMetadata;
     String? downloadLocation =
         FinampSettingsHelper.finampSettings.defaultDownloadLocation;
     if (!FinampSettingsHelper.finampSettings.downloadLocationsMap

--- a/lib/components/AlbumScreen/song_list_tile.dart
+++ b/lib/components/AlbumScreen/song_list_tile.dart
@@ -1,5 +1,7 @@
 import 'dart:async';
 
+import 'package:audio_service/audio_service.dart';
+import 'package:collection/collection.dart';
 import 'package:finamp/components/AlbumScreen/song_menu.dart';
 import 'package:finamp/components/MusicScreen/music_screen_tab_view.dart';
 import 'package:finamp/components/global_snackbar.dart';
@@ -7,8 +9,6 @@ import 'package:finamp/models/finamp_models.dart';
 import 'package:finamp/models/jellyfin_models.dart' as jellyfin_models;
 import 'package:finamp/services/finamp_user_helper.dart';
 import 'package:finamp/services/queue_service.dart';
-import 'package:audio_service/audio_service.dart';
-import 'package:collection/collection.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
@@ -180,15 +180,15 @@ class _SongListTileState extends ConsumerState<SongListTile>
                     if (widget.item.hasLyrics ?? false)
                       WidgetSpan(
                         child: Transform.translate(
-                          offset: const Offset(-2.5, 0),
-                          child: Icon(
-                            TablerIcons.microphone_2,
-                            size: Theme.of(context)
-                                  .textTheme
-                                  .bodyMedium!
-                                  .fontSize! + 2,
-                          )
-                        ),
+                            offset: const Offset(-2.5, 0),
+                            child: Icon(
+                              TablerIcons.microphone_2,
+                              size: Theme.of(context)
+                                      .textTheme
+                                      .bodyMedium!
+                                      .fontSize! +
+                                  2,
+                            )),
                         alignment: PlaceholderAlignment.top,
                       ),
                     TextSpan(
@@ -284,7 +284,9 @@ class _SongListTileState extends ConsumerState<SongListTile>
                       // nameFilter: widget.searchTerm,
                       viewFilter: finampUserHelper.currentUser?.currentView?.id,
                       nullableViewFilters:
-                          settings.showDownloadsWithUnknownLibrary);
+                          settings.showDownloadsWithUnknownLibrary,
+                      onlyFavorites: FinampSettingsHelper
+                          .finampSettings.onlyShowFavourite);
 
                   var items = offlineItems
                       .map((e) => e.baseItem)
@@ -312,8 +314,10 @@ class _SongListTileState extends ConsumerState<SongListTile>
                     ),
                   );
                 } else {
-                  if (FinampSettingsHelper.finampSettings.startInstantMixForIndividualTracks) {
-                    await _audioServiceHelper.startInstantMixForItem(widget.item);
+                  if (FinampSettingsHelper
+                      .finampSettings.startInstantMixForIndividualTracks) {
+                    await _audioServiceHelper
+                        .startInstantMixForItem(widget.item);
                   } else {
                     await _queueService.startPlayback(
                       items: [widget.item],

--- a/lib/components/PlayerScreen/feature_chips.dart
+++ b/lib/components/PlayerScreen/feature_chips.dart
@@ -40,6 +40,10 @@ class FeatureState {
       ? null
       : metadata?.mediaSourceInfo.mediaStreams
           .firstWhereOrNull((stream) => stream.type == "Audio");
+  // Transcoded downloads will not have a valid MediaStream, but will have
+  // the target transcode bitrate set for the mediasource bitrate.  Other items
+  // should have a valid mediaStream, so use that audio-only bitrate instead of the
+  // whole-file bitrate.
   int? get bitrate => isTranscoding
       ? settings.transcodeBitrate
       : audioStream?.bitRate ?? metadata?.mediaSourceInfo.bitrate;

--- a/lib/components/PlayerScreen/feature_chips.dart
+++ b/lib/components/PlayerScreen/feature_chips.dart
@@ -36,8 +36,10 @@ class FeatureState {
   String get container =>
       isTranscoding ? "aac" : metadata?.mediaSourceInfo.container ?? "";
   int? get size => isTranscoding ? null : metadata?.mediaSourceInfo.size;
-  MediaStream? get audioStream => metadata?.mediaSourceInfo.mediaStreams
-      .firstWhereOrNull((stream) => stream.type == "Audio");
+  MediaStream? get audioStream => isTranscoding
+      ? null
+      : metadata?.mediaSourceInfo.mediaStreams
+          .firstWhereOrNull((stream) => stream.type == "Audio");
   int? get bitrate => isTranscoding
       ? settings.transcodeBitrate
       : audioStream?.bitRate ?? metadata?.mediaSourceInfo.bitrate;

--- a/lib/models/finamp_models.dart
+++ b/lib/models/finamp_models.dart
@@ -177,7 +177,8 @@ class FinampSettings {
     this.showArtistChipImage = _showArtistChipImage,
     this.trackOfflineFavorites = _trackOfflineFavoritesDefault,
     this.showProgressOnNowPlayingBar = _showProgressOnNowPlayingBarDefault,
-    this.startInstantMixForIndividualTracks = _startInstantMixForIndividualTracksDefault,
+    this.startInstantMixForIndividualTracks =
+        _startInstantMixForIndividualTracksDefault,
   });
 
   @HiveField(0, defaultValue: _isOfflineDefault)
@@ -924,10 +925,22 @@ class DownloadStub {
   BaseItemDto? _baseItemCached;
 
   @ignore
-  FinampCollection? get finampCollection => _finampCollectionCached ??=
-      ((jsonItem == null || type != DownloadItemType.finampCollection)
+  FinampCollection? get finampCollection =>
+      _finampCollectionCached ??= (type != DownloadItemType.finampCollection
           ? null
-          : FinampCollection.fromJson(jsonDecode(jsonItem!)));
+          : jsonItem == null
+              // Switch on ID to allow legacy collections to continue syncing
+              ? switch (id) {
+                  "Favorites" =>
+                    FinampCollection(type: FinampCollectionType.favorites),
+                  "All Playlists" =>
+                    FinampCollection(type: FinampCollectionType.allPlaylists),
+                  "5 Latest Albums" =>
+                    FinampCollection(type: FinampCollectionType.latest5Albums),
+                  _ =>
+                    throw "Invalid FinampCollection DownloadItem: no attached collection"
+                }
+              : FinampCollection.fromJson(jsonDecode(jsonItem!)));
 
   @ignore
   FinampCollection? _finampCollectionCached;

--- a/lib/models/jellyfin_models.dart
+++ b/lib/models/jellyfin_models.dart
@@ -2206,7 +2206,7 @@ class BaseItemDto with RunTimeTickDuration {
 
   /// Custom helper field to determine if the BaseItemDto was created in offline mode
   bool? finampOffline;
-  
+
   /// Checks if the item has its own image (not inherited from a parent)
   bool get hasOwnImage => imageTags?.containsKey("Primary") ?? false;
 
@@ -2710,7 +2710,7 @@ class MediaStream {
   @HiveField(28)
   String? profile;
 
-  /// Enum: "Audio" "Video" "Subtitle" "EmbeddedImage"
+  /// Enum: "Audio" "Video" "Subtitle" "EmbeddedImage" "Data" "Lyric"
   /// Gets or sets the type.
   @HiveField(29)
   String type;

--- a/lib/services/downloads_service_backend.dart
+++ b/lib/services/downloads_service_backend.dart
@@ -1237,7 +1237,7 @@ class DownloadsSyncService {
       _metadataCache[id] = itemFetch.future;
       item = await _jellyfinApiData
           .getItemByIdBatched(id,
-              "${_jellyfinApiData.defaultFields},childCount,sortName,MediaSources,MediaStreams")
+              "${_jellyfinApiData.defaultFields},sortName,MediaSources,MediaStreams")
           .then((value) => value == null
               ? null
               : DownloadStub.fromItem(item: value, type: type));
@@ -1339,6 +1339,8 @@ class DownloadsSyncService {
       DownloadStub parent) async {
     assert(parent.type == DownloadItemType.finampCollection);
     FinampCollection collection = parent.finampCollection!;
+    final String fields =
+        "${_jellyfinApiData.defaultFields},MediaSources,MediaStreams,SortName";
     try {
       List<BaseItemDto> outputItems;
       DownloadItemType? typeOverride;
@@ -1347,45 +1349,55 @@ class DownloadsSyncService {
           outputItems = await _jellyfinApiData.getItems(
                 includeItemTypes: "Audio,MusicAlbum,Playlist",
                 filters: "IsFavorite",
+                fields: fields,
               ) ??
               [];
           // Artists use a different endpoint, so request those separately
           outputItems.addAll(await _jellyfinApiData.getItems(
                 includeItemTypes: "MusicArtist",
                 filters: "IsFavorite",
+                fields: fields,
               ) ??
               []);
         case FinampCollectionType.allPlaylists:
         case FinampCollectionType.allPlaylistsMetadata:
           outputItems = await _jellyfinApiData.getItems(
                 includeItemTypes: "Playlist",
+                fields: fields,
               ) ??
               [];
         case FinampCollectionType.latest5Albums:
           outputItems = await _jellyfinApiData.getLatestItems(
-                  includeItemTypes: "MusicAlbum", limit: 5) ??
+                includeItemTypes: "MusicAlbum",
+                limit: 5,
+                fields: fields,
+              ) ??
               [];
         case FinampCollectionType.libraryImages:
           outputItems = await _jellyfinApiData.getItems(
                 parentItem: collection.library!,
                 includeItemTypes: "MusicAlbum",
+                fields: fields,
               ) ??
               [];
           // Playlists need to be fetched without libraries
           outputItems.addAll(await _jellyfinApiData.getItems(
                 includeItemTypes: "Playlist",
+                fields: fields,
               ) ??
               []);
           // Artists use a different endpoint, so request those separately
           outputItems.addAll(await _jellyfinApiData.getItems(
                 parentItem: collection.library!,
                 includeItemTypes: "MusicArtist",
+                fields: fields,
               ) ??
               []);
           // Genres use a different endpoint, so request those separately
           outputItems.addAll(await _jellyfinApiData.getItems(
                 parentItem: collection.library!,
                 includeItemTypes: "MusicGenre",
+                fields: fields,
               ) ??
               []);
           outputItems.removeWhere((element) => element.imageId == null);
@@ -1512,7 +1524,7 @@ class DownloadsSyncService {
 
     // Container must be accurate because unknown container names break iOS playback
     String? container = downloadItem.syncTranscodingProfile?.codec.container ??
-        mediaSources?[0].container;
+        mediaSources?.firstOrNull?.container;
     String extension = container == null ? "" : ".$container";
 
     String fileName;

--- a/lib/services/downloads_service_backend.dart
+++ b/lib/services/downloads_service_backend.dart
@@ -1338,18 +1338,7 @@ class DownloadsSyncService {
   Future<List<DownloadStub>> _getFinampCollectionChildren(
       DownloadStub parent) async {
     assert(parent.type == DownloadItemType.finampCollection);
-    FinampCollection collection;
-    // Switch on ID to allow legacy collections to continue syncing
-    switch (parent.id) {
-      case "Favorites":
-        collection = FinampCollection(type: FinampCollectionType.favorites);
-      case "All Playlists":
-        collection = FinampCollection(type: FinampCollectionType.allPlaylists);
-      case "5 Latest Albums":
-        collection = FinampCollection(type: FinampCollectionType.latest5Albums);
-      case _:
-        collection = parent.finampCollection!;
-    }
+    FinampCollection collection = parent.finampCollection!;
     try {
       List<BaseItemDto> outputItems;
       DownloadItemType? typeOverride;

--- a/lib/services/jellyfin_api_helper.dart
+++ b/lib/services/jellyfin_api_helper.dart
@@ -234,14 +234,18 @@ class JellyfinApiHelper {
     BaseItemDto? parentItem,
     String? includeItemTypes,
     int? limit,
+    String? fields,
   }) async {
     assert(!FinampSettingsHelper.finampSettings.isOffline);
+
+    fields ??= defaultFields;
 
     var response = await jellyfinApi.getLatestItems(
       userId: _finampUserHelper.currentUser!.id,
       parentId: parentItem?.id,
       includeItemTypes: includeItemTypes,
       limit: limit,
+      fields: fields,
     );
 
     return (response as List<dynamic>)

--- a/lib/services/metadata_provider.dart
+++ b/lib/services/metadata_provider.dart
@@ -96,11 +96,15 @@ final AutoDisposeFutureProviderFamily<MetadataProvider?, MetadataRequest>
           ? profile?.stereoBitrate
           : downloadItem.baseItem!.mediaSources?.first.bitrate;
 
-      // We cannot create a fully accurate MediaStream for a transcoded item, so
-      // just return an empty list.
+      // We cannot create accurate MediaStreams for a transcoded item,so
+      // just return the lyrics stream, as those are not affected and will not
+      // be shown if the mediaStream is not present
       List<MediaStream> mediaStream =
           profile?.codec != FinampTranscodingCodec.original
-              ? []
+              ? downloadItem.baseItem!.mediaStreams
+                      ?.where((x) => x.type == "Lyrics")
+                      .toList() ??
+                  []
               : downloadItem.baseItem!.mediaStreams ?? [];
 
       localPlaybackInfo = MediaSourceInfo(
@@ -151,7 +155,12 @@ final AutoDisposeFutureProviderFamily<MetadataProvider?, MetadataRequest>
     if (localPlaybackInfo != null && playbackInfo != null) {
       playbackInfo.protocol = localPlaybackInfo.protocol;
       playbackInfo.bitrate = localPlaybackInfo.bitrate;
-      playbackInfo.mediaStreams = localPlaybackInfo.mediaStreams;
+      // Use lyrics mediastream from online item, but take all other streams
+      // from downloaded item
+      playbackInfo.mediaStreams =
+          playbackInfo.mediaStreams.where((x) => x.type == "Lyric").toList();
+      playbackInfo.mediaStreams.addAll(
+          localPlaybackInfo.mediaStreams.where((x) => x.type != "Lyric"));
       playbackInfo.container = localPlaybackInfo.container;
       playbackInfo.size = localPlaybackInfo.size;
     }

--- a/lib/services/metadata_provider.dart
+++ b/lib/services/metadata_provider.dart
@@ -40,6 +40,9 @@ class MetadataRequest {
       item.id, queueItem?.id, includeLyrics, checkIfSpeedControlNeeded);
 }
 
+/// A storage container for metadata about a song.  The codec information will reflect
+/// the downloaded file if appropriate, even for transcoded downloads.  Online
+/// transcoding will not be reflected.
 class MetadataProvider {
   static const speedControlGenres = ["audiobook", "podcast", "speech"];
   static const speedControlLongTrackDuration = Duration(minutes: 15);
@@ -93,6 +96,8 @@ final AutoDisposeFutureProviderFamily<MetadataProvider?, MetadataRequest>
           ? profile?.stereoBitrate
           : downloadItem.baseItem!.mediaSources?.first.bitrate;
 
+      // We cannot create a fully accurate MediaStream for a transcoded item, so
+      // just return an empty list.
       List<MediaStream> mediaStream =
           profile?.codec != FinampTranscodingCodec.original
               ? []

--- a/lib/services/metadata_provider.dart
+++ b/lib/services/metadata_provider.dart
@@ -102,7 +102,7 @@ final AutoDisposeFutureProviderFamily<MetadataProvider?, MetadataRequest>
       List<MediaStream> mediaStream =
           profile?.codec != FinampTranscodingCodec.original
               ? downloadItem.baseItem!.mediaStreams
-                      ?.where((x) => x.type == "Lyrics")
+                      ?.where((x) => x.type == "Lyric")
                       .toList() ??
                   []
               : downloadItem.baseItem!.mediaStreams ?? [];


### PR DESCRIPTION
Fixes an issue where a null check error is thrown while syncing older finampCollections that do not have a FinampCollection object attached.  I haven't actually tested it with a legacy item yet.