### PR TITLE
Use same logic for playback stop events and offline listen log

### DIFF
--- a/lib/services/offline_listen_helper.dart
+++ b/lib/services/offline_listen_helper.dart
@@ -57,6 +57,7 @@ class OfflineListenLogHelper {
   /// The [timestamp] provided to this function should be in seconds
   /// and marks the time the track was stopped.
   Future<void> _logOfflineListen(OfflineListen listen) {
+    _logger.info("Storing offline listen for ${listen.name}");
     return Future.wait([
       Hive.box<OfflineListen>("OfflineListens").add(listen),
       _exportOfflineListenToFile(listen)

--- a/lib/services/playback_history_service.dart
+++ b/lib/services/playback_history_service.dart
@@ -338,19 +338,21 @@ class PlaybackHistoryService {
     PlaybackState? previousState,
     bool skippingForward,
   ) async {
+    final shouldReportPreviousTrack = previousItem != null &&
+        previousState != null &&
+        // don't submit stop events for idle tracks (at position 0 and not playing)
+        (previousState.playing ||
+            previousState.updatePosition != Duration.zero);
+
     if (FinampSettingsHelper.finampSettings.isOffline) {
-      if (previousItem != null) {
+      if (shouldReportPreviousTrack) {
         await _offlineListenLogHelper.logOfflineListen(previousItem.item);
       }
       return;
     }
 
     jellyfin_models.PlaybackProgressInfo? previousTrackPlaybackData;
-    if (previousItem != null &&
-        previousState != null &&
-        // don't submit stop events for idle tracks (at position 0 and not playing)
-        (previousState.playing ||
-            previousState.updatePosition != Duration.zero)) {
+    if (shouldReportPreviousTrack) {
       previousTrackPlaybackData = generatePlaybackProgressInfoFromState(
         previousItem,
         previousState,


### PR DESCRIPTION
The boolean expression we currently use for server stop events already works very well, so the same should be used while offline (in the `onTrackChanged` callback). I also added a logging call to the `OfflineListenLogHelper` for good measure.