### PR TITLE
Only show artist top songs with at least one play

### DIFF
--- a/lib/components/ArtistScreen/artist_screen_content.dart
+++ b/lib/components/ArtistScreen/artist_screen_content.dart
@@ -156,7 +156,10 @@ class _ArtistScreenContentState extends State<ArtistScreenContent> {
             if (!isOffline &&
                 FinampSettingsHelper.finampSettings.showArtistsTopSongs)
               SongsSliverList(
-                childrenForList: songs.take(5).toList(),
+                childrenForList: songs
+                    .takeWhile((s) => (s.userData?.playCount ?? 0) > 0)
+                    .take(5)
+                    .toList(),
                 childrenForQueue: Future.value(songs),
                 showPlayCount: true,
                 isOnArtistScreen: true,


### PR DESCRIPTION
Fixes the minor issue where the artist top songs section would also show songs with "0 plays".