### PR TITLE
iOS UI Fixes in Album/Artist/Genre Screen Lists.

### DIFF
--- a/lib/screens/album_screen.dart
+++ b/lib/screens/album_screen.dart
@@ -40,7 +40,8 @@ class _AlbumScreenState extends State<AlbumScreen> {
 
     return Scaffold(
       extendBody: true,
-      body: ValueListenableBuilder<Box<FinampSettings>>(
+      body: SafeArea(
+        child: ValueListenableBuilder<Box<FinampSettings>>(
           valueListenable: FinampSettingsHelper.finampSettingsListener,
           builder: (context, box, widget) {
             bool isOffline = box.get("FinampSettings")?.isOffline ?? false;
@@ -109,7 +110,9 @@ class _AlbumScreenState extends State<AlbumScreen> {
                 }
               },
             );
-          }),
+          }
+        ),
+      ),
       bottomNavigationBar: const NowPlayingBar(),
     );
   }

--- a/lib/screens/artist_screen.dart
+++ b/lib/screens/artist_screen.dart
@@ -22,8 +22,10 @@ class ArtistScreen extends StatelessWidget {
 
     return Scaffold(
       extendBody: true,
-      body: ArtistScreenContent(
-        parent: artist,
+      body: SafeArea(
+        child: ArtistScreenContent(
+         parent: artist,
+        ),
       ),
       bottomNavigationBar: const NowPlayingBar(),
     );


### PR DESCRIPTION
Scrolling down on a list in the album, artist or genre screen caused the title bar to clash with the iOS status bar.
Mentioned in https://github.com/jmshrv/finamp/issues/1060.

Added `SafeArea()` around the list bodies, now it looks like this:
![Bildschirmfoto 2025-02-20 um 23 47 11](https://github.com/user-attachments/assets/2cb9b266-5e8d-4aff-8245-7143096e8278)
