### PR TITLE
[Redesign] Downloads Size Warning + other fixes

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -54,12 +54,19 @@ android {
     buildTypes {
         release {
             signingConfig signingConfigs.release
+            resValue "string", "app_name", "Finamp"
             // shrinkResources false
             // minifyEnabled false
+        }
+        profile {
+            applicationIdSuffix '.profile'
+            minifyEnabled true // avoid dexing issues
+            resValue "string", "app_name", "Finamp Profile"
         }
         debug {
             applicationIdSuffix '.debug'
             minifyEnabled true // avoid dexing issues
+            resValue "string", "app_name", "Finamp Debug"
         }
     }
     namespace 'com.unicornsonlsd.finamp'

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -13,7 +13,7 @@
          FlutterApplication and put your custom class here. -->
   <application
     android:name="${applicationName}"
-    android:label="Finamp"
+    android:label="@string/app_name"
     android:icon="@mipmap/ic_launcher"
     android:appCategory="audio"
     android:usesCleartextTraffic="true"

--- a/lib/components/AlbumScreen/album_screen_content.dart
+++ b/lib/components/AlbumScreen/album_screen_content.dart
@@ -86,7 +86,7 @@ class _AlbumScreenContentState extends State<AlbumScreenContent> {
             DownloadButton(
                 item: DownloadStub.fromItem(
                     type: DownloadItemType.collection, item: widget.parent),
-                children: widget.displayChildren.length)
+                children: widget.displayChildren)
           ],
         ),
         if (widget.displayChildren.length > 1 &&

--- a/lib/components/AlbumScreen/download_button.dart
+++ b/lib/components/AlbumScreen/download_button.dart
@@ -1,12 +1,12 @@
 import 'package:finamp/services/finamp_settings_helper.dart';
 import 'package:finamp/services/finamp_user_helper.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter/semantics.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:get_it/get_it.dart';
 
 import '../../models/finamp_models.dart';
+import '../../models/jellyfin_models.dart';
 import '../../services/downloads_service.dart';
 import '../confirmation_prompt_dialog.dart';
 import '../global_snackbar.dart';
@@ -21,14 +21,15 @@ class DownloadButton extends ConsumerWidget {
   });
 
   final DownloadStub item;
-  final int? children;
+  final List<BaseItemDto>? children;
   final bool isLibrary;
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final downloadsService = GetIt.instance<DownloadsService>();
-    DownloadItemStatus? status =
-        ref.watch(downloadsService.statusProvider((item, children))).value;
+    DownloadItemStatus? status = ref
+        .watch(downloadsService.statusProvider((item, children?.length)))
+        .value;
     var isOffline = ref.watch(finampSettingsProvider
             .select((value) => value.valueOrNull?.isOffline)) ??
         true;
@@ -73,7 +74,16 @@ class DownloadButton extends ConsumerWidget {
                     onAborted: () {},
                   ));
         } else {
-          await DownloadDialog.show(context, item, viewId);
+          int? songCount = switch (item.baseItemType) {
+            BaseItemDtoType.album ||
+            BaseItemDtoType.playlist =>
+              children?.length,
+            BaseItemDtoType.artist || BaseItemDtoType.genre => children
+                ?.fold<int>(0, (count, item) => count + (item.childCount ?? 0)),
+            _ => null
+          };
+          await DownloadDialog.show(context, item, viewId,
+              songCount: songCount);
         }
       },
       tooltip: parentTooltip,
@@ -93,8 +103,7 @@ class DownloadButton extends ConsumerWidget {
                 item.baseItem?.name ?? "", item.baseItemType.name),
             confirmButtonText:
                 AppLocalizations.of(context)!.deleteDownloadsConfirmButtonText,
-            abortButtonText:
-                AppLocalizations.of(context)!.genericCancel,
+            abortButtonText: AppLocalizations.of(context)!.genericCancel,
             onConfirmed: () async {
               try {
                 await downloadsService.deleteDownload(stub: item);

--- a/lib/components/AlbumScreen/download_dialog.dart
+++ b/lib/components/AlbumScreen/download_dialog.dart
@@ -13,8 +13,6 @@ import '../../services/finamp_user_helper.dart';
 import '../../services/jellyfin_api_helper.dart';
 import '../global_snackbar.dart';
 
-const songWarningCutoff = 150;
-
 class DownloadDialog extends StatefulWidget {
   const DownloadDialog._build({
     super.key,
@@ -76,6 +74,7 @@ class DownloadDialog extends StatefulWidget {
     // where this can be determined in one query.
     JellyfinApiHelper jellyfinApiHelper = GetIt.instance<JellyfinApiHelper>();
     List<BaseItemDto>? children;
+    print((await jellyfinApiHelper.getItemById(item.id)).toJson());
     if ((item.baseItemType == BaseItemDtoType.album ||
             item.baseItemType == BaseItemDtoType.playlist) &&
         (needTranscode || songCount == null)) {
@@ -99,7 +98,8 @@ class DownloadDialog extends StatefulWidget {
 
     if (!needTranscode &&
         downloadLocation != null &&
-        (songCount ?? 0) < songWarningCutoff) {
+        (songCount ?? 0) <
+            FinampSettingsHelper.finampSettings.downloadSizeWarningCutoff) {
       final downloadsService = GetIt.instance<DownloadsService>();
       var profile = FinampSettingsHelper
                   .finampSettings.shouldTranscodeDownloads ==
@@ -225,7 +225,8 @@ class _DownloadDialogState extends State<DownloadDialog> {
                         .dontTranscode(originalDescription)),
                   )
                 ]),
-          if ((widget.songCount ?? 0) >= songWarningCutoff)
+          if ((widget.songCount ?? 0) >=
+              FinampSettingsHelper.finampSettings.downloadSizeWarningCutoff)
             Padding(
                 padding: const EdgeInsets.only(left: 8.0, right: 8.0, top: 8.0),
                 child: Text(AppLocalizations.of(context)!

--- a/lib/components/AlbumScreen/download_dialog.dart
+++ b/lib/components/AlbumScreen/download_dialog.dart
@@ -74,7 +74,6 @@ class DownloadDialog extends StatefulWidget {
     // where this can be determined in one query.
     JellyfinApiHelper jellyfinApiHelper = GetIt.instance<JellyfinApiHelper>();
     List<BaseItemDto>? children;
-    print((await jellyfinApiHelper.getItemById(item.id)).toJson());
     if ((item.baseItemType == BaseItemDtoType.album ||
             item.baseItemType == BaseItemDtoType.playlist) &&
         (needTranscode || songCount == null)) {

--- a/lib/components/AlbumScreen/download_dialog.dart
+++ b/lib/components/AlbumScreen/download_dialog.dart
@@ -13,7 +13,7 @@ import '../../services/finamp_user_helper.dart';
 import '../../services/jellyfin_api_helper.dart';
 import '../global_snackbar.dart';
 
-const songWarningCutoff = 250;
+const songWarningCutoff = 150;
 
 class DownloadDialog extends StatefulWidget {
   const DownloadDialog._build({

--- a/lib/components/AlbumScreen/download_dialog.dart
+++ b/lib/components/AlbumScreen/download_dialog.dart
@@ -48,11 +48,7 @@ class DownloadDialog extends StatefulWidget {
     bool needTranscode =
         FinampSettingsHelper.finampSettings.shouldTranscodeDownloads ==
                 TranscodeDownloadsSetting.ask &&
-            // Skip asking for transcode for image only collection
-            item.finampCollection?.type != FinampCollectionType.libraryImages &&
-            // Skip asking for transcode for metadata +image collection
-            item.finampCollection?.type !=
-                FinampCollectionType.allPlaylistsMetadata;
+            (item.finampCollection?.type.hasAudio ?? true);
     String? downloadLocation =
         FinampSettingsHelper.finampSettings.defaultDownloadLocation;
     if (!FinampSettingsHelper.finampSettings.downloadLocationsMap

--- a/lib/components/ArtistScreen/artist_screen_content.dart
+++ b/lib/components/ArtistScreen/artist_screen_content.dart
@@ -62,7 +62,7 @@ class _ArtistScreenContentState extends State<ArtistScreenContent> {
                   relatedTo: widget.parent);
           artistAlbums.sort((a, b) => (a.baseItem?.premiereDate ?? "")
               .compareTo(b.baseItem!.premiereDate ?? ""));
-          return artistAlbums.map((e) => e.baseItem).whereNotNull().toList();
+          return artistAlbums.map((e) => e.baseItem).nonNulls.toList();
         }),
       ]);
       allSongs = Future.sync(() async {
@@ -144,7 +144,7 @@ class _ArtistScreenContentState extends State<ArtistScreenContent> {
                 DownloadButton(
                     item: DownloadStub.fromItem(
                         item: widget.parent, type: DownloadItemType.collection),
-                    children: albums.length)
+                    children: albums)
               ],
             ),
             if (!isOffline &&

--- a/lib/components/DownloadsScreen/item_file_size.dart
+++ b/lib/components/DownloadsScreen/item_file_size.dart
@@ -50,6 +50,10 @@ class ItemFileSize extends ConsumerWidget {
           } else {
             var profile =
                 item.userTranscodingProfile ?? item.syncTranscodingProfile;
+            //Suppress codec display on downloads without audio files
+            if (!(item.finampCollection?.type.hasAudio ?? true)) {
+              profile = null;
+            }
             var codec =
                 profile?.codec.name ?? FinampTranscodingCodec.original.name;
             return isarDownloader.getFileSize(item).then((value) =>

--- a/lib/components/print_duration.dart
+++ b/lib/components/print_duration.dart
@@ -10,18 +10,18 @@ String printDuration(
 
   String twoDigits(int n) => n.toString().padLeft(2, "0");
   final minutes = duration.inMinutes.remainder(60);
-  String twoDigitMinutes =
-      leadingZeroes ? twoDigits(minutes) : minutes.toString();
   String twoDigitSeconds = twoDigits(duration.inSeconds.remainder(60));
 
   String durationString;
   if (duration.inHours >= 1) {
-    String twoDigitHours = leadingZeroes
+    String paddedHours = leadingZeroes
         ? twoDigits(duration.inHours)
         : duration.inHours.toString();
-    durationString = "$twoDigitHours:$twoDigitMinutes:$twoDigitSeconds";
+    durationString = "$paddedHours:${twoDigits(minutes)}:$twoDigitSeconds";
   } else {
-    durationString = "$twoDigitMinutes:$twoDigitSeconds";
+    String paddedMinutes =
+        leadingZeroes ? twoDigits(minutes) : minutes.toString();
+    durationString = "$paddedMinutes:$twoDigitSeconds";
   }
 
   if (isRemaining) {

--- a/lib/gen/assets.gen.dart
+++ b/lib/gen/assets.gen.dart
@@ -40,7 +40,7 @@ class $ImagesGen {
 }
 
 class Assets {
-  Assets._();
+  const Assets._();
 
   static const $ImagesGen images = $ImagesGen();
 }
@@ -75,10 +75,10 @@ class AssetGenImage {
     ImageRepeat repeat = ImageRepeat.noRepeat,
     Rect? centerSlice,
     bool matchTextDirection = false,
-    bool gaplessPlayback = false,
+    bool gaplessPlayback = true,
     bool isAntiAlias = false,
     String? package,
-    FilterQuality filterQuality = FilterQuality.low,
+    FilterQuality filterQuality = FilterQuality.medium,
     int? cacheWidth,
     int? cacheHeight,
   }) {

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -476,7 +476,7 @@
   "@pathReturnSlashErrorMessage": {},
   "directoryMustBeEmpty": "Directory must be empty",
   "@directoryMustBeEmpty": {},
-  "customLocationsBuggy": "Custom locations are extremely buggy due to issues with permissions. I'm thinking of ways to fix this, but for now I wouldn't recommend using them.",
+  "customLocationsBuggy": "Custom locations can be extremely buggy and are not recommended in most cases. Locations under the system 'Music' folder prevent saving album covers due to OS limitations.",
   "@customLocationsBuggy": {},
   "enterLowPriorityStateOnPause": "Enter Low-Priority State on Pause",
   "@enterLowPriorityStateOnPause": {},
@@ -1835,5 +1835,14 @@
   "genericCancel": "Cancel",
   "@genericCancel": {
     "description": "Used when the user stops an action from taking place inside a popup dialog window"
+  },
+  "largeDownloadWarning": "Warning: You are about to download {count} tracks.",
+  "@largeDownloadWarning": {
+    "description": "A line of warning text on the download dialog when large numbers of songs are downloaded at once.",
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
   }
 }

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -1844,5 +1844,13 @@
         "type": "int"
       }
     }
+  },
+  "downloadSizeWarningCutoff": "Download Size Warning Cutoff",
+  "@downloadSizeWarningCutoff": {
+    "description": "Title for the setting controlling when to warn about a large download"
+  },
+  "downloadSizeWarningCutoffSubtitle": "A warning message will be displayed when downloading more than this many songs at once.",
+  "@downloadSizeWarningCutoffSubtitle": {
+    "description": "Subtitle for the setting controlling when to warn about a large download"
   }
 }

--- a/lib/models/finamp_models.dart
+++ b/lib/models/finamp_models.dart
@@ -140,6 +140,7 @@ class DefaultSettings {
   static const showDownloadsWithUnknownLibrary = true;
   static const downloadWorkers = 5;
   static const maxConcurrentDownloads = 10;
+  static const downloadSizeWarningCutoff = 150;
 }
 
 @HiveType(typeId: 28)
@@ -245,7 +246,9 @@ class FinampSettings {
       this.hasDownloadedPlaylistInfo =
           DefaultSettings.hasDownloadedPlaylistInfo,
       this.transcodingSegmentContainer =
-          DefaultSettings.transcodingSegmentContainer});
+          DefaultSettings.transcodingSegmentContainer,
+      this.downloadSizeWarningCutoff =
+          DefaultSettings.downloadSizeWarningCutoff});
 
   @HiveField(0, defaultValue: DefaultSettings.isOffline)
   bool isOffline;
@@ -258,8 +261,7 @@ class FinampSettings {
   @HiveField(3)
   List<DownloadLocation> downloadLocations;
 
-  @HiveField(4,
-      defaultValue: DefaultSettings.androidStopForegroundOnPause)
+  @HiveField(4, defaultValue: DefaultSettings.androidStopForegroundOnPause)
   bool androidStopForegroundOnPause;
   @HiveField(5)
   Map<TabContentType, bool> showTabs;
@@ -508,6 +510,9 @@ class FinampSettings {
 
   @HiveField(79, defaultValue: DefaultSettings.bufferSizeMegabytes)
   int bufferSizeMegabytes;
+
+  @HiveField(80, defaultValue: DefaultSettings.downloadSizeWarningCutoff)
+  int downloadSizeWarningCutoff;
 
   static Future<FinampSettings> create() async {
     final downloadLocation = await DownloadLocation.create(
@@ -2441,7 +2446,6 @@ class FinampFeatureChipsConfiguration {
     );
   }
 }
-
 
 @HiveType(typeId: 76)
 class DeviceInfo {

--- a/lib/models/finamp_models.dart
+++ b/lib/models/finamp_models.dart
@@ -2096,11 +2096,15 @@ enum PlaybackSpeedVisibility {
 }
 
 enum FinampCollectionType {
-  favorites,
-  allPlaylists,
-  latest5Albums,
-  libraryImages,
-  allPlaylistsMetadata;
+  favorites(true),
+  allPlaylists(true),
+  latest5Albums(true),
+  libraryImages(false),
+  allPlaylistsMetadata(false);
+
+  const FinampCollectionType(this.hasAudio);
+
+  final bool hasAudio;
 }
 
 @JsonSerializable(

--- a/lib/models/finamp_models.g.dart
+++ b/lib/models/finamp_models.g.dart
@@ -194,6 +194,7 @@ class FinampSettingsAdapter extends TypeAdapter<FinampSettings> {
       transcodingSegmentContainer: fields[75] == null
           ? FinampSegmentContainer.fragmentedMp4
           : fields[75] as FinampSegmentContainer,
+      downloadSizeWarningCutoff: fields[80] == null ? 150 : fields[80] as int,
     )
       ..disableGesture = fields[19] == null ? false : fields[19] as bool
       ..showFastScroller = fields[25] == null ? true : fields[25] as bool
@@ -203,7 +204,7 @@ class FinampSettingsAdapter extends TypeAdapter<FinampSettings> {
   @override
   void write(BinaryWriter writer, FinampSettings obj) {
     writer
-      ..writeByte(76)
+      ..writeByte(77)
       ..writeByte(0)
       ..write(obj.isOffline)
       ..writeByte(1)
@@ -355,7 +356,9 @@ class FinampSettingsAdapter extends TypeAdapter<FinampSettings> {
       ..writeByte(78)
       ..write(obj.bufferDisableSizeConstraints)
       ..writeByte(79)
-      ..write(obj.bufferSizeMegabytes);
+      ..write(obj.bufferSizeMegabytes)
+      ..writeByte(80)
+      ..write(obj.downloadSizeWarningCutoff);
   }
 
   @override
@@ -7122,20 +7125,11 @@ FinampCollection _$FinampCollectionFromJson(Map json) => FinampCollection(
               Map<String, dynamic>.from(json['Library'] as Map)),
     );
 
-Map<String, dynamic> _$FinampCollectionToJson(FinampCollection instance) {
-  final val = <String, dynamic>{
-    'Type': _$FinampCollectionTypeEnumMap[instance.type]!,
-  };
-
-  void writeNotNull(String key, dynamic value) {
-    if (value != null) {
-      val[key] = value;
-    }
-  }
-
-  writeNotNull('Library', instance.library?.toJson());
-  return val;
-}
+Map<String, dynamic> _$FinampCollectionToJson(FinampCollection instance) =>
+    <String, dynamic>{
+      'Type': _$FinampCollectionTypeEnumMap[instance.type]!,
+      if (instance.library?.toJson() case final value?) 'Library': value,
+    };
 
 const _$FinampCollectionTypeEnumMap = {
   FinampCollectionType.favorites: 'favorites',

--- a/lib/models/jellyfin_models.g.dart
+++ b/lib/models/jellyfin_models.g.dart
@@ -4010,179 +4010,215 @@ BaseItemDto _$BaseItemDtoFromJson(Map json) => BaseItemDto(
       hasLyrics: json['HasLyrics'] as bool?,
     )..finampOffline = json['FinampOffline'] as bool?;
 
-Map<String, dynamic> _$BaseItemDtoToJson(BaseItemDto instance) {
-  final val = <String, dynamic>{};
-
-  void writeNotNull(String key, dynamic value) {
-    if (value != null) {
-      val[key] = value;
-    }
-  }
-
-  writeNotNull('Name', instance.name);
-  writeNotNull('OriginalTitle', instance.originalTitle);
-  writeNotNull('ServerId', instance.serverId);
-  val['Id'] = instance.id;
-  writeNotNull('Etag', instance.etag);
-  writeNotNull('PlaylistItemId', instance.playlistItemId);
-  writeNotNull('DateCreated', instance.dateCreated);
-  writeNotNull('ExtraType', instance.extraType);
-  writeNotNull('AirsBeforeSeasonNumber', instance.airsBeforeSeasonNumber);
-  writeNotNull('AirsAfterSeasonNumber', instance.airsAfterSeasonNumber);
-  writeNotNull('AirsBeforeEpisodeNumber', instance.airsBeforeEpisodeNumber);
-  writeNotNull('CanDelete', instance.canDelete);
-  writeNotNull('CanDownload', instance.canDownload);
-  writeNotNull('HasSubtitles', instance.hasSubtitles);
-  writeNotNull('PreferredMetadataLanguage', instance.preferredMetadataLanguage);
-  writeNotNull(
-      'PreferredMetadataCountryCode', instance.preferredMetadataCountryCode);
-  writeNotNull('SupportsSync', instance.supportsSync);
-  writeNotNull('Container', instance.container);
-  writeNotNull('SortName', instance.sortName);
-  writeNotNull('ForcedSortName', instance.forcedSortName);
-  writeNotNull('Video3DFormat', instance.video3DFormat);
-  writeNotNull('PremiereDate', instance.premiereDate);
-  writeNotNull(
-      'ExternalUrls', instance.externalUrls?.map((e) => e.toJson()).toList());
-  writeNotNull(
-      'MediaSources', instance.mediaSources?.map((e) => e.toJson()).toList());
-  writeNotNull('CriticRating', instance.criticRating);
-  writeNotNull('ProductionLocations', instance.productionLocations);
-  writeNotNull('Path', instance.path);
-  writeNotNull('OfficialRating', instance.officialRating);
-  writeNotNull('CustomRating', instance.customRating);
-  writeNotNull('ChannelId', instance.channelId);
-  writeNotNull('ChannelName', instance.channelName);
-  writeNotNull('Overview', instance.overview);
-  writeNotNull('Taglines', instance.taglines);
-  writeNotNull('Genres', instance.genres);
-  writeNotNull('CommunityRating', instance.communityRating);
-  writeNotNull('RunTimeTicks', instance.runTimeTicks);
-  writeNotNull('PlayAccess', instance.playAccess);
-  writeNotNull('AspectRatio', instance.aspectRatio);
-  writeNotNull('ProductionYear', instance.productionYear);
-  writeNotNull('Number', instance.number);
-  writeNotNull('ChannelNumber', instance.channelNumber);
-  writeNotNull('IndexNumber', instance.indexNumber);
-  writeNotNull('IndexNumberEnd', instance.indexNumberEnd);
-  writeNotNull('ParentIndexNumber', instance.parentIndexNumber);
-  writeNotNull('RemoteTrailers',
-      instance.remoteTrailers?.map((e) => e.toJson()).toList());
-  writeNotNull('ProviderIds', instance.providerIds);
-  writeNotNull('IsFolder', instance.isFolder);
-  writeNotNull('ParentId', instance.parentId);
-  writeNotNull('Type', instance.type);
-  writeNotNull('People', instance.people?.map((e) => e.toJson()).toList());
-  writeNotNull('Studios', instance.studios?.map((e) => e.toJson()).toList());
-  writeNotNull(
-      'GenreItems', instance.genreItems?.map((e) => e.toJson()).toList());
-  writeNotNull('ParentLogoItemId', instance.parentLogoItemId);
-  writeNotNull('ParentBackdropItemId', instance.parentBackdropItemId);
-  writeNotNull('ParentBackdropImageTags', instance.parentBackdropImageTags);
-  writeNotNull('LocalTrailerCount', instance.localTrailerCount);
-  writeNotNull('UserData', instance.userData?.toJson());
-  writeNotNull('RecursiveItemCount', instance.recursiveItemCount);
-  writeNotNull('ChildCount', instance.childCount);
-  writeNotNull('SeriesName', instance.seriesName);
-  writeNotNull('SeriesId', instance.seriesId);
-  writeNotNull('SeasonId', instance.seasonId);
-  writeNotNull('SpecialFeatureCount', instance.specialFeatureCount);
-  writeNotNull('DisplayPreferencesId', instance.displayPreferencesId);
-  writeNotNull('Status', instance.status);
-  writeNotNull('AirTime', instance.airTime);
-  writeNotNull('AirDays', instance.airDays);
-  writeNotNull('Tags', instance.tags);
-  writeNotNull('PrimaryImageAspectRatio', instance.primaryImageAspectRatio);
-  writeNotNull('Artists', instance.artists);
-  writeNotNull(
-      'ArtistItems', instance.artistItems?.map((e) => e.toJson()).toList());
-  writeNotNull('Album', instance.album);
-  writeNotNull('CollectionType', instance.collectionType);
-  writeNotNull('DisplayOrder', instance.displayOrder);
-  writeNotNull('AlbumId', instance.albumId);
-  writeNotNull('AlbumPrimaryImageTag', instance.albumPrimaryImageTag);
-  writeNotNull('SeriesPrimaryImageTag', instance.seriesPrimaryImageTag);
-  writeNotNull('AlbumArtist', instance.albumArtist);
-  writeNotNull(
-      'AlbumArtists', instance.albumArtists?.map((e) => e.toJson()).toList());
-  writeNotNull('SeasonName', instance.seasonName);
-  writeNotNull(
-      'MediaStreams', instance.mediaStreams?.map((e) => e.toJson()).toList());
-  writeNotNull('PartCount', instance.partCount);
-  writeNotNull('ImageTags', instance.imageTags);
-  writeNotNull('BackdropImageTags', instance.backdropImageTags);
-  writeNotNull('ParentLogoImageTag', instance.parentLogoImageTag);
-  writeNotNull('ParentArtItemId', instance.parentArtItemId);
-  writeNotNull('ParentArtImageTag', instance.parentArtImageTag);
-  writeNotNull('SeriesThumbImageTag', instance.seriesThumbImageTag);
-  writeNotNull('SeriesStudio', instance.seriesStudio);
-  writeNotNull('ParentThumbItemId', instance.parentThumbItemId);
-  writeNotNull('ParentThumbImageTag', instance.parentThumbImageTag);
-  writeNotNull('ParentPrimaryImageItemId', instance.parentPrimaryImageItemId);
-  writeNotNull('ParentPrimaryImageTag', instance.parentPrimaryImageTag);
-  writeNotNull('Chapters', instance.chapters?.map((e) => e.toJson()).toList());
-  writeNotNull('LocationType', instance.locationType);
-  writeNotNull('MediaType', instance.mediaType);
-  writeNotNull('EndDate', instance.endDate);
-  writeNotNull('LockedFields', instance.lockedFields);
-  writeNotNull('LockData', instance.lockData);
-  writeNotNull('Width', instance.width);
-  writeNotNull('Height', instance.height);
-  writeNotNull('CameraMake', instance.cameraMake);
-  writeNotNull('CameraModel', instance.cameraModel);
-  writeNotNull('Software', instance.software);
-  writeNotNull('ExposureTime', instance.exposureTime);
-  writeNotNull('FocalLength', instance.focalLength);
-  writeNotNull('ImageOrientation', instance.imageOrientation);
-  writeNotNull('Aperture', instance.aperture);
-  writeNotNull('ShutterSpeed', instance.shutterSpeed);
-  writeNotNull('Latitude', instance.latitude);
-  writeNotNull('Longitude', instance.longitude);
-  writeNotNull('Altitude', instance.altitude);
-  writeNotNull('IsoSpeedRating', instance.isoSpeedRating);
-  writeNotNull('SeriesTimerId', instance.seriesTimerId);
-  writeNotNull('ChannelPrimaryImageTag', instance.channelPrimaryImageTag);
-  writeNotNull('StartDate', instance.startDate);
-  writeNotNull('CompletionPercentage', instance.completionPercentage);
-  writeNotNull('IsRepeat', instance.isRepeat);
-  writeNotNull('EpisodeTitle', instance.episodeTitle);
-  writeNotNull('IsMovie', instance.isMovie);
-  writeNotNull('IsSports', instance.isSports);
-  writeNotNull('IsSeries', instance.isSeries);
-  writeNotNull('IsLive', instance.isLive);
-  writeNotNull('IsNews', instance.isNews);
-  writeNotNull('IsKids', instance.isKids);
-  writeNotNull('IsPremiere', instance.isPremiere);
-  writeNotNull('TimerId', instance.timerId);
-  writeNotNull('CurrentProgram', instance.currentProgram);
-  writeNotNull('MovieCount', instance.movieCount);
-  writeNotNull('SeriesCount', instance.seriesCount);
-  writeNotNull('AlbumCount', instance.albumCount);
-  writeNotNull('SongCount', instance.songCount);
-  writeNotNull('MusicVideoCount', instance.musicVideoCount);
-  writeNotNull('SourceType', instance.sourceType);
-  writeNotNull('DateLastMediaAdded', instance.dateLastMediaAdded);
-  writeNotNull('EnableMediaSourceDisplay', instance.enableMediaSourceDisplay);
-  writeNotNull('CumulativeRunTimeTicks', instance.cumulativeRunTimeTicks);
-  writeNotNull('IsPlaceHolder', instance.isPlaceHolder);
-  writeNotNull('IsHD', instance.isHD);
-  writeNotNull('VideoType', instance.videoType);
-  writeNotNull('MediaSourceCount', instance.mediaSourceCount);
-  writeNotNull('ScreenshotImageTags', instance.screenshotImageTags);
-  writeNotNull('ImageBlurHashes', instance.imageBlurHashes?.toJson());
-  writeNotNull('IsoType', instance.isoType);
-  writeNotNull('TrailerCount', instance.trailerCount);
-  writeNotNull('ProgramCount', instance.programCount);
-  writeNotNull('EpisodeCount', instance.episodeCount);
-  writeNotNull('ArtistCount', instance.artistCount);
-  writeNotNull('ProgramId', instance.programId);
-  writeNotNull('ChannelType', instance.channelType);
-  writeNotNull('Audio', instance.audio);
-  writeNotNull('NormalizationGain', instance.normalizationGain);
-  writeNotNull('HasLyrics', instance.hasLyrics);
-  writeNotNull('FinampOffline', instance.finampOffline);
-  return val;
-}
+Map<String, dynamic> _$BaseItemDtoToJson(BaseItemDto instance) =>
+    <String, dynamic>{
+      if (instance.name case final value?) 'Name': value,
+      if (instance.originalTitle case final value?) 'OriginalTitle': value,
+      if (instance.serverId case final value?) 'ServerId': value,
+      'Id': instance.id,
+      if (instance.etag case final value?) 'Etag': value,
+      if (instance.playlistItemId case final value?) 'PlaylistItemId': value,
+      if (instance.dateCreated case final value?) 'DateCreated': value,
+      if (instance.extraType case final value?) 'ExtraType': value,
+      if (instance.airsBeforeSeasonNumber case final value?)
+        'AirsBeforeSeasonNumber': value,
+      if (instance.airsAfterSeasonNumber case final value?)
+        'AirsAfterSeasonNumber': value,
+      if (instance.airsBeforeEpisodeNumber case final value?)
+        'AirsBeforeEpisodeNumber': value,
+      if (instance.canDelete case final value?) 'CanDelete': value,
+      if (instance.canDownload case final value?) 'CanDownload': value,
+      if (instance.hasSubtitles case final value?) 'HasSubtitles': value,
+      if (instance.preferredMetadataLanguage case final value?)
+        'PreferredMetadataLanguage': value,
+      if (instance.preferredMetadataCountryCode case final value?)
+        'PreferredMetadataCountryCode': value,
+      if (instance.supportsSync case final value?) 'SupportsSync': value,
+      if (instance.container case final value?) 'Container': value,
+      if (instance.sortName case final value?) 'SortName': value,
+      if (instance.forcedSortName case final value?) 'ForcedSortName': value,
+      if (instance.video3DFormat case final value?) 'Video3DFormat': value,
+      if (instance.premiereDate case final value?) 'PremiereDate': value,
+      if (instance.externalUrls?.map((e) => e.toJson()).toList()
+          case final value?)
+        'ExternalUrls': value,
+      if (instance.mediaSources?.map((e) => e.toJson()).toList()
+          case final value?)
+        'MediaSources': value,
+      if (instance.criticRating case final value?) 'CriticRating': value,
+      if (instance.productionLocations case final value?)
+        'ProductionLocations': value,
+      if (instance.path case final value?) 'Path': value,
+      if (instance.officialRating case final value?) 'OfficialRating': value,
+      if (instance.customRating case final value?) 'CustomRating': value,
+      if (instance.channelId case final value?) 'ChannelId': value,
+      if (instance.channelName case final value?) 'ChannelName': value,
+      if (instance.overview case final value?) 'Overview': value,
+      if (instance.taglines case final value?) 'Taglines': value,
+      if (instance.genres case final value?) 'Genres': value,
+      if (instance.communityRating case final value?) 'CommunityRating': value,
+      if (instance.runTimeTicks case final value?) 'RunTimeTicks': value,
+      if (instance.playAccess case final value?) 'PlayAccess': value,
+      if (instance.aspectRatio case final value?) 'AspectRatio': value,
+      if (instance.productionYear case final value?) 'ProductionYear': value,
+      if (instance.number case final value?) 'Number': value,
+      if (instance.channelNumber case final value?) 'ChannelNumber': value,
+      if (instance.indexNumber case final value?) 'IndexNumber': value,
+      if (instance.indexNumberEnd case final value?) 'IndexNumberEnd': value,
+      if (instance.parentIndexNumber case final value?)
+        'ParentIndexNumber': value,
+      if (instance.remoteTrailers?.map((e) => e.toJson()).toList()
+          case final value?)
+        'RemoteTrailers': value,
+      if (instance.providerIds case final value?) 'ProviderIds': value,
+      if (instance.isFolder case final value?) 'IsFolder': value,
+      if (instance.parentId case final value?) 'ParentId': value,
+      if (instance.type case final value?) 'Type': value,
+      if (instance.people?.map((e) => e.toJson()).toList() case final value?)
+        'People': value,
+      if (instance.studios?.map((e) => e.toJson()).toList() case final value?)
+        'Studios': value,
+      if (instance.genreItems?.map((e) => e.toJson()).toList()
+          case final value?)
+        'GenreItems': value,
+      if (instance.parentLogoItemId case final value?)
+        'ParentLogoItemId': value,
+      if (instance.parentBackdropItemId case final value?)
+        'ParentBackdropItemId': value,
+      if (instance.parentBackdropImageTags case final value?)
+        'ParentBackdropImageTags': value,
+      if (instance.localTrailerCount case final value?)
+        'LocalTrailerCount': value,
+      if (instance.userData?.toJson() case final value?) 'UserData': value,
+      if (instance.recursiveItemCount case final value?)
+        'RecursiveItemCount': value,
+      if (instance.childCount case final value?) 'ChildCount': value,
+      if (instance.seriesName case final value?) 'SeriesName': value,
+      if (instance.seriesId case final value?) 'SeriesId': value,
+      if (instance.seasonId case final value?) 'SeasonId': value,
+      if (instance.specialFeatureCount case final value?)
+        'SpecialFeatureCount': value,
+      if (instance.displayPreferencesId case final value?)
+        'DisplayPreferencesId': value,
+      if (instance.status case final value?) 'Status': value,
+      if (instance.airTime case final value?) 'AirTime': value,
+      if (instance.airDays case final value?) 'AirDays': value,
+      if (instance.tags case final value?) 'Tags': value,
+      if (instance.primaryImageAspectRatio case final value?)
+        'PrimaryImageAspectRatio': value,
+      if (instance.artists case final value?) 'Artists': value,
+      if (instance.artistItems?.map((e) => e.toJson()).toList()
+          case final value?)
+        'ArtistItems': value,
+      if (instance.album case final value?) 'Album': value,
+      if (instance.collectionType case final value?) 'CollectionType': value,
+      if (instance.displayOrder case final value?) 'DisplayOrder': value,
+      if (instance.albumId case final value?) 'AlbumId': value,
+      if (instance.albumPrimaryImageTag case final value?)
+        'AlbumPrimaryImageTag': value,
+      if (instance.seriesPrimaryImageTag case final value?)
+        'SeriesPrimaryImageTag': value,
+      if (instance.albumArtist case final value?) 'AlbumArtist': value,
+      if (instance.albumArtists?.map((e) => e.toJson()).toList()
+          case final value?)
+        'AlbumArtists': value,
+      if (instance.seasonName case final value?) 'SeasonName': value,
+      if (instance.mediaStreams?.map((e) => e.toJson()).toList()
+          case final value?)
+        'MediaStreams': value,
+      if (instance.partCount case final value?) 'PartCount': value,
+      if (instance.imageTags case final value?) 'ImageTags': value,
+      if (instance.backdropImageTags case final value?)
+        'BackdropImageTags': value,
+      if (instance.parentLogoImageTag case final value?)
+        'ParentLogoImageTag': value,
+      if (instance.parentArtItemId case final value?) 'ParentArtItemId': value,
+      if (instance.parentArtImageTag case final value?)
+        'ParentArtImageTag': value,
+      if (instance.seriesThumbImageTag case final value?)
+        'SeriesThumbImageTag': value,
+      if (instance.seriesStudio case final value?) 'SeriesStudio': value,
+      if (instance.parentThumbItemId case final value?)
+        'ParentThumbItemId': value,
+      if (instance.parentThumbImageTag case final value?)
+        'ParentThumbImageTag': value,
+      if (instance.parentPrimaryImageItemId case final value?)
+        'ParentPrimaryImageItemId': value,
+      if (instance.parentPrimaryImageTag case final value?)
+        'ParentPrimaryImageTag': value,
+      if (instance.chapters?.map((e) => e.toJson()).toList() case final value?)
+        'Chapters': value,
+      if (instance.locationType case final value?) 'LocationType': value,
+      if (instance.mediaType case final value?) 'MediaType': value,
+      if (instance.endDate case final value?) 'EndDate': value,
+      if (instance.lockedFields case final value?) 'LockedFields': value,
+      if (instance.lockData case final value?) 'LockData': value,
+      if (instance.width case final value?) 'Width': value,
+      if (instance.height case final value?) 'Height': value,
+      if (instance.cameraMake case final value?) 'CameraMake': value,
+      if (instance.cameraModel case final value?) 'CameraModel': value,
+      if (instance.software case final value?) 'Software': value,
+      if (instance.exposureTime case final value?) 'ExposureTime': value,
+      if (instance.focalLength case final value?) 'FocalLength': value,
+      if (instance.imageOrientation case final value?)
+        'ImageOrientation': value,
+      if (instance.aperture case final value?) 'Aperture': value,
+      if (instance.shutterSpeed case final value?) 'ShutterSpeed': value,
+      if (instance.latitude case final value?) 'Latitude': value,
+      if (instance.longitude case final value?) 'Longitude': value,
+      if (instance.altitude case final value?) 'Altitude': value,
+      if (instance.isoSpeedRating case final value?) 'IsoSpeedRating': value,
+      if (instance.seriesTimerId case final value?) 'SeriesTimerId': value,
+      if (instance.channelPrimaryImageTag case final value?)
+        'ChannelPrimaryImageTag': value,
+      if (instance.startDate case final value?) 'StartDate': value,
+      if (instance.completionPercentage case final value?)
+        'CompletionPercentage': value,
+      if (instance.isRepeat case final value?) 'IsRepeat': value,
+      if (instance.episodeTitle case final value?) 'EpisodeTitle': value,
+      if (instance.isMovie case final value?) 'IsMovie': value,
+      if (instance.isSports case final value?) 'IsSports': value,
+      if (instance.isSeries case final value?) 'IsSeries': value,
+      if (instance.isLive case final value?) 'IsLive': value,
+      if (instance.isNews case final value?) 'IsNews': value,
+      if (instance.isKids case final value?) 'IsKids': value,
+      if (instance.isPremiere case final value?) 'IsPremiere': value,
+      if (instance.timerId case final value?) 'TimerId': value,
+      if (instance.currentProgram case final value?) 'CurrentProgram': value,
+      if (instance.movieCount case final value?) 'MovieCount': value,
+      if (instance.seriesCount case final value?) 'SeriesCount': value,
+      if (instance.albumCount case final value?) 'AlbumCount': value,
+      if (instance.songCount case final value?) 'SongCount': value,
+      if (instance.musicVideoCount case final value?) 'MusicVideoCount': value,
+      if (instance.sourceType case final value?) 'SourceType': value,
+      if (instance.dateLastMediaAdded case final value?)
+        'DateLastMediaAdded': value,
+      if (instance.enableMediaSourceDisplay case final value?)
+        'EnableMediaSourceDisplay': value,
+      if (instance.cumulativeRunTimeTicks case final value?)
+        'CumulativeRunTimeTicks': value,
+      if (instance.isPlaceHolder case final value?) 'IsPlaceHolder': value,
+      if (instance.isHD case final value?) 'IsHD': value,
+      if (instance.videoType case final value?) 'VideoType': value,
+      if (instance.mediaSourceCount case final value?)
+        'MediaSourceCount': value,
+      if (instance.screenshotImageTags case final value?)
+        'ScreenshotImageTags': value,
+      if (instance.imageBlurHashes?.toJson() case final value?)
+        'ImageBlurHashes': value,
+      if (instance.isoType case final value?) 'IsoType': value,
+      if (instance.trailerCount case final value?) 'TrailerCount': value,
+      if (instance.programCount case final value?) 'ProgramCount': value,
+      if (instance.episodeCount case final value?) 'EpisodeCount': value,
+      if (instance.artistCount case final value?) 'ArtistCount': value,
+      if (instance.programId case final value?) 'ProgramId': value,
+      if (instance.channelType case final value?) 'ChannelType': value,
+      if (instance.audio case final value?) 'Audio': value,
+      if (instance.normalizationGain case final value?)
+        'NormalizationGain': value,
+      if (instance.hasLyrics case final value?) 'HasLyrics': value,
+      if (instance.finampOffline case final value?) 'FinampOffline': value,
+    };
 
 ExternalUrl _$ExternalUrlFromJson(Map json) => ExternalUrl(
       name: json['Name'] as String?,
@@ -4250,62 +4286,59 @@ MediaSourceInfo _$MediaSourceInfoFromJson(Map json) => MediaSourceInfo(
           .toList(),
     );
 
-Map<String, dynamic> _$MediaSourceInfoToJson(MediaSourceInfo instance) {
-  final val = <String, dynamic>{
-    'Protocol': instance.protocol,
-  };
-
-  void writeNotNull(String key, dynamic value) {
-    if (value != null) {
-      val[key] = value;
-    }
-  }
-
-  writeNotNull('Id', instance.id);
-  writeNotNull('Path', instance.path);
-  writeNotNull('EncoderPath', instance.encoderPath);
-  writeNotNull('EncoderProtocol', instance.encoderProtocol);
-  val['Type'] = instance.type;
-  writeNotNull('Container', instance.container);
-  writeNotNull('Size', instance.size);
-  writeNotNull('Name', instance.name);
-  val['IsRemote'] = instance.isRemote;
-  writeNotNull('RunTimeTicks', instance.runTimeTicks);
-  val['SupportsTranscoding'] = instance.supportsTranscoding;
-  val['SupportsDirectStream'] = instance.supportsDirectStream;
-  val['SupportsDirectPlay'] = instance.supportsDirectPlay;
-  val['IsInfiniteStream'] = instance.isInfiniteStream;
-  val['RequiresOpening'] = instance.requiresOpening;
-  writeNotNull('OpenToken', instance.openToken);
-  val['RequiresClosing'] = instance.requiresClosing;
-  writeNotNull('LiveStreamId', instance.liveStreamId);
-  writeNotNull('BufferMs', instance.bufferMs);
-  val['RequiresLooping'] = instance.requiresLooping;
-  val['SupportsProbing'] = instance.supportsProbing;
-  writeNotNull('Video3DFormat', instance.video3DFormat);
-  val['MediaStreams'] = instance.mediaStreams.map((e) => e.toJson()).toList();
-  writeNotNull('Formats', instance.formats);
-  writeNotNull('Bitrate', instance.bitrate);
-  writeNotNull('Timestamp', instance.timestamp);
-  writeNotNull('RequiredHttpHeaders', instance.requiredHttpHeaders);
-  writeNotNull('TranscodingUrl', instance.transcodingUrl);
-  writeNotNull('TranscodingSubProtocol', instance.transcodingSubProtocol);
-  writeNotNull('TranscodingContainer', instance.transcodingContainer);
-  writeNotNull('AnalyzeDurationMs', instance.analyzeDurationMs);
-  val['ReadAtNativeFramerate'] = instance.readAtNativeFramerate;
-  writeNotNull('DefaultAudioStreamIndex', instance.defaultAudioStreamIndex);
-  writeNotNull(
-      'DefaultSubtitleStreamIndex', instance.defaultSubtitleStreamIndex);
-  writeNotNull('Etag', instance.etag);
-  val['IgnoreDts'] = instance.ignoreDts;
-  val['IgnoreIndex'] = instance.ignoreIndex;
-  val['GenPtsInput'] = instance.genPtsInput;
-  writeNotNull('VideoType', instance.videoType);
-  writeNotNull('IsoType', instance.isoType);
-  writeNotNull('MediaAttachments',
-      instance.mediaAttachments?.map((e) => e.toJson()).toList());
-  return val;
-}
+Map<String, dynamic> _$MediaSourceInfoToJson(MediaSourceInfo instance) =>
+    <String, dynamic>{
+      'Protocol': instance.protocol,
+      if (instance.id case final value?) 'Id': value,
+      if (instance.path case final value?) 'Path': value,
+      if (instance.encoderPath case final value?) 'EncoderPath': value,
+      if (instance.encoderProtocol case final value?) 'EncoderProtocol': value,
+      'Type': instance.type,
+      if (instance.container case final value?) 'Container': value,
+      if (instance.size case final value?) 'Size': value,
+      if (instance.name case final value?) 'Name': value,
+      'IsRemote': instance.isRemote,
+      if (instance.runTimeTicks case final value?) 'RunTimeTicks': value,
+      'SupportsTranscoding': instance.supportsTranscoding,
+      'SupportsDirectStream': instance.supportsDirectStream,
+      'SupportsDirectPlay': instance.supportsDirectPlay,
+      'IsInfiniteStream': instance.isInfiniteStream,
+      'RequiresOpening': instance.requiresOpening,
+      if (instance.openToken case final value?) 'OpenToken': value,
+      'RequiresClosing': instance.requiresClosing,
+      if (instance.liveStreamId case final value?) 'LiveStreamId': value,
+      if (instance.bufferMs case final value?) 'BufferMs': value,
+      'RequiresLooping': instance.requiresLooping,
+      'SupportsProbing': instance.supportsProbing,
+      if (instance.video3DFormat case final value?) 'Video3DFormat': value,
+      'MediaStreams': instance.mediaStreams.map((e) => e.toJson()).toList(),
+      if (instance.formats case final value?) 'Formats': value,
+      if (instance.bitrate case final value?) 'Bitrate': value,
+      if (instance.timestamp case final value?) 'Timestamp': value,
+      if (instance.requiredHttpHeaders case final value?)
+        'RequiredHttpHeaders': value,
+      if (instance.transcodingUrl case final value?) 'TranscodingUrl': value,
+      if (instance.transcodingSubProtocol case final value?)
+        'TranscodingSubProtocol': value,
+      if (instance.transcodingContainer case final value?)
+        'TranscodingContainer': value,
+      if (instance.analyzeDurationMs case final value?)
+        'AnalyzeDurationMs': value,
+      'ReadAtNativeFramerate': instance.readAtNativeFramerate,
+      if (instance.defaultAudioStreamIndex case final value?)
+        'DefaultAudioStreamIndex': value,
+      if (instance.defaultSubtitleStreamIndex case final value?)
+        'DefaultSubtitleStreamIndex': value,
+      if (instance.etag case final value?) 'Etag': value,
+      'IgnoreDts': instance.ignoreDts,
+      'IgnoreIndex': instance.ignoreIndex,
+      'GenPtsInput': instance.genPtsInput,
+      if (instance.videoType case final value?) 'VideoType': value,
+      if (instance.isoType case final value?) 'IsoType': value,
+      if (instance.mediaAttachments?.map((e) => e.toJson()).toList()
+          case final value?)
+        'MediaAttachments': value,
+    };
 
 MediaStream _$MediaStreamFromJson(Map json) => MediaStream(
       codec: json['Codec'] as String?,
@@ -4357,64 +4390,59 @@ MediaStream _$MediaStreamFromJson(Map json) => MediaStream(
       ..localizedDefault = json['LocalizedDefault'] as String?
       ..localizedForced = json['LocalizedForced'] as String?;
 
-Map<String, dynamic> _$MediaStreamToJson(MediaStream instance) {
-  final val = <String, dynamic>{};
-
-  void writeNotNull(String key, dynamic value) {
-    if (value != null) {
-      val[key] = value;
-    }
-  }
-
-  writeNotNull('Codec', instance.codec);
-  writeNotNull('CodecTag', instance.codecTag);
-  writeNotNull('Language', instance.language);
-  writeNotNull('ColorTransfer', instance.colorTransfer);
-  writeNotNull('ColorPrimaries', instance.colorPrimaries);
-  writeNotNull('ColorSpace', instance.colorSpace);
-  writeNotNull('Comment', instance.comment);
-  writeNotNull('TimeBase', instance.timeBase);
-  writeNotNull('CodecTimeBase', instance.codecTimeBase);
-  writeNotNull('Title', instance.title);
-  writeNotNull('VideoRange', instance.videoRange);
-  writeNotNull('DisplayTitle', instance.displayTitle);
-  writeNotNull('NalLengthSize', instance.nalLengthSize);
-  val['IsInterlaced'] = instance.isInterlaced;
-  writeNotNull('IsAVC', instance.isAVC);
-  writeNotNull('ChannelLayout', instance.channelLayout);
-  writeNotNull('BitRate', instance.bitRate);
-  writeNotNull('BitDepth', instance.bitDepth);
-  writeNotNull('RefFrames', instance.refFrames);
-  writeNotNull('PacketLength', instance.packetLength);
-  writeNotNull('Channels', instance.channels);
-  writeNotNull('SampleRate', instance.sampleRate);
-  val['IsDefault'] = instance.isDefault;
-  val['IsForced'] = instance.isForced;
-  writeNotNull('Height', instance.height);
-  writeNotNull('Width', instance.width);
-  writeNotNull('AverageFrameRate', instance.averageFrameRate);
-  writeNotNull('RealFrameRate', instance.realFrameRate);
-  writeNotNull('Profile', instance.profile);
-  val['Type'] = instance.type;
-  writeNotNull('AspectRatio', instance.aspectRatio);
-  val['Index'] = instance.index;
-  writeNotNull('Score', instance.score);
-  val['IsExternal'] = instance.isExternal;
-  writeNotNull('DeliveryMethod', instance.deliveryMethod);
-  writeNotNull('DeliveryUrl', instance.deliveryUrl);
-  writeNotNull('IsExternalUrl', instance.isExternalUrl);
-  val['IsTextSubtitleStream'] = instance.isTextSubtitleStream;
-  val['SupportsExternalStream'] = instance.supportsExternalStream;
-  writeNotNull('Path', instance.path);
-  writeNotNull('PixelFormat', instance.pixelFormat);
-  writeNotNull('Level', instance.level);
-  writeNotNull('IsAnamorphic', instance.isAnamorphic);
-  writeNotNull('ColorRange', instance.colorRange);
-  writeNotNull('LocalizedUndefined', instance.localizedUndefined);
-  writeNotNull('LocalizedDefault', instance.localizedDefault);
-  writeNotNull('LocalizedForced', instance.localizedForced);
-  return val;
-}
+Map<String, dynamic> _$MediaStreamToJson(MediaStream instance) =>
+    <String, dynamic>{
+      if (instance.codec case final value?) 'Codec': value,
+      if (instance.codecTag case final value?) 'CodecTag': value,
+      if (instance.language case final value?) 'Language': value,
+      if (instance.colorTransfer case final value?) 'ColorTransfer': value,
+      if (instance.colorPrimaries case final value?) 'ColorPrimaries': value,
+      if (instance.colorSpace case final value?) 'ColorSpace': value,
+      if (instance.comment case final value?) 'Comment': value,
+      if (instance.timeBase case final value?) 'TimeBase': value,
+      if (instance.codecTimeBase case final value?) 'CodecTimeBase': value,
+      if (instance.title case final value?) 'Title': value,
+      if (instance.videoRange case final value?) 'VideoRange': value,
+      if (instance.displayTitle case final value?) 'DisplayTitle': value,
+      if (instance.nalLengthSize case final value?) 'NalLengthSize': value,
+      'IsInterlaced': instance.isInterlaced,
+      if (instance.isAVC case final value?) 'IsAVC': value,
+      if (instance.channelLayout case final value?) 'ChannelLayout': value,
+      if (instance.bitRate case final value?) 'BitRate': value,
+      if (instance.bitDepth case final value?) 'BitDepth': value,
+      if (instance.refFrames case final value?) 'RefFrames': value,
+      if (instance.packetLength case final value?) 'PacketLength': value,
+      if (instance.channels case final value?) 'Channels': value,
+      if (instance.sampleRate case final value?) 'SampleRate': value,
+      'IsDefault': instance.isDefault,
+      'IsForced': instance.isForced,
+      if (instance.height case final value?) 'Height': value,
+      if (instance.width case final value?) 'Width': value,
+      if (instance.averageFrameRate case final value?)
+        'AverageFrameRate': value,
+      if (instance.realFrameRate case final value?) 'RealFrameRate': value,
+      if (instance.profile case final value?) 'Profile': value,
+      'Type': instance.type,
+      if (instance.aspectRatio case final value?) 'AspectRatio': value,
+      'Index': instance.index,
+      if (instance.score case final value?) 'Score': value,
+      'IsExternal': instance.isExternal,
+      if (instance.deliveryMethod case final value?) 'DeliveryMethod': value,
+      if (instance.deliveryUrl case final value?) 'DeliveryUrl': value,
+      if (instance.isExternalUrl case final value?) 'IsExternalUrl': value,
+      'IsTextSubtitleStream': instance.isTextSubtitleStream,
+      'SupportsExternalStream': instance.supportsExternalStream,
+      if (instance.path case final value?) 'Path': value,
+      if (instance.pixelFormat case final value?) 'PixelFormat': value,
+      if (instance.level case final value?) 'Level': value,
+      if (instance.isAnamorphic case final value?) 'IsAnamorphic': value,
+      if (instance.colorRange case final value?) 'ColorRange': value,
+      if (instance.localizedUndefined case final value?)
+        'LocalizedUndefined': value,
+      if (instance.localizedDefault case final value?)
+        'LocalizedDefault': value,
+      if (instance.localizedForced case final value?) 'LocalizedForced': value,
+    };
 
 MediaUrl _$MediaUrlFromJson(Map json) => MediaUrl(
       url: json['Url'] as String?,
@@ -4472,28 +4500,22 @@ UserItemDataDto _$UserItemDataDtoFromJson(Map json) => UserItemDataDto(
       itemId: json['ItemId'] as String?,
     );
 
-Map<String, dynamic> _$UserItemDataDtoToJson(UserItemDataDto instance) {
-  final val = <String, dynamic>{};
-
-  void writeNotNull(String key, dynamic value) {
-    if (value != null) {
-      val[key] = value;
-    }
-  }
-
-  writeNotNull('Rating', instance.rating);
-  writeNotNull('PlayedPercentage', instance.playedPercentage);
-  writeNotNull('UnplayedItemCount', instance.unplayedItemCount);
-  val['PlaybackPositionTicks'] = instance.playbackPositionTicks;
-  val['PlayCount'] = instance.playCount;
-  val['IsFavorite'] = instance.isFavorite;
-  writeNotNull('Likes', instance.likes);
-  writeNotNull('LastPlayedDate', instance.lastPlayedDate);
-  val['Played'] = instance.played;
-  writeNotNull('Key', instance.key);
-  writeNotNull('ItemId', instance.itemId);
-  return val;
-}
+Map<String, dynamic> _$UserItemDataDtoToJson(UserItemDataDto instance) =>
+    <String, dynamic>{
+      if (instance.rating case final value?) 'Rating': value,
+      if (instance.playedPercentage case final value?)
+        'PlayedPercentage': value,
+      if (instance.unplayedItemCount case final value?)
+        'UnplayedItemCount': value,
+      'PlaybackPositionTicks': instance.playbackPositionTicks,
+      'PlayCount': instance.playCount,
+      'IsFavorite': instance.isFavorite,
+      if (instance.likes case final value?) 'Likes': value,
+      if (instance.lastPlayedDate case final value?) 'LastPlayedDate': value,
+      'Played': instance.played,
+      if (instance.key case final value?) 'Key': value,
+      if (instance.itemId case final value?) 'ItemId': value,
+    };
 
 NameIdPair _$NameIdPairFromJson(Map json) => NameIdPair(
       name: json['Name'] as String?,
@@ -4656,30 +4678,22 @@ ImageBlurHashes _$ImageBlurHashesFromJson(Map json) => ImageBlurHashes(
       ),
     );
 
-Map<String, dynamic> _$ImageBlurHashesToJson(ImageBlurHashes instance) {
-  final val = <String, dynamic>{};
-
-  void writeNotNull(String key, dynamic value) {
-    if (value != null) {
-      val[key] = value;
-    }
-  }
-
-  writeNotNull('Primary', instance.primary);
-  writeNotNull('Art', instance.art);
-  writeNotNull('Backdrop', instance.backdrop);
-  writeNotNull('Banner', instance.banner);
-  writeNotNull('Logo', instance.logo);
-  writeNotNull('Thumb', instance.thumb);
-  writeNotNull('Disc', instance.disc);
-  writeNotNull('Box', instance.box);
-  writeNotNull('Screenshot', instance.screenshot);
-  writeNotNull('Menu', instance.menu);
-  writeNotNull('Chapter', instance.chapter);
-  writeNotNull('BoxRear', instance.boxRear);
-  writeNotNull('Profile', instance.profile);
-  return val;
-}
+Map<String, dynamic> _$ImageBlurHashesToJson(ImageBlurHashes instance) =>
+    <String, dynamic>{
+      if (instance.primary case final value?) 'Primary': value,
+      if (instance.art case final value?) 'Art': value,
+      if (instance.backdrop case final value?) 'Backdrop': value,
+      if (instance.banner case final value?) 'Banner': value,
+      if (instance.logo case final value?) 'Logo': value,
+      if (instance.thumb case final value?) 'Thumb': value,
+      if (instance.disc case final value?) 'Disc': value,
+      if (instance.box case final value?) 'Box': value,
+      if (instance.screenshot case final value?) 'Screenshot': value,
+      if (instance.menu case final value?) 'Menu': value,
+      if (instance.chapter case final value?) 'Chapter': value,
+      if (instance.boxRear case final value?) 'BoxRear': value,
+      if (instance.profile case final value?) 'Profile': value,
+    };
 
 MediaAttachment _$MediaAttachmentFromJson(Map json) => MediaAttachment(
       codec: json['Codec'] as String?,

--- a/lib/screens/downloads_settings_screen.dart
+++ b/lib/screens/downloads_settings_screen.dart
@@ -96,6 +96,7 @@ class _DownloadsSettingsScreenState extends State<DownloadsSettingsScreen> {
           const DownloadWorkersSelector(),
           // Do not limit enqueued downloads on IOS, it throttles them like crazy on its own.
           if (!Platform.isIOS) const ConcurentDownloadsSelector(),
+          const DownloadSizeWarningCutoffTile(),
         ],
       ),
     );
@@ -375,6 +376,48 @@ class RedownloadTranscodesSwitch extends ConsumerWidget {
                     AppLocalizations.of(scaffold)!.redownloadcomplete);
               }
             },
+    );
+  }
+}
+
+class DownloadSizeWarningCutoffTile extends StatefulWidget {
+  const DownloadSizeWarningCutoffTile({super.key});
+
+  @override
+  State<DownloadSizeWarningCutoffTile> createState() =>
+      _BufferSizeListTileState();
+}
+
+class _BufferSizeListTileState extends State<DownloadSizeWarningCutoffTile> {
+  final _controller = TextEditingController(
+      text: FinampSettingsHelper.finampSettings.downloadSizeWarningCutoff
+          .toString());
+
+  @override
+  Widget build(BuildContext context) {
+    return ListTile(
+      title: Text(AppLocalizations.of(context)!.downloadSizeWarningCutoff),
+      subtitle:
+          Text(AppLocalizations.of(context)!.downloadSizeWarningCutoffSubtitle),
+      trailing: SizedBox(
+        width: 50 * MediaQuery.of(context).textScaleFactor,
+        child: TextField(
+          controller: _controller,
+          textAlign: TextAlign.center,
+          keyboardType: TextInputType.number,
+          onChanged: (value) {
+            var valueInt = int.tryParse(value);
+
+            if (valueInt != null && !valueInt.isNegative) {
+              FinampSettings finampSettingsTemp =
+                  FinampSettingsHelper.finampSettings;
+              finampSettingsTemp.downloadSizeWarningCutoff = valueInt;
+              Hive.box<FinampSettings>("FinampSettings")
+                  .put("FinampSettings", finampSettingsTemp);
+            }
+          },
+        ),
+      ),
     );
   }
 }

--- a/lib/services/downloads_service.dart
+++ b/lib/services/downloads_service.dart
@@ -691,6 +691,17 @@ class DownloadsService {
         syncItemDownloadSettings(item);
       }
     });
+    _isar.writeTxnSync(() {
+      var itemsWithFiles = _isar.downloadItems
+          .where()
+          .typeEqualTo(DownloadItemType.song)
+          .or()
+          .typeEqualTo(DownloadItemType.image)
+          .findAllSync();
+      for (var item in itemsWithFiles) {
+        syncItemDownloadSettings(item);
+      }
+    });
     markOutdatedTranscodes();
 
     // Step 3 - Resync all nodes from anchor to connect up all needed nodes

--- a/lib/services/downloads_service.dart
+++ b/lib/services/downloads_service.dart
@@ -963,7 +963,7 @@ class DownloadsService {
         .first;
     if (!transcodeProfiles.nonNulls.contains(item.syncTranscodingProfile) ||
         (bestProfile.quality > (item.syncTranscodingProfile!.quality + 2000) &&
-            item.type == DownloadItemType.song)) {
+            item.type != DownloadItemType.image)) {
       _downloadsLogger.finest("Updating download settings for ${item.name}");
       item.syncTranscodingProfile = bestProfile;
       if ((item.state == DownloadItemState.enqueued ||

--- a/lib/services/downloads_service.dart
+++ b/lib/services/downloads_service.dart
@@ -5,7 +5,6 @@ import 'dart:io';
 import 'package:background_downloader/background_downloader.dart';
 import 'package:collection/collection.dart';
 import 'package:finamp/components/global_snackbar.dart';
-import 'package:finamp/services/finamp_user_helper.dart';
 import 'package:finamp/services/jellyfin_api_helper.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
@@ -933,9 +932,6 @@ class DownloadsService {
   /// location and transcode settings with the highest quality are selected.
   /// This should only be called inside an isar write transaction.
   void syncItemDownloadSettings(DownloadItem item) {
-    if (item.type == DownloadItemType.image) {
-      return;
-    }
     var transcodeProfiles =
         item.requiredBy.filter().syncTranscodingProfileProperty().findAllSync();
     if (transcodeProfiles.isEmpty) {
@@ -944,27 +940,25 @@ class DownloadsService {
       return;
     }
     transcodeProfiles.add(item.userTranscodingProfile);
-    if (transcodeProfiles.whereNotNull().isEmpty) {
+    if (transcodeProfiles.nonNulls.isEmpty) {
       _downloadsLogger
           .severe("No valid download profiles for required item ${item.name}");
       return;
     }
 
     // Prioritize original quality if allowed, otherwise choose highest quality approximation
-    DownloadProfile bestProfile = transcodeProfiles
-        .whereNotNull()
+    DownloadProfile bestProfile = transcodeProfiles.nonNulls
         .sorted((i, j) => ((j.quality - i.quality) * 1000).toInt())
         .first;
-    if (!transcodeProfiles
-            .whereNotNull()
-            .contains(item.syncTranscodingProfile) ||
-        bestProfile.quality > (item.syncTranscodingProfile!.quality + 2000)) {
+    if (!transcodeProfiles.nonNulls.contains(item.syncTranscodingProfile) ||
+        (bestProfile.quality > (item.syncTranscodingProfile!.quality + 2000) &&
+            item.type == DownloadItemType.song)) {
       _downloadsLogger.finest("Updating download settings for ${item.name}");
       item.syncTranscodingProfile = bestProfile;
       if ((item.state == DownloadItemState.enqueued ||
               item.state == DownloadItemState.downloading ||
               item.state == DownloadItemState.complete) &&
-          item.type == DownloadItemType.song &&
+          item.type.hasFiles &&
           FinampSettingsHelper.finampSettings.shouldRedownloadTranscodes) {
         if (item.state == DownloadItemState.complete) {
           updateItemState(item, DownloadItemState.needsRedownloadComplete,
@@ -990,6 +984,8 @@ class DownloadsService {
       var items = _isar.downloadItems
           .where()
           .typeEqualTo(DownloadItemType.song)
+          .or()
+          .typeEqualTo(DownloadItemType.image)
           .filter()
           .not()
           .stateEqualTo(DownloadItemState.notDownloaded)

--- a/lib/services/downloads_service_backend.dart
+++ b/lib/services/downloads_service_backend.dart
@@ -1000,7 +1000,7 @@ class DownloadsSyncService {
           try {
             var collectionChildren = await Future.wait(collectionIds.map((e) =>
                 _getCollectionInfo(e, DownloadItemType.collection, false)));
-            infoChildren.addAll(collectionChildren.whereNotNull());
+            infoChildren.addAll(collectionChildren.nonNulls);
           } catch (e) {
             _syncLogger
                 .info("Failed to download metadata for ${item.name}: $e");
@@ -1134,7 +1134,7 @@ class DownloadsSyncService {
         // the parent's download settings already may be skipped.
         for (var child in _isar.downloadItems
             .getAllSync(requiredChanges.$2.toList())
-            .whereNotNull()) {
+            .nonNulls) {
           if (child.syncTranscodingProfile !=
               canonParent!.syncTranscodingProfile) {
             _downloadsService.syncItemDownloadSettings(child);
@@ -1149,6 +1149,10 @@ class DownloadsSyncService {
         if (canonParent!.syncDownloadLocation == null) {
           _syncLogger.severe(
               "could not download ${parent.name}, no download location found.");
+          _isar.writeTxnSync(() {
+            _downloadsService.updateItemState(
+                canonParent!, DownloadItemState.failed);
+          });
         } else {
           await _initiateDownload(canonParent!);
         }
@@ -1175,7 +1179,7 @@ class DownloadsSyncService {
     var missingChildIds = newChildIds.difference(oldChildIds);
     var childrenToUnlink =
         (_isar.downloadItems.getAllSync(childIdsToUnlink.toList()))
-            .whereNotNull()
+            .nonNulls
             .toList();
     // anyOf filter allows all objects when given empty list, but we want no objects
     var childIdsToLink = (missingChildIds.isEmpty)
@@ -1289,8 +1293,8 @@ class DownloadsSyncService {
 
     if (_childCache.containsKey(item.id)) {
       var childIds = await _childCache[item.id]!;
-      return Future.wait(childIds.map((e) => _metadataCache[e]).whereNotNull())
-          .then((value) => value.whereNotNull().toList());
+      return Future.wait(childIds.map((e) => _metadataCache[e]).nonNulls)
+          .then((value) => value.nonNulls.toList());
     }
     Completer<List<String>> itemFetch = Completer();
     // This prevents errors in itemFetch being reported as unhandled.
@@ -1431,8 +1435,7 @@ class DownloadsSyncService {
         in (userHelper.currentUser?.views.values ?? <BaseItemDto>[])) {
       var children = await _getCollectionChildren(
           DownloadStub.fromItem(type: DownloadItemType.collection, item: view));
-      var childIds =
-          children.map((e) => e.baseItem?.id).whereNotNull().toList();
+      var childIds = children.map((e) => e.baseItem?.id).nonNulls.toList();
       if (childIds.contains(albumId)) {
         return view.id;
       }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -42,18 +42,18 @@ packages:
     dependency: transitive
     description:
       name: archive
-      sha256: cb6a278ef2dbb298455e1a713bda08524a175630ec643a242c399c932a0a1f7d
+      sha256: "6199c74e3db4fbfbd04f66d739e72fe11c8a8957d5f219f1f4482dbde6420b5a"
       url: "https://pub.dev"
     source: hosted
-    version: "3.6.1"
+    version: "4.0.2"
   args:
     dependency: transitive
     description:
       name: args
-      sha256: "7cf60b9f0cc88203c5a190b4cd62a99feea42759a7fa695010eb5de1c0b2252a"
+      sha256: bf9f5caeea8d8fe6721a9c358dd8a5c1947b27f1cfaa18b39c301273594919e6
       url: "https://pub.dev"
     source: hosted
-    version: "2.5.0"
+    version: "2.6.0"
   async:
     dependency: transitive
     description:
@@ -66,42 +66,42 @@ packages:
     dependency: "direct main"
     description:
       name: audio_service
-      sha256: "9dd5ba7e77567b290c35908b1950d61485b4dfdd3a0ac398e98cfeec04651b75"
+      sha256: "887ddf15fce31fd12aa8044c3bffd14c58929fb20e31d96284fe3aaf48315ac6"
       url: "https://pub.dev"
     source: hosted
-    version: "0.18.15"
+    version: "0.18.17"
   audio_service_mpris:
     dependency: "direct main"
     description:
       name: audio_service_mpris
-      sha256: b16db3584a4b2464c0bfd575c1a21765723d257931222f8adfcb0511f940d352
+      sha256: fdab1ae1f659c6db36d5cc396e46e4ee9663caefa6153f8453fcd01d57567c08
       url: "https://pub.dev"
     source: hosted
-    version: "0.1.5"
+    version: "0.2.0"
   audio_service_platform_interface:
     dependency: "direct main"
     description:
       name: audio_service_platform_interface
-      sha256: "8431a455dac9916cc9ee6f7da5620a666436345c906ad2ebb7fa41d18b3c1bf4"
+      sha256: "6283782851f6c8b501b60904a32fc7199dc631172da0629d7301e66f672ab777"
       url: "https://pub.dev"
     source: hosted
-    version: "0.1.1"
+    version: "0.1.3"
   audio_service_web:
     dependency: transitive
     description:
       name: audio_service_web
-      sha256: "4cdc2127cd4562b957fb49227dc58e3303fafb09bde2573bc8241b938cf759d9"
+      sha256: b8ea9243201ee53383157fbccf13d5d2a866b5dda922ec19d866d1d5d70424df
       url: "https://pub.dev"
     source: hosted
-    version: "0.1.3"
+    version: "0.1.4"
   audio_session:
     dependency: "direct main"
     description:
       name: audio_session
-      sha256: b2a26ba8b7efa1790d6460e82971fde3e398cfbe2295df9dea22f3499d2c12a7
+      sha256: "2b7fff16a552486d078bfc09a8cde19f426dc6d6329262b684182597bec5b1ac"
       url: "https://pub.dev"
     source: hosted
-    version: "0.1.23"
+    version: "0.1.25"
   auto_size_text:
     dependency: "direct main"
     description:
@@ -114,10 +114,10 @@ packages:
     dependency: "direct main"
     description:
       name: background_downloader
-      sha256: "91448c0fcb41af14ede14485c33b8ca684fcd6c0ac0a439be9f83fa964753e13"
+      sha256: ed64a215cd24c83a478f602364a3ca86a6dafd178ad783188cc32c6956d5e529
       url: "https://pub.dev"
     source: hosted
-    version: "8.6.0"
+    version: "8.9.4"
   balanced_text:
     dependency: "direct main"
     description:
@@ -131,10 +131,10 @@ packages:
     dependency: "direct main"
     description:
       name: battery_plus
-      sha256: "220c8f1961efb01d6870493b5ac5a80afaeaffc8757f7a11ed3025a8570d29e7"
+      sha256: a0409fe7d21905987eb1348ad57c634f913166f14f0c8936b73d3f5940fac551
       url: "https://pub.dev"
     source: hosted
-    version: "6.2.0"
+    version: "6.2.1"
   battery_plus_platform_interface:
     dependency: transitive
     description:
@@ -155,10 +155,10 @@ packages:
     dependency: transitive
     description:
       name: build
-      sha256: "80184af8b6cb3e5c1c4ec6d8544d27711700bc3e6d2efad04238c7b5290889f0"
+      sha256: cef23f1eda9b57566c81e2133d196f8e3df48f244b317368d65c5943d91148f0
       url: "https://pub.dev"
     source: hosted
-    version: "2.4.1"
+    version: "2.4.2"
   build_cli_annotations:
     dependency: transitive
     description:
@@ -171,42 +171,42 @@ packages:
     dependency: transitive
     description:
       name: build_config
-      sha256: bf80fcfb46a29945b423bd9aad884590fb1dc69b330a4d4700cac476af1708d1
+      sha256: "4ae2de3e1e67ea270081eaee972e1bd8f027d459f249e0f1186730784c2e7e33"
       url: "https://pub.dev"
     source: hosted
-    version: "1.1.1"
+    version: "1.1.2"
   build_daemon:
     dependency: transitive
     description:
       name: build_daemon
-      sha256: "79b2aef6ac2ed00046867ed354c88778c9c0f029df8a20fe10b5436826721ef9"
+      sha256: "8e928697a82be082206edb0b9c99c5a4ad6bc31c9e9b8b2f291ae65cd4a25daa"
       url: "https://pub.dev"
     source: hosted
-    version: "4.0.2"
+    version: "4.0.4"
   build_resolvers:
     dependency: transitive
     description:
       name: build_resolvers
-      sha256: "339086358431fa15d7eca8b6a36e5d783728cf025e559b834f4609a1fcfb7b0a"
+      sha256: b9e4fda21d846e192628e7a4f6deda6888c36b5b69ba02ff291a01fd529140f0
       url: "https://pub.dev"
     source: hosted
-    version: "2.4.2"
+    version: "2.4.4"
   build_runner:
     dependency: "direct dev"
     description:
       name: build_runner
-      sha256: "028819cfb90051c6b5440c7e574d1896f8037e3c96cf17aaeb054c9311cfbf4d"
+      sha256: "058fe9dce1de7d69c4b84fada934df3e0153dd000758c4d65964d0166779aa99"
       url: "https://pub.dev"
     source: hosted
-    version: "2.4.13"
+    version: "2.4.15"
   build_runner_core:
     dependency: transitive
     description:
       name: build_runner_core
-      sha256: f8126682b87a7282a339b871298cc12009cb67109cfa1614d6436fb0289193e0
+      sha256: "22e3aa1c80e0ada3722fe5b63fd43d9c8990759d0a2cf489c8c5d7b2bdebc021"
       url: "https://pub.dev"
     source: hosted
-    version: "7.3.2"
+    version: "8.0.0"
   built_collection:
     dependency: transitive
     description:
@@ -219,10 +219,10 @@ packages:
     dependency: transitive
     description:
       name: built_value
-      sha256: c7913a9737ee4007efedaffc968c049fd0f3d0e49109e778edc10de9426005cb
+      sha256: "28a712df2576b63c6c005c465989a348604960c0958d28be5303ba9baa841ac2"
       url: "https://pub.dev"
     source: hosted
-    version: "8.9.2"
+    version: "8.9.3"
   characters:
     dependency: transitive
     description:
@@ -243,18 +243,18 @@ packages:
     dependency: "direct main"
     description:
       name: chopper
-      sha256: "40899b729fb6d8969d967264b189efaf2452bc3ccf6ed0782d00f1d8a6161c31"
+      sha256: "18928a74069cf1c257e657809c1b84b0304d8e32a6fc446dd2bbb28657e0358a"
       url: "https://pub.dev"
     source: hosted
-    version: "8.0.3"
+    version: "8.1.0"
   chopper_generator:
     dependency: "direct dev"
     description:
       name: chopper_generator
-      sha256: de438569cba1e2a2888e8d91e3c2ac60106574eea7f36823ed0334e96146328a
+      sha256: "2cb23febc9ac9bbc9288b4703e60f3edc8e301a2ef5057d0c22369eab7313c6d"
       url: "https://pub.dev"
     source: hosted
-    version: "8.0.3"
+    version: "8.1.0"
   ci:
     dependency: transitive
     description:
@@ -339,42 +339,50 @@ packages:
     dependency: transitive
     description:
       name: crypto
-      sha256: ec30d999af904f33454ba22ed9a86162b35e52b44ac4807d1d93c288041d7d27
+      sha256: "1e445881f28f22d6140f181e07737b22f1e099a5e1ff94b0af2f9e4a463f4855"
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.5"
+    version: "3.0.6"
   custom_lint:
     dependency: "direct dev"
     description:
       name: custom_lint
-      sha256: "7c0aec12df22f9082146c354692056677f1e70bc43471644d1fdb36c6fdda799"
+      sha256: "3486c470bb93313a9417f926c7dd694a2e349220992d7b9d14534dc49c15bba9"
       url: "https://pub.dev"
     source: hosted
-    version: "0.6.4"
+    version: "0.7.0"
   custom_lint_builder:
     dependency: transitive
     description:
       name: custom_lint_builder
-      sha256: d7dc41e709dde223806660268678be7993559e523eb3164e2a1425fd6f7615a9
+      sha256: "42cdc41994eeeddab0d7a722c7093ec52bd0761921eeb2cbdbf33d192a234759"
       url: "https://pub.dev"
     source: hosted
-    version: "0.6.4"
+    version: "0.7.0"
   custom_lint_core:
     dependency: transitive
     description:
       name: custom_lint_core
-      sha256: a85e8f78f4c52f6c63cdaf8c872eb573db0231dcdf3c3a5906d493c1f8bc20e6
+      sha256: "02450c3e45e2a6e8b26c4d16687596ab3c4644dd5792e3313aa9ceba5a49b7f5"
       url: "https://pub.dev"
     source: hosted
-    version: "0.6.3"
+    version: "0.7.0"
+  custom_lint_visitor:
+    dependency: transitive
+    description:
+      name: custom_lint_visitor
+      sha256: "36282d85714af494ee2d7da8c8913630aa6694da99f104fb2ed4afcf8fc857d8"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.0+7.3.0"
   dart_style:
     dependency: transitive
     description:
       name: dart_style
-      sha256: "7856d364b589d1f08986e140938578ed36ed948581fbc3bc9aef1805039ac5ab"
+      sha256: "7306ab8a2359a48d22310ad823521d723acfed60ee1f7e37388e8986853b6820"
       url: "https://pub.dev"
     source: hosted
-    version: "2.3.7"
+    version: "2.3.8"
   dartx:
     dependency: transitive
     description:
@@ -387,34 +395,34 @@ packages:
     dependency: transitive
     description:
       name: dbus
-      sha256: "365c771ac3b0e58845f39ec6deebc76e3276aa9922b0cc60840712094d9047ac"
+      sha256: "79e0c23480ff85dc68de79e2cd6334add97e48f7f4865d17686dd6ea81a47e8c"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.10"
+    version: "0.7.11"
   device_info_plus:
     dependency: "direct main"
     description:
       name: device_info_plus
-      sha256: c4af09051b4f0508f6c1dc0a5c085bf014d5c9a4a0678ce1799c2b4d716387a0
+      sha256: "72d146c6d7098689ff5c5f66bcf593ac11efc530095385356e131070333e64da"
       url: "https://pub.dev"
     source: hosted
-    version: "11.1.0"
+    version: "11.3.0"
   device_info_plus_platform_interface:
     dependency: transitive
     description:
       name: device_info_plus_platform_interface
-      sha256: "282d3cf731045a2feb66abfe61bbc40870ae50a3ed10a4d3d217556c35c8c2ba"
+      sha256: "0b04e02b30791224b31969eb1b50d723498f402971bff3630bca2ba839bd1ed2"
       url: "https://pub.dev"
     source: hosted
-    version: "7.0.1"
+    version: "7.0.2"
   equatable:
     dependency: transitive
     description:
       name: equatable
-      sha256: c2b87cb7756efdf69892005af546c56c0b5037f54d2a88269b4f347a505e3ca2
+      sha256: "567c64b3cb4cf82397aac55f4f0cbd3ca20d77c6c03bedbc4ceaddc08904aef7"
       url: "https://pub.dev"
     source: hosted
-    version: "2.0.5"
+    version: "2.0.7"
   fading_edge_scrollview:
     dependency: transitive
     description:
@@ -451,10 +459,10 @@ packages:
     dependency: "direct main"
     description:
       name: file_picker
-      sha256: aac85f20436608e01a6ffd1fdd4e746a7f33c93a2c83752e626bdfaea139b877
+      sha256: "3d57312a53746ed4eb8c843dc50372454bbda37dd0c01a4d40fedc83e2ce4921"
       url: "https://pub.dev"
     source: hosted
-    version: "8.1.3"
+    version: "8.3.5"
   file_sizes:
     dependency: "direct main"
     description:
@@ -496,26 +504,26 @@ packages:
     dependency: transitive
     description:
       name: flutter_gen_core
-      sha256: "638d518897f1aefc55a24278968027591d50223a6943b6ae9aa576fe1494d99d"
+      sha256: "53890b653738f34363d9f0d40f82104c261716bd551d3ba65f648770b6764c21"
       url: "https://pub.dev"
     source: hosted
-    version: "5.7.0"
+    version: "5.9.0"
   flutter_gen_runner:
     dependency: "direct dev"
     description:
       name: flutter_gen_runner
-      sha256: "7f2f02d95e3ec96cf70a1c515700c0dd3ea905af003303a55d6fb081240e6b8a"
+      sha256: de70b42eb5329f712c8b041069d081ad5fb5109f32d6d1ea9c1b39596786215d
       url: "https://pub.dev"
     source: hosted
-    version: "5.7.0"
+    version: "5.9.0"
   flutter_launcher_icons:
     dependency: "direct dev"
     description:
       name: flutter_launcher_icons
-      sha256: "619817c4b65b322b5104b6bb6dfe6cda62d9729bd7ad4303ecc8b4e690a67a77"
+      sha256: bfa04787c85d80ecb3f8777bde5fc10c3de809240c48fa061a2c2bf15ea5211c
       url: "https://pub.dev"
     source: hosted
-    version: "0.14.1"
+    version: "0.14.3"
   flutter_lints:
     dependency: "direct dev"
     description:
@@ -533,10 +541,10 @@ packages:
     dependency: transitive
     description:
       name: flutter_plugin_android_lifecycle
-      sha256: "9ee02950848f61c4129af3d6ec84a1cfc0e47931abc746b03e7a3bc3e8ff6eda"
+      sha256: "615a505aef59b151b46bbeef55b36ce2b6ed299d160c51d84281946f0aa0ce0e"
       url: "https://pub.dev"
     source: hosted
-    version: "2.0.22"
+    version: "2.0.24"
   flutter_riverpod:
     dependency: "direct main"
     description:
@@ -573,10 +581,10 @@ packages:
     dependency: "direct main"
     description:
       name: flutter_svg
-      sha256: "7b4ca6cf3304575fe9c8ec64813c8d02ee41d2afe60bcfe0678bcb5375d596a2"
+      sha256: c200fd79c918a40c5cd50ea0877fa13f81bdaf6f0a5d3dbcc2a13e3285d6aa1b
       url: "https://pub.dev"
     source: hosted
-    version: "2.0.10+1"
+    version: "2.0.17"
   flutter_tabler_icons:
     dependency: "direct main"
     description:
@@ -647,10 +655,10 @@ packages:
     dependency: transitive
     description:
       name: glob
-      sha256: "0e7014b3b7d4dac1ca4d6114f82bf1782ee86745b9b42a92c9289c23d8a0ab63"
+      sha256: c3f1ee72c96f8f78935e18aa8cecced9ab132419e8625dc187e1c2408efc20de
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.2"
+    version: "2.1.3"
   graphs:
     dependency: transitive
     description:
@@ -695,50 +703,50 @@ packages:
     dependency: transitive
     description:
       name: hotreloader
-      sha256: ed56fdc1f3a8ac924e717257621d09e9ec20e308ab6352a73a50a1d7a4d9158e
+      sha256: bc167a1163807b03bada490bfe2df25b0d744df359227880220a5cbd04e5734b
       url: "https://pub.dev"
     source: hosted
-    version: "4.2.0"
+    version: "4.3.0"
   http:
     dependency: transitive
     description:
       name: http
-      sha256: b9c29a161230ee03d3ccf545097fccd9b87a5264228c5d348202e0f0c28f9010
+      sha256: fe7ab022b76f3034adc518fb6ea04a82387620e19977665ea18d30a1cf43442f
       url: "https://pub.dev"
     source: hosted
-    version: "1.2.2"
+    version: "1.3.0"
   http_multi_server:
     dependency: transitive
     description:
       name: http_multi_server
-      sha256: "97486f20f9c2f7be8f514851703d0119c3596d14ea63227af6f7a481ef2b2f8b"
+      sha256: aa6199f908078bb1c5efb8d8638d4ae191aac11b311132c3ef48ce352fb52ef8
       url: "https://pub.dev"
     source: hosted
-    version: "3.2.1"
+    version: "3.2.2"
   http_parser:
     dependency: transitive
     description:
       name: http_parser
-      sha256: "2aa08ce0341cc9b354a498388e30986515406668dbcc4f7c950c3e715496693b"
+      sha256: "178d74305e7866013777bab2c3d8726205dc5a4dd935297175b19a23a2e66571"
       url: "https://pub.dev"
     source: hosted
-    version: "4.0.2"
+    version: "4.1.2"
   image:
     dependency: transitive
     description:
       name: image
-      sha256: "2237616a36c0d69aef7549ab439b833fb7f9fb9fc861af2cc9ac3eedddd69ca8"
+      sha256: "8346ad4b5173924b5ddddab782fc7d8a6300178c8b1dc427775405a01701c4a6"
       url: "https://pub.dev"
     source: hosted
-    version: "4.2.0"
+    version: "4.5.2"
   image_size_getter:
     dependency: transitive
     description:
       name: image_size_getter
-      sha256: f98c4246144e9b968899d2dfde69091e22a539bb64bc9b0bea51505fbb490e57
+      sha256: "9a299e3af2ebbcfd1baf21456c3c884037ff524316c97d8e56035ea8fdf35653"
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.3"
+    version: "2.4.0"
   infinite_scroll_pagination:
     dependency: "direct main"
     description:
@@ -759,10 +767,10 @@ packages:
     dependency: transitive
     description:
       name: io
-      sha256: "2ec25704aba361659e10e3e5f5d672068d332fc8ac516421d483a11e5cbd061e"
+      sha256: dfd5a80599cf0165756e3181807ed3e77daf6dd4137caaad72d0b7931597650b
       url: "https://pub.dev"
     source: hosted
-    version: "1.0.4"
+    version: "1.0.5"
   isar:
     dependency: "direct main"
     description:
@@ -807,18 +815,18 @@ packages:
     dependency: "direct dev"
     description:
       name: json_serializable
-      sha256: ea1432d167339ea9b5bb153f0571d0039607a873d6e04e0117af043f14a1fd4b
+      sha256: c2fcb3920cf2b6ae6845954186420fca40bc0a8abcc84903b7801f17d7050d7c
       url: "https://pub.dev"
     source: hosted
-    version: "6.8.0"
+    version: "6.9.0"
   just_audio:
     dependency: "direct main"
     description:
       name: just_audio
-      sha256: "1a1eb86e7d81e69a1d36943f2b3efd62dece3dad2cafd9ec2e62e6db7c04d9b7"
+      sha256: f978d5b4ccea08f267dae0232ec5405c1b05d3f3cd63f82097ea46c015d5c09e
       url: "https://pub.dev"
     source: hosted
-    version: "0.9.43"
+    version: "0.9.46"
   just_audio_media_kit:
     dependency: "direct main"
     description:
@@ -831,18 +839,18 @@ packages:
     dependency: transitive
     description:
       name: just_audio_platform_interface
-      sha256: "0243828cce503c8366cc2090cefb2b3c871aa8ed2f520670d76fd47aa1ab2790"
+      sha256: "271b93b484c6f494ecd72a107fffbdb26b425f170c665b9777a0a24a726f2f24"
       url: "https://pub.dev"
     source: hosted
-    version: "4.3.0"
+    version: "4.4.0"
   just_audio_web:
     dependency: transitive
     description:
       name: just_audio_web
-      sha256: "9a98035b8b24b40749507687520ec5ab404e291d2b0937823ff45d92cb18d448"
+      sha256: "58915be64509a7683c44bf11cd1a23c15a48de104927bee116e3c63c8eeea0d4"
       url: "https://pub.dev"
     source: hosted
-    version: "0.4.13"
+    version: "0.4.14"
   leak_tracker:
     dependency: transitive
     description:
@@ -871,10 +879,10 @@ packages:
     dependency: transitive
     description:
       name: lints
-      sha256: "3315600f3fb3b135be672bf4a178c55f274bebe368325ae18462c89ac1e3b413"
+      sha256: c35bb79562d980e9a453fc715854e1ed39e24e7d0297a880ef54e17f9874a9d7
       url: "https://pub.dev"
     source: hosted
-    version: "5.0.0"
+    version: "5.1.1"
   locale_names:
     dependency: "direct main"
     description:
@@ -960,10 +968,10 @@ packages:
     dependency: transitive
     description:
       name: mime
-      sha256: "801fd0b26f14a4a58ccb09d5892c3fbdeff209594300a542492cf13fba9d247a"
+      sha256: "41a20518f0cb1256669420fdba0cd90d21561e560ac240f26ef8322e45bb7ed6"
       url: "https://pub.dev"
     source: hosted
-    version: "1.0.6"
+    version: "2.0.0"
   msix:
     dependency: "direct dev"
     description:
@@ -992,26 +1000,26 @@ packages:
     dependency: transitive
     description:
       name: package_config
-      sha256: "1c5b77ccc91e4823a5af61ee74e6b972db1ef98c2ff5a18d3161c982a55448bd"
+      sha256: "92d4488434b520a62570293fbd33bb556c7d49230791c1b4bbd973baf6d2dc67"
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.0"
+    version: "2.1.1"
   package_info_plus:
     dependency: "direct main"
     description:
       name: package_info_plus
-      sha256: a75164ade98cb7d24cfd0a13c6408927c6b217fa60dee5a7ff5c116a58f28918
+      sha256: "67eae327b1b0faf761964a1d2e5d323c797f3799db0e85aa232db8d9e922bc35"
       url: "https://pub.dev"
     source: hosted
-    version: "8.0.2"
+    version: "8.2.1"
   package_info_plus_platform_interface:
     dependency: transitive
     description:
       name: package_info_plus_platform_interface
-      sha256: ac1f4a4847f1ade8e6a87d1f39f5d7c67490738642e2542f559ec38c37489a66
+      sha256: "205ec83335c2ab9107bbba3f8997f9356d72ca3c715d2f038fc773d0366b4c76"
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.1"
+    version: "3.1.0"
   palette_generator:
     dependency: "direct main"
     description:
@@ -1033,34 +1041,34 @@ packages:
     dependency: transitive
     description:
       name: path_parsing
-      sha256: e3e67b1629e6f7e8100b367d3db6ba6af4b1f0bb80f64db18ef1fbabd2fa9ccf
+      sha256: "883402936929eac138ee0a45da5b0f2c80f89913e6dc3bf77eb65b84b409c6ca"
       url: "https://pub.dev"
     source: hosted
-    version: "1.0.1"
+    version: "1.1.0"
   path_provider:
     dependency: "direct main"
     description:
       name: path_provider
-      sha256: fec0d61223fba3154d87759e3cc27fe2c8dc498f6386c6d6fc80d1afdd1bf378
+      sha256: "50c5dd5b6e1aaf6fb3a78b33f6aa3afca52bf903a8a5298f53101fdaee55bbcd"
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.4"
+    version: "2.1.5"
   path_provider_android:
     dependency: transitive
     description:
       name: path_provider_android
-      sha256: "6f01f8e37ec30b07bc424b4deabac37cacb1bc7e2e515ad74486039918a37eb7"
+      sha256: "4adf4fd5423ec60a29506c76581bc05854c55e3a0b72d35bb28d661c9686edf2"
       url: "https://pub.dev"
     source: hosted
-    version: "2.2.10"
+    version: "2.2.15"
   path_provider_foundation:
     dependency: transitive
     description:
       name: path_provider_foundation
-      sha256: f234384a3fdd67f989b4d54a5d73ca2a6c422fa55ae694381ae0f4375cd1ea16
+      sha256: "4843174df4d288f5e29185bd6e72a6fbdf5a4a4602717eed565497429f179942"
       url: "https://pub.dev"
     source: hosted
-    version: "2.4.0"
+    version: "2.4.1"
   path_provider_linux:
     dependency: transitive
     description:
@@ -1097,10 +1105,10 @@ packages:
     dependency: transitive
     description:
       name: permission_handler_android
-      sha256: "76e4ab092c1b240d31177bb64d2b0bea43f43d0e23541ec866151b9f7b2490fa"
+      sha256: "71bbecfee799e65aff7c744761a57e817e73b738fedf62ab7afd5593da21f9f1"
       url: "https://pub.dev"
     source: hosted
-    version: "12.0.12"
+    version: "12.0.13"
   permission_handler_apple:
     dependency: transitive
     description:
@@ -1113,10 +1121,10 @@ packages:
     dependency: transitive
     description:
       name: permission_handler_html
-      sha256: af26edbbb1f2674af65a8f4b56e1a6f526156bc273d0e65dd8075fab51c78851
+      sha256: "38f000e83355abb3392140f6bc3030660cfaef189e1f87824facb76300b4ff24"
       url: "https://pub.dev"
     source: hosted
-    version: "0.1.3+2"
+    version: "0.1.3+5"
   permission_handler_platform_interface:
     dependency: transitive
     description:
@@ -1145,10 +1153,10 @@ packages:
     dependency: transitive
     description:
       name: platform
-      sha256: "9b71283fc13df574056616011fb138fd3b793ea47cc509c189a6c3fa5f8a1a65"
+      sha256: "5d6b1b0036a5f331ebc77c850ebc8506cbc1e9416c27e59b439f917a902a4984"
       url: "https://pub.dev"
     source: hosted
-    version: "3.1.5"
+    version: "3.1.6"
   plugin_platform_interface:
     dependency: transitive
     description:
@@ -1165,6 +1173,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.5.1"
+  posix:
+    dependency: transitive
+    description:
+      name: posix
+      sha256: a0117dc2167805aa9125b82eee515cc891819bac2f538c83646d355b16f58b9a
+      url: "https://pub.dev"
+    source: hosted
+    version: "6.0.1"
   provider:
     dependency: "direct main"
     description:
@@ -1177,26 +1193,26 @@ packages:
     dependency: transitive
     description:
       name: pub_semver
-      sha256: "40d3ab1bbd474c4c2328c91e3a7df8c6dd629b79ece4c4bd04bee496a224fb0c"
+      sha256: "7b3cfbf654f3edd0c6298ecd5be782ce997ddf0e00531b9464b55245185bbbbd"
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.4"
+    version: "2.1.5"
   pubspec_parse:
     dependency: transitive
     description:
       name: pubspec_parse
-      sha256: c799b721d79eb6ee6fa56f00c04b472dcd44a30d258fac2174a6ec57302678f8
+      sha256: "0560ba233314abbed0a48a2956f7f022cce7c3e1e73df540277da7544cad4082"
       url: "https://pub.dev"
     source: hosted
-    version: "1.3.0"
+    version: "1.5.0"
   qs_dart:
     dependency: transitive
     description:
       name: qs_dart
-      sha256: be73d060d29c0716ded88380ba32e87ce8105f0ba234edb3edefa0d74d47d64b
+      sha256: "98a068f7224fe17b68028dbbd43dd48a6049d2de2175f50b2fad2e08f2811f0e"
       url: "https://pub.dev"
     source: hosted
-    version: "1.2.4"
+    version: "1.3.2"
   recursive_regex:
     dependency: transitive
     description:
@@ -1217,10 +1233,10 @@ packages:
     dependency: transitive
     description:
       name: riverpod_analyzer_utils
-      sha256: "0dcb0af32d561f8fa000c6a6d95633c9fb08ea8a8df46e3f9daca59f11218167"
+      sha256: c6b8222b2b483cb87ae77ad147d6408f400c64f060df7a225b127f4afef4f8c8
       url: "https://pub.dev"
     source: hosted
-    version: "0.5.6"
+    version: "0.5.8"
   riverpod_annotation:
     dependency: "direct main"
     description:
@@ -1233,26 +1249,26 @@ packages:
     dependency: "direct dev"
     description:
       name: riverpod_generator
-      sha256: "851aedac7ad52693d12af3bf6d92b1626d516ed6b764eb61bf19e968b5e0b931"
+      sha256: "63546d70952015f0981361636bf8f356d9cfd9d7f6f0815e3c07789a41233188"
       url: "https://pub.dev"
     source: hosted
-    version: "2.6.1"
+    version: "2.6.3"
   riverpod_lint:
     dependency: "direct dev"
     description:
       name: riverpod_lint
-      sha256: "0684c21a9a4582c28c897d55c7b611fa59a351579061b43f8c92c005804e63a8"
+      sha256: "83e4caa337a9840469b7b9bd8c2351ce85abad80f570d84146911b32086fbd99"
       url: "https://pub.dev"
     source: hosted
-    version: "2.6.1"
+    version: "2.6.3"
   rxdart:
     dependency: "direct main"
     description:
       name: rxdart
-      sha256: "0c7c0cedd93788d996e33041ffecda924cc54389199cde4e6a34b440f50044cb"
+      sha256: "5c3004a4a8dbb94bd4bf5412a4def4acdaa12e12f269737a5751369e12d1a962"
       url: "https://pub.dev"
     source: hosted
-    version: "0.27.7"
+    version: "0.28.0"
   safe_local_storage:
     dependency: transitive
     description:
@@ -1313,34 +1329,34 @@ packages:
     dependency: "direct main"
     description:
       name: share_plus
-      sha256: "3af2cda1752e5c24f2fc04b6083b40f013ffe84fb90472f30c6499a9213d5442"
+      sha256: fce43200aa03ea87b91ce4c3ac79f0cecd52e2a7a56c7a4185023c271fbfa6da
       url: "https://pub.dev"
     source: hosted
-    version: "10.1.1"
+    version: "10.1.4"
   share_plus_platform_interface:
     dependency: transitive
     description:
       name: share_plus_platform_interface
-      sha256: c57c0bbfec7142e3a0f55633be504b796af72e60e3c791b44d5a017b985f7a48
+      sha256: cc012a23fc2d479854e6c80150696c4a5f5bb62cb89af4de1c505cf78d0a5d0b
       url: "https://pub.dev"
     source: hosted
-    version: "5.0.1"
+    version: "5.0.2"
   shelf:
     dependency: transitive
     description:
       name: shelf
-      sha256: ad29c505aee705f41a4d8963641f91ac4cee3c8fad5947e033390a7bd8180fa4
+      sha256: e7dd780a7ffb623c57850b33f43309312fc863fb6aa3d276a754bb299839ef12
       url: "https://pub.dev"
     source: hosted
-    version: "1.4.1"
+    version: "1.4.2"
   shelf_web_socket:
     dependency: transitive
     description:
       name: shelf_web_socket
-      sha256: "073c147238594ecd0d193f3456a5fe91c4b0abbcc68bf5cd95b36c4e194ac611"
+      sha256: "3632775c8e90d6c9712f883e633716432a27758216dfb61bd86a8321c0580925"
       url: "https://pub.dev"
     source: hosted
-    version: "2.0.0"
+    version: "3.0.0"
   simple_gesture_detector:
     dependency: "direct main"
     description:
@@ -1382,10 +1398,10 @@ packages:
     dependency: transitive
     description:
       name: source_helper
-      sha256: "6adebc0006c37dd63fe05bca0a929b99f06402fc95aa35bf36d67f5c06de01fd"
+      sha256: "86d247119aedce8e63f4751bd9626fc9613255935558447569ad42f9f5b48b3c"
       url: "https://pub.dev"
     source: hosted
-    version: "1.3.4"
+    version: "1.3.5"
   source_span:
     dependency: transitive
     description:
@@ -1415,18 +1431,42 @@ packages:
     dependency: transitive
     description:
       name: sqflite
-      sha256: ff5a2436ef8ebdfda748fbfe957f9981524cb5ff11e7bafa8c42771840e8a788
+      sha256: "2d7299468485dca85efeeadf5d38986909c5eb0cd71fd3db2c2f000e6c9454bb"
       url: "https://pub.dev"
     source: hosted
-    version: "2.3.3+2"
+    version: "2.4.1"
+  sqflite_android:
+    dependency: transitive
+    description:
+      name: sqflite_android
+      sha256: "78f489aab276260cdd26676d2169446c7ecd3484bbd5fead4ca14f3ed4dd9ee3"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.4.0"
   sqflite_common:
     dependency: transitive
     description:
       name: sqflite_common
-      sha256: "2d8e607db72e9cb7748c9c6e739e2c9618320a5517de693d5a24609c4671b1a4"
+      sha256: "761b9740ecbd4d3e66b8916d784e581861fd3c3553eda85e167bc49fdb68f709"
       url: "https://pub.dev"
     source: hosted
-    version: "2.5.4+4"
+    version: "2.5.4+6"
+  sqflite_darwin:
+    dependency: transitive
+    description:
+      name: sqflite_darwin
+      sha256: "22adfd9a2c7d634041e96d6241e6e1c8138ca6817018afc5d443fef91dcefa9c"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.4.1+1"
+  sqflite_platform_interface:
+    dependency: transitive
+    description:
+      name: sqflite_platform_interface
+      sha256: "8dd4515c7bdcae0a785b0062859336de775e8c65db81ae33dd5445f35be61920"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.4.0"
   stack_trace:
     dependency: transitive
     description:
@@ -1455,10 +1495,10 @@ packages:
     dependency: transitive
     description:
       name: stream_transform
-      sha256: "14a00e794c7c11aa145a170587321aedce29769c08d7f58b1d141da75e3b1c6f"
+      sha256: ad47125e588cfd37a9a7f86c7d6356dde8dfe89d071d293f80ca9e9273a33871
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.0"
+    version: "2.1.1"
   string_scanner:
     dependency: transitive
     description:
@@ -1495,26 +1535,26 @@ packages:
     dependency: transitive
     description:
       name: time
-      sha256: ad8e018a6c9db36cb917a031853a1aae49467a93e0d464683e029537d848c221
+      sha256: "370572cf5d1e58adcb3e354c47515da3f7469dac3a95b447117e728e7be6f461"
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.4"
+    version: "2.1.5"
   timing:
     dependency: transitive
     description:
       name: timing
-      sha256: "70a3b636575d4163c477e6de42f247a23b315ae20e86442bebe32d3cabf61c32"
+      sha256: "62ee18aca144e4a9f29d212f5a4c6a053be252b895ab14b5821996cff4ed90fe"
       url: "https://pub.dev"
     source: hosted
-    version: "1.0.1"
+    version: "1.0.2"
   typed_data:
     dependency: transitive
     description:
       name: typed_data
-      sha256: facc8d6582f16042dd49f2463ff1bd6e2c9ef9f3d5da3d9b087e244a7b564b3c
+      sha256: f9049c039ebfeb4cf7a7104a675823cd72dba8297f264b6637062516699fa006
       url: "https://pub.dev"
     source: hosted
-    version: "1.3.2"
+    version: "1.4.0"
   universal_io:
     dependency: transitive
     description:
@@ -1559,34 +1599,34 @@ packages:
     dependency: transitive
     description:
       name: url_launcher_android
-      sha256: e35a698ac302dd68e41f73250bd9517fe3ab5fa4f18fe4647a0872db61bacbab
+      sha256: "6fc2f56536ee873eeb867ad176ae15f304ccccc357848b351f6f0d8d4a40d193"
       url: "https://pub.dev"
     source: hosted
-    version: "6.3.10"
+    version: "6.3.14"
   url_launcher_ios:
     dependency: transitive
     description:
       name: url_launcher_ios
-      sha256: e43b677296fadce447e987a2f519dcf5f6d1e527dc35d01ffab4fff5b8a7063e
+      sha256: "16a513b6c12bb419304e72ea0ae2ab4fed569920d1c7cb850263fe3acc824626"
       url: "https://pub.dev"
     source: hosted
-    version: "6.3.1"
+    version: "6.3.2"
   url_launcher_linux:
     dependency: transitive
     description:
       name: url_launcher_linux
-      sha256: e2b9622b4007f97f504cd64c0128309dfb978ae66adbe944125ed9e1750f06af
+      sha256: "4e9ba368772369e3e08f231d2301b4ef72b9ff87c31192ef471b380ef29a4935"
       url: "https://pub.dev"
     source: hosted
-    version: "3.2.0"
+    version: "3.2.1"
   url_launcher_macos:
     dependency: transitive
     description:
       name: url_launcher_macos
-      sha256: "769549c999acdb42b8bcfa7c43d72bf79a382ca7441ab18a808e101149daf672"
+      sha256: "17ba2000b847f334f16626a574c702b196723af2a289e7a93ffcb79acff855c2"
       url: "https://pub.dev"
     source: hosted
-    version: "3.2.1"
+    version: "3.2.2"
   url_launcher_platform_interface:
     dependency: transitive
     description:
@@ -1599,18 +1639,18 @@ packages:
     dependency: transitive
     description:
       name: url_launcher_web
-      sha256: "772638d3b34c779ede05ba3d38af34657a05ac55b06279ea6edd409e323dca8e"
+      sha256: "3ba963161bd0fe395917ba881d320b9c4f6dd3c4a233da62ab18a5025c85f1e9"
       url: "https://pub.dev"
     source: hosted
-    version: "2.3.3"
+    version: "2.4.0"
   url_launcher_windows:
     dependency: transitive
     description:
       name: url_launcher_windows
-      sha256: "49c10f879746271804767cb45551ec5592cdab00ee105c06dddde1a98f73b185"
+      sha256: "3284b6d2ac454cf34f114e1d3319866fdd1e19cdc329999057e44ffe936cfa77"
       url: "https://pub.dev"
     source: hosted
-    version: "3.1.2"
+    version: "3.1.4"
   uuid:
     dependency: "direct main"
     description:
@@ -1631,26 +1671,26 @@ packages:
     dependency: transitive
     description:
       name: vector_graphics
-      sha256: "32c3c684e02f9bc0afb0ae0aa653337a2fe022e8ab064bcd7ffda27a74e288e3"
+      sha256: "44cc7104ff32563122a929e4620cf3efd584194eec6d1d913eb5ba593dbcf6de"
       url: "https://pub.dev"
     source: hosted
-    version: "1.1.11+1"
+    version: "1.1.18"
   vector_graphics_codec:
     dependency: transitive
     description:
       name: vector_graphics_codec
-      sha256: c86987475f162fadff579e7320c7ddda04cd2fdeffbe1129227a85d9ac9e03da
+      sha256: "99fd9fbd34d9f9a32efd7b6a6aae14125d8237b10403b422a6a6dfeac2806146"
       url: "https://pub.dev"
     source: hosted
-    version: "1.1.11+1"
+    version: "1.1.13"
   vector_graphics_compiler:
     dependency: transitive
     description:
       name: vector_graphics_compiler
-      sha256: "12faff3f73b1741a36ca7e31b292ddeb629af819ca9efe9953b70bd63fc8cd81"
+      sha256: "1b4b9e706a10294258727674a340ae0d6e64a7231980f9f9a3d12e4b42407aad"
       url: "https://pub.dev"
     source: hosted
-    version: "1.1.11+1"
+    version: "1.1.16"
   vector_math:
     dependency: transitive
     description:
@@ -1679,34 +1719,34 @@ packages:
     dependency: "direct main"
     description:
       name: wakelock_plus
-      sha256: bf4ee6f17a2fa373ed3753ad0e602b7603f8c75af006d5b9bdade263928c0484
+      sha256: "36c88af0b930121941345306d259ec4cc4ecca3b151c02e3a9e71aede83c615e"
       url: "https://pub.dev"
     source: hosted
-    version: "1.2.8"
+    version: "1.2.10"
   wakelock_plus_platform_interface:
     dependency: transitive
     description:
       name: wakelock_plus_platform_interface
-      sha256: "422d1cdbb448079a8a62a5a770b69baa489f8f7ca21aef47800c726d404f9d16"
+      sha256: "70e780bc99796e1db82fe764b1e7dcb89a86f1e5b3afb1db354de50f2e41eb7a"
       url: "https://pub.dev"
     source: hosted
-    version: "1.2.1"
+    version: "1.2.2"
   watcher:
     dependency: transitive
     description:
       name: watcher
-      sha256: "3d2ad6751b3c16cf07c7fca317a1413b3f26530319181b37e3b9039b84fc01d8"
+      sha256: "69da27e49efa56a15f8afe8f4438c4ec02eff0a117df1b22ea4aad194fe1c104"
       url: "https://pub.dev"
     source: hosted
-    version: "1.1.0"
+    version: "1.1.1"
   weak_map:
     dependency: transitive
     description:
       name: weak_map
-      sha256: "95ca338f0cdf5f0022cc283dfa4d97f6f6b03752f67eca85ebe6d7a679ffe3ed"
+      sha256: "5f8e5d5ce57dc624db5fae814dd689ccae1f17f92b426e52f0a7cbe7f6f4ab97"
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.1"
+    version: "4.0.1"
   web:
     dependency: transitive
     description:
@@ -1715,22 +1755,30 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.1.0"
+  web_socket:
+    dependency: transitive
+    description:
+      name: web_socket
+      sha256: "3c12d96c0c9a4eec095246debcea7b86c0324f22df69893d538fcc6f1b8cce83"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.1.6"
   web_socket_channel:
     dependency: transitive
     description:
       name: web_socket_channel
-      sha256: d88238e5eac9a42bb43ca4e721edba3c08c6354d4a53063afaa568516217621b
+      sha256: "0b8e2457400d8a859b7b2030786835a28a8e80836ef64402abef392ff4f1d0e5"
       url: "https://pub.dev"
     source: hosted
-    version: "2.4.0"
+    version: "3.0.2"
   win32:
     dependency: transitive
     description:
       name: win32
-      sha256: "4d45dc9069dba4619dc0ebd93c7cec5e66d8482cb625a370ac806dcc8165f2ec"
+      sha256: daf97c9d80197ed7b619040e86c8ab9a9dad285e7671ee7390f9180cc828a51e
       url: "https://pub.dev"
     source: hosted
-    version: "5.5.5"
+    version: "5.10.1"
   win32_registry:
     dependency: transitive
     description:
@@ -1767,18 +1815,18 @@ packages:
     dependency: transitive
     description:
       name: xxh3
-      sha256: cbeb0e1d10f4c6bf67b650f395eac0cc689425b5efc2ba0cc3d3e069a0beaeec
+      sha256: "399a0438f5d426785723c99da6b16e136f4953fb1e9db0bf270bd41dd4619916"
       url: "https://pub.dev"
     source: hosted
-    version: "1.1.0"
+    version: "1.2.0"
   yaml:
     dependency: transitive
     description:
       name: yaml
-      sha256: "75769501ea3489fca56601ff33454fe45507ea3bfb014161abc3b43ae25989d5"
+      sha256: b9da305ac7c39faa3f030eccd175340f968459dae4af175130b3fc47e40d76ce
       url: "https://pub.dev"
     source: hosted
-    version: "3.1.2"
+    version: "3.1.3"
 sdks:
-  dart: ">=3.5.0 <4.0.0"
-  flutter: ">=3.24.0"
+  dart: ">=3.6.0 <4.0.0"
+  flutter: ">=3.27.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -43,10 +43,10 @@ dependencies:
       path: libs/windows/media_kit_libs_windows_audio
   smtc_windows: ^1.0.0
   audio_service: ^0.18.15
-  audio_service_mpris: ^0.1.5
+  audio_service_mpris: ^0.2.0
   audio_service_platform_interface: ^0.1.1
   audio_session: ^0.1.21
-  rxdart: ^0.27.7
+  rxdart: ^0.28.0
   simple_gesture_detector: ^0.2.0
   path_provider: ^2.0.14
   hive: ^2.2.3


### PR DESCRIPTION
Added warning text to downloads dialog for downloads with more than 150 songs.  Download dialog will be shown if this triggers, even if no download settings are needed.  This necessitates a 1 request delay before the dialog shows, which for me can take quite a while if the artist page is still loading because my server is very slow, but which should hopefully be fairly quick for most people.

Additional fixes:
- Reworded custom download location warning to mention the issue with the "Music" directory.
- Padded minutes to two digits for any time over an hour in queue time remaining display.
- Altered app name of android debug builds to make them less confusing when a release build is installed.