### PR TITLE
[Redesign] Adding Albums to Playlists and Private Playlists

### DIFF
--- a/lib/components/AddToPlaylistScreen/add_to_playlist_list.dart
+++ b/lib/components/AddToPlaylistScreen/add_to_playlist_list.dart
@@ -4,6 +4,7 @@ import 'package:collection/collection.dart';
 import 'package:finamp/components/Buttons/cta_medium.dart';
 import 'package:finamp/components/PlayerScreen/queue_source_helper.dart';
 import 'package:finamp/components/album_image.dart';
+import 'package:finamp/models/finamp_models.dart';
 import 'package:finamp/services/downloads_service.dart';
 import 'package:finamp/services/finamp_settings_helper.dart';
 import 'package:finamp/services/jellyfin_api_helper.dart';
@@ -13,6 +14,7 @@ import 'package:flutter_tabler_icons/flutter_tabler_icons.dart';
 import 'package:get_it/get_it.dart';
 
 import '../../models/jellyfin_models.dart';
+import '../confirmation_prompt_dialog.dart';
 import '../global_snackbar.dart';
 import 'new_playlist_dialog.dart';
 import 'playlist_actions_menu.dart';
@@ -123,12 +125,23 @@ class _AddToPlaylistListState extends State<AddToPlaylistList> {
                   await Future.delayed(const Duration(seconds: 1));
                   final jellyfinApiHelper = GetIt.instance<JellyfinApiHelper>();
                   var playlist = await jellyfinApiHelper.getItemById(newId);
-                  var playlistItems = await jellyfinApiHelper.getItems(
-                      parentItem: playlist, fields: "");
-                  var song = playlistItems?.firstWhere(
-                      (element) => element.id == widget.itemToAdd.id);
+                  String? songId;
+                  if (BaseItemDtoType.fromItem(widget.itemToAdd) ==
+                      BaseItemDtoType.song) {
+                    var playlistItems = await jellyfinApiHelper.getItems(
+                        parentItem: playlist, fields: "");
+                    songId = playlistItems
+                        ?.firstWhere(
+                            (element) => element.id == widget.itemToAdd.id)
+                        .playlistItemId;
+                  } else {
+                    // Provide a fake playlist id for playlists created with a non-song initial item.  It
+                    // will not be used as non-songs cannot be removed.
+                    songId = "";
+                  }
+                  if (!context.mounted) return;
                   setState(() {
-                    var newItem = [(playlist, false, song?.playlistItemId)];
+                    var newItem = [(playlist, false, songId)];
                     playlistsFuture =
                         oldFuture.then((value) => value + newItem);
                   });
@@ -208,6 +221,10 @@ class _AddToPlaylistTileState extends State<AddToPlaylistTile> {
       initialState: itemIsIncluded ?? false,
       onToggle: (bool currentState) async {
         if (currentState) {
+          // Only songs can be removed from playlists
+          if (BaseItemDtoType.fromItem(widget.song) != BaseItemDtoType.song) {
+            return true;
+          }
           // If playlistItemId is null, we need to fetch from the server before we can remove
           if (playlistItemId == null) {
             final jellyfinApiHelper = GetIt.instance<JellyfinApiHelper>();
@@ -242,6 +259,30 @@ class _AddToPlaylistTileState extends State<AddToPlaylistTile> {
           return !removed;
         } else {
           // add to playlist
+          if (BaseItemDtoType.fromItem(widget.song) != BaseItemDtoType.song) {
+            bool confirmed = false;
+            String itemType = switch (widget.song.type) {
+              "MusicAlbum" => "album",
+              "MusicArtist" => "artist",
+              "MusicGenre" => "genre",
+              "Playlist" => "playlist",
+              _ => "unknown"
+            };
+            await showDialog(
+                context: context,
+                builder: (context) => ConfirmationPromptDialog(
+                      promptText: AppLocalizations.of(context)!
+                          .confirmAddAlbumToPlaylist(
+                              itemType, widget.song.name ?? "Unknown"),
+                      confirmButtonText:
+                          AppLocalizations.of(context)!.addButtonLabel,
+                      abortButtonText:
+                          MaterialLocalizations.of(context).cancelButtonLabel,
+                      onConfirmed: () => confirmed = true,
+                      onAborted: () {},
+                    ));
+            if (!confirmed || !context.mounted) return false;
+          }
           bool added =
               await addItemToPlaylist(context, widget.song, widget.playlist);
           if (added) {

--- a/lib/components/AddToPlaylistScreen/new_playlist_dialog.dart
+++ b/lib/components/AddToPlaylistScreen/new_playlist_dialog.dart
@@ -31,24 +31,45 @@ class _NewPlaylistDialogState extends State<NewPlaylistDialog> {
   bool _isSubmitting = false;
 
   String? _name;
+  bool? _public;
   @override
   Widget build(BuildContext context) {
     return AlertDialog(
       title: Text(AppLocalizations.of(context)!.newPlaylist),
       content: Form(
         key: _formKey,
-        child: TextFormField(
-          decoration:
-              InputDecoration(labelText: AppLocalizations.of(context)!.name),
-          textInputAction: TextInputAction.done,
-          validator: (value) {
-            if (value == null || value.isEmpty) {
-              return AppLocalizations.of(context)!.required;
-            }
-            return null;
-          },
-          onFieldSubmitted: (_) async => await _submit(),
-          onSaved: (newValue) => _name = newValue,
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            TextFormField(
+              decoration: InputDecoration(
+                  labelText: AppLocalizations.of(context)!.name),
+              textInputAction: TextInputAction.done,
+              validator: (value) {
+                if (value == null || value.isEmpty) {
+                  return AppLocalizations.of(context)!.required;
+                }
+                return null;
+              },
+              onFieldSubmitted: (_) async => await _submit(),
+              onSaved: (newValue) => _name = newValue,
+            ),
+            FormField<bool>(
+              builder: (state) {
+                return CheckboxListTile(
+                  value: state.value,
+                  title: Text(
+                    AppLocalizations.of(context)!.publiclyVisiblePlaylist,
+                    textAlign: TextAlign.end,
+                  ),
+                  onChanged: state.didChange,
+                  contentPadding: EdgeInsets.zero,
+                );
+              },
+              initialValue: true,
+              onSaved: (newValue) => _public = newValue,
+            )
+          ],
         ),
       ),
       actions: [
@@ -58,7 +79,7 @@ class _NewPlaylistDialogState extends State<NewPlaylistDialog> {
           child: Text(MaterialLocalizations.of(context).cancelButtonLabel),
         ),
         TextButton(
-          onPressed: _isSubmitting ? null : () async => await _submit(),
+          onPressed: () async => await _submit(),
           child: Text(AppLocalizations.of(context)!.createButtonLabel),
         ),
       ],
@@ -66,11 +87,9 @@ class _NewPlaylistDialogState extends State<NewPlaylistDialog> {
   }
 
   Future<void> _submit() async {
+    if (_isSubmitting) return;
     if (_formKey.currentState != null && _formKey.currentState!.validate()) {
-      setState(() {
-        _isSubmitting = true;
-      });
-
+      _isSubmitting = true;
       _formKey.currentState!.save();
 
       Navigator.of(context).pop<(Future<String>, String?)?>((
@@ -79,6 +98,7 @@ class _NewPlaylistDialogState extends State<NewPlaylistDialog> {
             name: _name,
             ids: [widget.itemToAdd],
             userId: _finampUserHelper.currentUser!.id,
+            isPublic: _public,
           ));
 
           GlobalSnackbar.message(

--- a/lib/components/MusicScreen/album_item.dart
+++ b/lib/components/MusicScreen/album_item.dart
@@ -16,6 +16,7 @@ import '../../screens/artist_screen.dart';
 import '../../services/downloads_service.dart';
 import '../../services/favorite_provider.dart';
 import '../../services/jellyfin_api_helper.dart';
+import '../AddToPlaylistScreen/playlist_actions_menu.dart';
 import '../AlbumScreen/download_dialog.dart';
 import '../global_snackbar.dart';
 import 'album_item_card.dart';
@@ -34,6 +35,7 @@ enum _AlbumListTileMenuItems {
   addToQueue,
   shuffleToQueue,
   goToArtist,
+  addToPlaylist,
 }
 
 //TODO should this be unified with artist screen version?
@@ -274,6 +276,13 @@ class _AlbumItemState extends ConsumerState<AlbumItem> {
                 title: Text(AppLocalizations.of(context)!.goToArtist),
               ),
             ),
+          PopupMenuItem<_AlbumListTileMenuItems>(
+            value: _AlbumListTileMenuItems.addToPlaylist,
+            child: ListTile(
+              leading: const Icon(Icons.playlist_add),
+              title: Text(local.addToPlaylistTitle),
+            ),
+          ),
         ],
       );
 
@@ -610,8 +619,8 @@ class _AlbumItemState extends ConsumerState<AlbumItem> {
             GlobalSnackbar.error(e);
             return;
           }
-          if (mounted) {
-            Navigator.of(context)
+          if (context.mounted) {
+            await Navigator.of(context)
                 .pushNamed(ArtistScreen.routeName, arguments: artist);
           }
         case null:
@@ -624,6 +633,14 @@ class _AlbumItemState extends ConsumerState<AlbumItem> {
           var item = DownloadStub.fromItem(
               type: DownloadItemType.collection, item: widget.album);
           await downloadsService.deleteDownload(stub: item);
+        case _AlbumListTileMenuItems.addToPlaylist:
+          if (context.mounted) {
+            await showPlaylistActionsMenu(
+              context: context,
+              item: widget.album,
+              parentPlaylist: null,
+            );
+          }
       }
     }
 

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -1852,5 +1852,22 @@
   "downloadSizeWarningCutoffSubtitle": "A warning message will be displayed when downloading more than this many songs at once.",
   "@downloadSizeWarningCutoffSubtitle": {
     "description": "Subtitle for the setting controlling when to warn about a large download"
+  },
+  "confirmAddAlbumToPlaylist": "Are you sure you want add all tracks from {itemType, select, album{album} playlist{playlist} artist{artist} genre{genre} other{item}} '{itemName}' to this playlist?  They can only be removed individually.",
+  "@confirmAddAlbumToPlaylist": {
+    "description": "Warning dialog for adding an album, artist, or similar to a playlist, clarifying that this cannot be undone without removing all tracks individually.",
+    "placeholders": {
+      "itemType": {
+        "type": "String",
+        "example": "album"
+      },
+      "itemName": {
+        "type": "String"
+      }
+    }
+  },
+  "publiclyVisiblePlaylist": "Publicly Visible:",
+  "@publiclyVisiblePlaylist": {
+    "description": "Toggle for playlist creation where true means the playlist is publicly visible, false means only the creator can see it."
   }
 }

--- a/lib/l10n/app_pl.arb
+++ b/lib/l10n/app_pl.arb
@@ -290,7 +290,7 @@
   "@setSleepTimer": {},
   "enterLowPriorityStateOnPause": "Przechodź w stan niskiego priorytetu w trakcie trwania pauzy",
   "@enterLowPriorityStateOnPause": {},
-  "songCount": "{count,plural,=1{{count} Utwór} =2..4{{count} Utwory} other{{count} Utworów}}",
+  "songCount": "{count,plural,=1{{count} Utwór} few{{count} Utwory} other{{count} Utworów}}",
   "@songCount": {
     "placeholders": {
       "count": {
@@ -900,7 +900,7 @@
   "@playbackSpeedControlSettingSubtitle": {
     "description": "Subtitle for the playback speed visibility setting"
   },
-  "albumCount": "{count,plural,=1{{count} Album} =3{{count} Albumy} =4{{count} Albumy} other{{count} Albumów}}",
+  "albumCount": "{count,plural,=1{{count} Album} few{{count} Albumy} other{{count} Albumów}}",
   "@albumCount": {
     "placeholders": {
       "count": {
@@ -1080,7 +1080,7 @@
   "@shuffleAlbumsToQueue": {
     "description": "Label for action that shuffles all albums of an artist or genre and adds them at the end of the regular queue"
   },
-  "playCountValue": "{playCount,plural,=1{{playCount} odtworzenie} =2{{playCount} odtworzenia} =3{{playCount} odtworzenia} =4{{playCount} odtworzenia} other{{playCount} odtworzeń}}",
+  "playCountValue": "{playCount,plural,=1{{playCount} odtworzenie} few{{playCount} odtworzenia} other{{playCount} odtworzeń}}",
   "@playCountValue": {
     "placeholders": {
       "playCount": {
@@ -1469,7 +1469,7 @@
   "@confirmShuffleNext": {
     "description": "A confirmation message that is shown after successfully shuffling a list (album, playlist, etc.) to the front of the \"Next Up\" queue"
   },
-  "queueRestoreSubtitle2": "{count,plural,=1{1 utwór} =2..4{{count} Utwory} other{{count} Utworów}}, {remaining} nieodtworzonych",
+  "queueRestoreSubtitle2": "{count,plural,=1{1 utwór} few{{count} Utwory} other{{count} Utworów}}, {remaining} nieodtworzonych",
   "@queueRestoreSubtitle2": {
     "description": "Description of length of a saved queue",
     "placeholders": {

--- a/lib/models/jellyfin_models.dart
+++ b/lib/models/jellyfin_models.dart
@@ -3362,6 +3362,7 @@ class NewPlaylist {
     required this.ids,
     this.userId,
     this.mediaType,
+    this.isPublic,
   });
 
   /// Gets or sets the name of the new playlist.
@@ -3376,6 +3377,9 @@ class NewPlaylist {
 
   /// Gets or sets the media type.
   String? mediaType;
+
+  /// Whether the playlist should be publicly visible
+  bool? isPublic;
 
   factory NewPlaylist.fromJson(Map<String, dynamic> json) =>
       _$NewPlaylistFromJson(json);

--- a/lib/models/jellyfin_models.g.dart
+++ b/lib/models/jellyfin_models.g.dart
@@ -4766,6 +4766,7 @@ NewPlaylist _$NewPlaylistFromJson(Map json) => NewPlaylist(
       ids: (json['Ids'] as List<dynamic>).map((e) => e as String).toList(),
       userId: json['UserId'] as String?,
       mediaType: json['MediaType'] as String?,
+      isPublic: json['IsPublic'] as bool?,
     );
 
 Map<String, dynamic> _$NewPlaylistToJson(NewPlaylist instance) =>
@@ -4774,6 +4775,7 @@ Map<String, dynamic> _$NewPlaylistToJson(NewPlaylist instance) =>
       'Ids': instance.ids,
       'UserId': instance.userId,
       'MediaType': instance.mediaType,
+      'IsPublic': instance.isPublic,
     };
 
 NewPlaylistResponse _$NewPlaylistResponseFromJson(Map json) =>

--- a/lib/services/downloads_service.dart
+++ b/lib/services/downloads_service.dart
@@ -1456,7 +1456,7 @@ class DownloadsService {
   /// needed, such as when building ImageProviders.  Exactly one of the two arguments
   /// should be provided.
   DownloadItem? getImageDownload({BaseItemDto? item, String? blurHash}) {
-    assert((item?.blurHash == null) != (blurHash == null));
+    assert((item == null) != (blurHash == null));
     String? imageId = blurHash ?? item!.blurHash ?? item!.imageId;
     if (imageId == null) {
       return null;


### PR DESCRIPTION
Allows albums, artists, and the like to be added to playlists.  Jellyfin responds to this by adding all songs the item contains to the playlist without us needing to manually list them out.  Also, an option has been added allowing the user to select public or private visibility when creating a playlist.