### PR TITLE
[Redesign] Add more BaseItemDtoTypes

### DIFF
--- a/lib/models/finamp_models.g.dart
+++ b/lib/models/finamp_models.g.dart
@@ -3332,7 +3332,7 @@ P _downloadItemDeserializeProp<P>(
 }
 
 const _DownloadItembaseItemTypeEnumValueMap = {
-  'unknown': 0,
+  'noItem': 0,
   'album': 1,
   'artist': 2,
   'playlist': 3,
@@ -3341,6 +3341,12 @@ const _DownloadItembaseItemTypeEnumValueMap = {
   'library': 6,
   'folder': 7,
   'musicVideo': 8,
+  'audioBook': 9,
+  'tvEpisode': 10,
+  'video': 11,
+  'movie': 12,
+  'trailer': 13,
+  'unknown': 14,
 };
 const _DownloadItembaseItemTypeValueEnumMap = {
   0: BaseItemDtoType.noItem,
@@ -3352,6 +3358,12 @@ const _DownloadItembaseItemTypeValueEnumMap = {
   6: BaseItemDtoType.library,
   7: BaseItemDtoType.folder,
   8: BaseItemDtoType.musicVideo,
+  9: BaseItemDtoType.audioBook,
+  10: BaseItemDtoType.tvEpisode,
+  11: BaseItemDtoType.video,
+  12: BaseItemDtoType.movie,
+  13: BaseItemDtoType.trailer,
+  14: BaseItemDtoType.unknown,
 };
 const _DownloadItemstateEnumValueMap = {
   'notDownloaded': 0,
@@ -6618,7 +6630,7 @@ const _$DownloadItemTypeEnumMap = {
 };
 
 const _$BaseItemDtoTypeEnumMap = {
-  BaseItemDtoType.noItem: 'unknown',
+  BaseItemDtoType.noItem: 'noItem',
   BaseItemDtoType.album: 'album',
   BaseItemDtoType.artist: 'artist',
   BaseItemDtoType.playlist: 'playlist',
@@ -6627,6 +6639,12 @@ const _$BaseItemDtoTypeEnumMap = {
   BaseItemDtoType.library: 'library',
   BaseItemDtoType.folder: 'folder',
   BaseItemDtoType.musicVideo: 'musicVideo',
+  BaseItemDtoType.audioBook: 'audioBook',
+  BaseItemDtoType.tvEpisode: 'tvEpisode',
+  BaseItemDtoType.video: 'video',
+  BaseItemDtoType.movie: 'movie',
+  BaseItemDtoType.trailer: 'trailer',
+  BaseItemDtoType.unknown: 'unknown',
 };
 
 FinampCollection _$FinampCollectionFromJson(Map json) => FinampCollection(

--- a/lib/models/finamp_models.g.dart
+++ b/lib/models/finamp_models.g.dart
@@ -3243,7 +3243,7 @@ DownloadItem _downloadItemDeserialize(
     baseIndexNumber: reader.readLongOrNull(offsets[0]),
     baseItemType: _DownloadItembaseItemTypeValueEnumMap[
             reader.readByteOrNull(offsets[1])] ??
-        BaseItemDtoType.unknown,
+        BaseItemDtoType.noItem,
     fileTranscodingProfile: reader.readObjectOrNull<DownloadProfile>(
       offsets[2],
       DownloadProfileSchema.deserialize,
@@ -3287,7 +3287,7 @@ P _downloadItemDeserializeProp<P>(
     case 1:
       return (_DownloadItembaseItemTypeValueEnumMap[
               reader.readByteOrNull(offset)] ??
-          BaseItemDtoType.unknown) as P;
+          BaseItemDtoType.noItem) as P;
     case 2:
       return (reader.readObjectOrNull<DownloadProfile>(
         offset,
@@ -3343,7 +3343,7 @@ const _DownloadItembaseItemTypeEnumValueMap = {
   'musicVideo': 8,
 };
 const _DownloadItembaseItemTypeValueEnumMap = {
-  0: BaseItemDtoType.unknown,
+  0: BaseItemDtoType.noItem,
   1: BaseItemDtoType.album,
   2: BaseItemDtoType.artist,
   3: BaseItemDtoType.playlist,
@@ -6618,7 +6618,7 @@ const _$DownloadItemTypeEnumMap = {
 };
 
 const _$BaseItemDtoTypeEnumMap = {
-  BaseItemDtoType.unknown: 'unknown',
+  BaseItemDtoType.noItem: 'unknown',
   BaseItemDtoType.album: 'album',
   BaseItemDtoType.artist: 'artist',
   BaseItemDtoType.playlist: 'playlist',

--- a/lib/models/jellyfin_models.dart
+++ b/lib/models/jellyfin_models.dart
@@ -2206,7 +2206,7 @@ class BaseItemDto with RunTimeTickDuration {
 
   /// Custom helper field to determine if the BaseItemDto was created in offline mode
   bool? finampOffline;
-  
+
   /// Checks if the item has its own image (not inherited from a parent)
   bool get hasOwnImage => imageTags?.containsKey("Primary") ?? false;
 
@@ -2302,7 +2302,7 @@ class BaseItemDto with RunTimeTickDuration {
   }
 
   DownloadItemType get downloadType =>
-      type! == "Audio" ? DownloadItemType.song : DownloadItemType.collection;
+      BaseItemDtoType.fromItem(this).downloadType!;
 }
 
 @JsonSerializable(

--- a/lib/services/downloads_service_backend.dart
+++ b/lib/services/downloads_service_backend.dart
@@ -1265,6 +1265,7 @@ class DownloadsSyncService {
     String? fields;
     String? sortOrder;
     assert(parent.type == DownloadItemType.collection);
+    assert(parent.baseItemType.downloadType == DownloadItemType.collection);
     switch (parent.baseItemType) {
       case BaseItemDtoType.playlist || BaseItemDtoType.album:
         childType = DownloadItemType.song;
@@ -1279,7 +1280,9 @@ class DownloadsSyncService {
         childFilter = BaseItemDtoType.album;
         fields = "${_jellyfinApiData.defaultFields},SortName";
       case _:
-        throw StateError("Unknown collection type ${parent.baseItemType}");
+        _syncLogger.severe(
+            "Unknown collection type ${parent.baseItemType} for ${parent.name}");
+        return Future.value([]);
     }
     var item = parent.baseItem!;
 


### PR DESCRIPTION
Adds several more types which will be treated like songs by download system, like Movie or Video.  They may or may not download correctly, but hopefully they shouldn't throw errors?

Changed default action when parsing a BaseItemDto of unknown type from throwing an error to creating a collection which will not have any children when syncing.  Hopefully this keeps the download system from ever breaking the UI.