### PR TITLE
[Redesign] download Migration Fix

### DIFF
--- a/lib/services/downloads_service.dart
+++ b/lib/services/downloads_service.dart
@@ -1204,7 +1204,9 @@ class DownloadsService {
       }
 
       isarItem.state = DownloadItemState.complete;
-      isarItem.viewId = parent.viewId;
+      if (isarItem.baseItemType != BaseItemDtoType.playlist) {
+        isarItem.viewId = parent.viewId;
+      }
 
       _isar.writeTxnSync(() {
         _isar.downloadItems.putSync(isarItem);


### PR DESCRIPTION
Skip adding viewIds to migrated playlists as are shouldn't have them.