### PR TITLE
Fix aspect ratio of non-square offline images

### DIFF
--- a/lib/services/album_image_provider.dart
+++ b/lib/services/album_image_provider.dart
@@ -84,8 +84,12 @@ final AutoDisposeProviderFamily<ImageProvider?, AlbumImageRequest>
     // This helps keep cache usage by fileImages in check
     // Caching smaller at 2X size results in blurriness comparable to
     // NetworkImages fetched with display size
-    out = ResizeImage(out,
-        width: request.maxWidth! * 2, height: request.maxHeight! * 2);
+    out = ResizeImage(
+      out,
+      width: request.maxWidth! * 2,
+      height: request.maxHeight! * 2,
+      policy: ResizeImagePolicy.fit,
+    );
   }
   return out;
 });


### PR DESCRIPTION
Offline images were previously resized with a policy of `exact`, which caused them to be weirdly stretched if they weren't square. Setting the policy to `fit` fixes this issue.