### PR TITLE
Sort albums by PremiereDate on artist screen

### DIFF
--- a/lib/components/ArtistScreen/artist_screen_content.dart
+++ b/lib/components/ArtistScreen/artist_screen_content.dart
@@ -91,11 +91,11 @@ class _ArtistScreenContentState extends State<ArtistScreenContent> {
           )
         else
           Future.value(null),
-        // Get Albums sorted by Production Year and Premiere Date
+        // Get Albums sorted by Premiere Date
         jellyfinApiHelper.getItems(
           parentItem: widget.parent,
           filters: "Artist=${widget.parent.name}",
-          sortBy: "ProductionYear,PremiereDate",
+          sortBy: "PremiereDate",
           includeItemTypes: "MusicAlbum",
         ),
       ]);

--- a/lib/components/ArtistScreen/artist_screen_content.dart
+++ b/lib/components/ArtistScreen/artist_screen_content.dart
@@ -91,11 +91,11 @@ class _ArtistScreenContentState extends State<ArtistScreenContent> {
           )
         else
           Future.value(null),
-        // Get Albums sorted by Production Year
+        // Get Albums sorted by Production Year and Premiere Date
         jellyfinApiHelper.getItems(
           parentItem: widget.parent,
           filters: "Artist=${widget.parent.name}",
-          sortBy: "ProductionYear",
+          sortBy: "ProductionYear,PremiereDate",
           includeItemTypes: "MusicAlbum",
         ),
       ]);

--- a/lib/components/ArtistScreen/artist_screen_content.dart
+++ b/lib/components/ArtistScreen/artist_screen_content.dart
@@ -95,7 +95,7 @@ class _ArtistScreenContentState extends State<ArtistScreenContent> {
         jellyfinApiHelper.getItems(
           parentItem: widget.parent,
           filters: "Artist=${widget.parent.name}",
-          sortBy: "PremiereDate",
+          sortBy: "PremiereDate,SortName",
           includeItemTypes: "MusicAlbum",
         ),
       ]);


### PR DESCRIPTION
This ensures albums are correctly ordered by release date, if there are more than one within the same year.
I am not sure if the `ProductionYear` sort is still needed here, but it doesn't hurt, I suppose. If the `PremiereDate` is empty, that would mean it's at least sorted by `ProductionYear` like before.