### PR TITLE
Get metainfo under 35 chars

### DIFF
--- a/assets/com.unicornsonlsd.finamp.metainfo.xml
+++ b/assets/com.unicornsonlsd.finamp.metainfo.xml
@@ -2,7 +2,7 @@
 <component type="desktop-application">
   <id>com.unicornsonlsd.finamp</id>
   <name>Finamp</name>
-  <summary>An open source Jellyfin music player</summary>
+  <summary>Open source Jellyfin music player</summary>
   <metadata_license>CC0-1.0</metadata_license>
   <project_license>MPL-2.0</project_license>
   <recommends>


### PR DESCRIPTION
![image](https://github.com/jmshrv/finamp/assets/5101747/fe691ec5-70a0-46dd-8808-b642a1f32c75)

Get metainfo summary under 35 characters so we meet the Flathub high quality app data criteria.