### PR TITLE
[Redesign] Fix queue item playlist removal cache

### DIFF
--- a/lib/components/PlayerScreen/queue_source_helper.dart
+++ b/lib/components/PlayerScreen/queue_source_helper.dart
@@ -147,5 +147,5 @@ bool queueItemInPlaylist(FinampQueueItem? queueItem) {
           .contains(queueItem.source.type) &&
       baseItem?.playlistItemId != null &&
       !playlistRemovalsCache
-          .contains(queueItem.source.id + (baseItem?.id ?? ""));
+          .contains(queueItem.source.id + (baseItem?.playlistItemId ?? ""));
 }


### PR DESCRIPTION
Use the correct ID so that queue items removed from a playlist actually stop showing up as in it.