### PR TITLE
Fix URI passed to ContentProvider

### DIFF
--- a/android/app/src/main/kotlin/com/unicornsonlsd/finamp/MediaItemContentProvider.kt
+++ b/android/app/src/main/kotlin/com/unicornsonlsd/finamp/MediaItemContentProvider.kt
@@ -15,10 +15,10 @@ class MediaItemContentProvider : ContentProvider() {
     private lateinit var memoryCache : LruCache<String, ByteArray>
 
     override fun openFile(uri: Uri, mode: String): ParcelFileDescriptor? {
-        if (uri.fragment != null) {
+        if (uri.encodedFragment != null) {
             // we store the original scheme://host in fragment since it should be unused
-            val origin = Uri.parse(uri.fragment)
-            val fixedUri = uri.buildUpon().fragment(null).scheme(origin.scheme).authority(origin.authority).toString()
+            val origin = Uri.parse(uri.encodedFragment)
+            val fixedUri = uri.buildUpon().fragment(null).scheme(origin.scheme).encodedAuthority(origin.encodedAuthority).toString()
 
             // check if we already cached the image
             val bytes = memoryCache.get(fixedUri)

--- a/lib/services/queue_service.dart
+++ b/lib/services/queue_service.dart
@@ -1046,7 +1046,7 @@ class QueueService {
         artUri = Uri(scheme: "content", host: contentProviderPackageName, path: path_helper.join(applicationSupportDirectory.absolute.path, Assets.images.albumWhite.path));
       } else {
         // store the origin in fragment since it should be unused
-        artUri = artUri.replace(scheme: "content", host: contentProviderPackageName, fragment: ["http", "https"].contains(artUri.scheme) ? artUri.origin : null);
+        artUri = Uri(scheme: "content", host: contentProviderPackageName, path: artUri.path, fragment: ["http", "https"].contains(artUri.scheme) ? artUri.origin : null);
       }
     }
 


### PR DESCRIPTION
Fixes an issue where artwork doesn't display in the media notification or android auto/automotive if the server uses a port number.

The issue was the port number wasn't removed from the URI when passing to the ContentProvider, so it wasn't able to find it.
![image](https://github.com/jmshrv/finamp/assets/33184334/114a3e37-c562-4905-aa8b-820f0cb13ec0)
Additionally, the ContentProvider would encode the URI's authority (breaking the URL) unless we set the encoded authority directly.