### PR TITLE
Add an option to keep screen awake in the Lyrics View

### DIFF
--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -1570,12 +1570,12 @@
   "@showLyricsTimestampsSubtitle": {
     "description": "Subtitle for the setting that controls if timestamps are shown for lyrics"
   },
-  "keepScreenAwakeInLyricsScreenTitile": "Keep screen awake",
-  "@keepScreenAwakeInLyricsScreenTitile": {
+  "keepScreenAwakeOnLyricsScreenTitile": "Keep screen awake",
+  "@keepScreenAwakeOnLyricsScreenTitile": {
     "description": "Title for the setting that controls if the screen should be prevented from sleeping"
   },
-  "keepScreenAwakeInLyricsScreenSubtitle": "Prevents the phone from sleeping in the lyrics view",
-  "@keepScreenAwakeInLyricsScreenSubtitle": {
+  "keepScreenAwakeOnLyricsScreenSubtitle": "Prevents the phone from sleeping if there are lyrics showing",
+  "@keepScreenAwakeOnLyricsScreenSubtitle": {
     "description": "Subtitle for the setting that controls if the screen should be prevented from sleeping"
   },
   "showStopButtonOnMediaNotificationTitle": "Show stop button on media notification",

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -1570,12 +1570,12 @@
   "@showLyricsTimestampsSubtitle" {
     "description": "Subtitle for the setting that controls if timestamps are shown for lyrics"
   },
-  "keepScreenAwakeTitile": "Keep screen awake",
-  "@keepScreenAwakeTitile": {
+  "keepScreenAwakeInLyricsScreenTitile": "Keep screen awake",
+  "@keepScreenAwakeInLyricsScreenTitile": {
     "description": "Title for the setting that controls if the screen should be prevented from sleeping"
   },
-  "keepScreenAwakeSubtitle": "Prevents the phone from sleeping in the lyrics view",
-  "@keepScreenAwakeSubtitle": {
+  "keepScreenAwakeInLyricsScreenSubtitle": "Prevents the phone from sleeping in the lyrics view",
+  "@keepScreenAwakeInLyricsScreenSubtitle": {
     "description": "Subtitle for the setting that controls if the screen should be prevented from sleeping"
   },
   "showStopButtonOnMediaNotificationTitle": "Show stop button on media notification",

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -1567,8 +1567,16 @@
     "description": "Title for the setting that controls if timestamps are shown for lyrics"
   },
   "showLyricsTimestampsSubtitle": "Controls if the timestamp of each lyric line is shown in the lyrics view, if available.",
-  "@showLyricsTimestampsSubtitle": {
+  "@showLyricsTimestampsSubtitle" {
     "description": "Subtitle for the setting that controls if timestamps are shown for lyrics"
+  },
+  "keepScreenAwakeTitile": "Keep screen awake",
+  "@keepScreenAwakeTitile": {
+    "description": "Title for the setting that controls if the screen should be prevented from sleeping"
+  },
+  "keepScreenAwakeSubtitle": "Prevents the phone from sleeping in the lyrics view",
+  "@keepScreenAwakeSubtitle": {
+    "description": "Subtitle for the setting that controls if the screen should be prevented from sleeping"
   },
   "showStopButtonOnMediaNotificationTitle": "Show stop button on media notification",
   "@showStopButtonOnMediaNotificationTitle": {

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -1567,7 +1567,7 @@
     "description": "Title for the setting that controls if timestamps are shown for lyrics"
   },
   "showLyricsTimestampsSubtitle": "Controls if the timestamp of each lyric line is shown in the lyrics view, if available.",
-  "@showLyricsTimestampsSubtitle" {
+  "@showLyricsTimestampsSubtitle": {
     "description": "Subtitle for the setting that controls if timestamps are shown for lyrics"
   },
   "keepScreenAwakeInLyricsScreenTitile": "Keep screen awake",

--- a/lib/models/finamp_models.dart
+++ b/lib/models/finamp_models.dart
@@ -107,6 +107,7 @@ const _showProgressOnNowPlayingBarDefault = true;
 const _startInstantMixForIndividualTracksDefault = true;
 const _showLyricsTimestampsDefault = true;
 const _lyricsAlignmentDefault = LyricsAlignment.start;
+const _keepScreenAwakeOnLyricsDefault = false;
 const _showStopButtonOnMediaNotificationDefault = false;
 const _showSeekControlsOnMediaNotificationDefault = true;
 
@@ -184,6 +185,7 @@ class FinampSettings {
     this.startInstantMixForIndividualTracks = _startInstantMixForIndividualTracksDefault,
     this.showLyricsTimestamps = _showLyricsTimestampsDefault,
     this.lyricsAlignment = _lyricsAlignmentDefault,
+    this.keepScreenAwakeOnLyrics = _keepScreenAwakeOnLyricsDefault,
     this.showStopButtonOnMediaNotification = _showStopButtonOnMediaNotificationDefault,
     this.showSeekControlsOnMediaNotification = _showSeekControlsOnMediaNotificationDefault,
   });
@@ -410,6 +412,9 @@ class FinampSettings {
 
   @HiveField(69, defaultValue: _showSeekControlsOnMediaNotificationDefault)
   bool showSeekControlsOnMediaNotification;
+
+  @HiveField(70, defaultValue: _keepScreenAwakeOnLyricsDefault)
+  bool keepScreenAwakeOnLyrics;
 
   static Future<FinampSettings> create() async {
     final downloadLocation = await DownloadLocation.create(

--- a/lib/models/finamp_models.g.dart
+++ b/lib/models/finamp_models.g.dart
@@ -171,6 +171,7 @@ class FinampSettingsAdapter extends TypeAdapter<FinampSettings> {
       lyricsAlignment: fields[67] == null
           ? LyricsAlignment.start
           : fields[67] as LyricsAlignment,
+      keepScreenAwakeOnLyrics: fields[70] == null ? false : fields[70] as bool,
       showStopButtonOnMediaNotification:
           fields[68] == null ? false : fields[68] as bool,
       showSeekControlsOnMediaNotification:
@@ -184,7 +185,7 @@ class FinampSettingsAdapter extends TypeAdapter<FinampSettings> {
   @override
   void write(BinaryWriter writer, FinampSettings obj) {
     writer
-      ..writeByte(68)
+      ..writeByte(69)
       ..writeByte(0)
       ..write(obj.isOffline)
       ..writeByte(1)
@@ -320,7 +321,9 @@ class FinampSettingsAdapter extends TypeAdapter<FinampSettings> {
       ..writeByte(68)
       ..write(obj.showStopButtonOnMediaNotification)
       ..writeByte(69)
-      ..write(obj.showSeekControlsOnMediaNotification);
+      ..write(obj.showSeekControlsOnMediaNotification)
+      ..writeByte(70)
+      ..write(obj.keepScreenAwakeOnLyrics);
   }
 
   @override

--- a/lib/screens/lyrics_screen.dart
+++ b/lib/screens/lyrics_screen.dart
@@ -19,6 +19,7 @@ import 'package:flutter_vibrate/flutter_vibrate.dart';
 import 'package:get_it/get_it.dart';
 import 'package:scroll_to_index/scroll_to_index.dart';
 import 'package:simple_gesture_detector/simple_gesture_detector.dart';
+import 'package:wakelock_plus/wakelock_plus.dart';
 
 import '../components/PlayerScreen/control_area.dart';
 import '../components/PlayerScreen/player_screen_album_image.dart';
@@ -38,6 +39,9 @@ class LyricsScreen extends ConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final imageTheme = ref.watch(playerScreenThemeProvider);
+    if (FinampSettingsHelper.finampSettings.keepScreenAwakeInLyrics) {
+      WakelockPlus.enable();
+    }
 
     return ProviderScope(
         overrides: [
@@ -124,7 +128,7 @@ class _LyricsScreenContentState extends State<_LyricsScreenContent> {
                       if (direction == SwipeDirection.right) {
                         if (!FinampSettingsHelper
                             .finampSettings.disableGesture) {
-                          Navigator.of(context).pop();
+                          _goBack();
                         }
                       }
                     },
@@ -134,7 +138,7 @@ class _LyricsScreenContentState extends State<_LyricsScreenContent> {
                   onHorizontalSwipe: (direction) {
                     if (direction == SwipeDirection.right) {
                       if (!FinampSettingsHelper.finampSettings.disableGesture) {
-                        Navigator.of(context).pop();
+                        _goBack();
                       }
                     }
                   },
@@ -172,6 +176,13 @@ class _LyricsScreenContentState extends State<_LyricsScreenContent> {
         ],
       ),
     );
+  }
+
+  void _goBack() {
+    if (FinampSettingsHelper.finampSettings.keepScreenAwakeInLyrics) {
+      WakelockPlus.disable();
+    }
+    Navigator.of(context).pop();
   }
 }
 

--- a/lib/screens/lyrics_settings_screen.dart
+++ b/lib/screens/lyrics_settings_screen.dart
@@ -21,6 +21,7 @@ class LyricsSettingsScreen extends StatelessWidget {
         children: const [
           ShowLyricsTimestampsToggle(),
           LyricsAlignmentSelector(),
+          KeepScreenAwakeToggle(),
         ],
       ),
     );
@@ -92,3 +93,32 @@ class LyricsAlignmentSelector extends StatelessWidget {
   }
 }
 
+class KeepScreenAwakeToggle extends StatelessWidget {
+  const KeepScreenAwakeToggle({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return ValueListenableBuilder<Box<FinampSettings>>(
+      valueListenable: FinampSettingsHelper.finampSettingsListener,
+      builder: (context, box, child) {
+        bool? showLyricsTimestamps =
+            box.get("FinampSettings")?.keepScreenAwake;
+
+        return SwitchListTile.adaptive(
+          title: Text(AppLocalizations.of(context)!.keepScreenAwakeTitle),
+          subtitle:
+              Text(AppLocalizations.of(context)!.keepScreenAwakeSubtitle),
+          value: keepScreenAwake ?? false,
+          onChanged: keepScreenAwake == null
+              ? null
+              : (value) {
+                  FinampSettings finampSettingsTemp =
+                      box.get("FinampSettings")!;
+                  finampSettingsTemp.keepScreenAwake = value;
+                  box.put("FinampSettings", finampSettingsTemp);
+                },
+        );
+      },
+    );
+  }
+}

--- a/lib/screens/lyrics_settings_screen.dart
+++ b/lib/screens/lyrics_settings_screen.dart
@@ -102,19 +102,19 @@ class KeepScreenAwakeToggle extends StatelessWidget {
       valueListenable: FinampSettingsHelper.finampSettingsListener,
       builder: (context, box, child) {
         bool? showLyricsTimestamps =
-            box.get("FinampSettings")?.keepScreenAwake;
+            box.get("FinampSettings")?.keepScreenAwakeInLyrics;
 
         return SwitchListTile.adaptive(
-          title: Text(AppLocalizations.of(context)!.keepScreenAwakeTitle),
+          title: Text(AppLocalizations.of(context)!.keepScreenAwakeInLyricsScreenTitile),
           subtitle:
-              Text(AppLocalizations.of(context)!.keepScreenAwakeSubtitle),
-          value: keepScreenAwake ?? false,
-          onChanged: keepScreenAwake == null
+              Text(AppLocalizations.of(context)!.keepScreenAwakeInLyricsScreenSubtitle),
+          value: keepScreenAwakeInLyrics ?? false,
+          onChanged: keepScreenAwakeInLyrics == null
               ? null
               : (value) {
                   FinampSettings finampSettingsTemp =
                       box.get("FinampSettings")!;
-                  finampSettingsTemp.keepScreenAwake = value;
+                  finampSettingsTemp.keepScreenAwakeInLyrics = value;
                   box.put("FinampSettings", finampSettingsTemp);
                 },
         );

--- a/lib/screens/lyrics_settings_screen.dart
+++ b/lib/screens/lyrics_settings_screen.dart
@@ -2,7 +2,6 @@ import 'package:flutter/material.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:hive/hive.dart';
 
-import '../components/LayoutSettingsScreen/player_screen_minimum_cover_padding_editor.dart';
 import '../models/finamp_models.dart';
 import '../services/finamp_settings_helper.dart';
 
@@ -101,20 +100,21 @@ class KeepScreenAwakeToggle extends StatelessWidget {
     return ValueListenableBuilder<Box<FinampSettings>>(
       valueListenable: FinampSettingsHelper.finampSettingsListener,
       builder: (context, box, child) {
-        bool? showLyricsTimestamps =
-            box.get("FinampSettings")?.keepScreenAwakeInLyrics;
+        bool? keepScreenAwakeOnLyrics =
+            box.get("FinampSettings")?.keepScreenAwakeOnLyrics;
 
         return SwitchListTile.adaptive(
-          title: Text(AppLocalizations.of(context)!.keepScreenAwakeInLyricsScreenTitile),
-          subtitle:
-              Text(AppLocalizations.of(context)!.keepScreenAwakeInLyricsScreenSubtitle),
-          value: keepScreenAwakeInLyrics ?? false,
-          onChanged: keepScreenAwakeInLyrics == null
+          title: Text(AppLocalizations.of(context)!
+              .keepScreenAwakeOnLyricsScreenTitile),
+          subtitle: Text(AppLocalizations.of(context)!
+              .keepScreenAwakeOnLyricsScreenSubtitle),
+          value: keepScreenAwakeOnLyrics ?? false,
+          onChanged: keepScreenAwakeOnLyrics == null
               ? null
               : (value) {
                   FinampSettings finampSettingsTemp =
                       box.get("FinampSettings")!;
-                  finampSettingsTemp.keepScreenAwakeInLyrics = value;
+                  finampSettingsTemp.keepScreenAwakeOnLyrics = value;
                   box.put("FinampSettings", finampSettingsTemp);
                 },
         );

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -1583,6 +1583,22 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "14.2.1"
+  wakelock_plus:
+    dependency: "direct main"
+    description:
+      name: wakelock_plus
+      sha256: "14758533319a462ffb5aa3b7ddb198e59b29ac3b02da14173a1715d65d4e6e68"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.2.5"
+  wakelock_plus_platform_interface:
+    dependency: transitive
+    description:
+      name: wakelock_plus_platform_interface
+      sha256: "422d1cdbb448079a8a62a5a770b69baa489f8f7ca21aef47800c726d404f9d16"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.2.1"
   watcher:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -101,6 +101,7 @@ dependencies:
   scroll_to_index: ^3.0.1
   window_manager: ^0.3.8
   url_launcher: ^6.2.6
+  wakelock_plus: ^1.2.5
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
This adds support to prevent the phone screen from sleeping when you are reading lyrics (it shouldn't happen if the song doesn't have lyrics). I also ran dart fix on the touched files.

I didn't find any test files so didn't add any, if there actually are let me know and I'll add them. I also tried testing this on a device with no success. I kept running into errors related to the Gradle config and/or android dependencies so I eventually gave up trying to do this. If someone is willing to test this that'd be appreciated.