### PR TITLE
Rename DownloadItemType.track back to song

### DIFF
--- a/lib/components/AlbumScreen/track_list_tile.dart
+++ b/lib/components/AlbumScreen/track_list_tile.dart
@@ -413,7 +413,7 @@ class TrackListItemState extends ConsumerState<TrackListItem>
     if (FinampSettingsHelper.finampSettings.isOffline) {
       playable = ref.watch(GetIt.instance<DownloadsService>()
           .stateProvider(DownloadStub.fromItem(
-              type: DownloadItemType.track, item: widget.baseItem))
+              type: DownloadItemType.song, item: widget.baseItem))
           .select((value) => value.value?.isComplete ?? false));
     } else {
       playable = true;
@@ -717,7 +717,7 @@ class TrackListItemTile extends StatelessWidget {
                           offset: const Offset(-1.5, 2.5),
                           child: DownloadedIndicator(
                             item: DownloadStub.fromItem(
-                                item: baseItem, type: DownloadItemType.track),
+                                item: baseItem, type: DownloadItemType.song),
                             size: Theme.of(context)
                                     .textTheme
                                     .bodyMedium!

--- a/lib/components/AlbumScreen/track_menu.dart
+++ b/lib/components/AlbumScreen/track_menu.dart
@@ -226,7 +226,7 @@ class _TrackMenuState extends ConsumerState<TrackMenu> {
   List<Widget> _menuEntries(BuildContext context) {
     final downloadsService = GetIt.instance<DownloadsService>();
     final downloadStatus = downloadsService.getStatus(
-        DownloadStub.fromItem(type: DownloadItemType.track, item: widget.item),
+        DownloadStub.fromItem(type: DownloadItemType.song, item: widget.item),
         null);
     var iconColor = Theme.of(context).colorScheme.primary;
 
@@ -242,7 +242,7 @@ class _TrackMenuState extends ConsumerState<TrackMenu> {
     String? parentTooltip;
     if (downloadStatus.isIncidental) {
       var parent = downloadsService.getFirstRequiringItem(DownloadStub.fromItem(
-          type: DownloadItemType.track, item: widget.item));
+          type: DownloadItemType.song, item: widget.item));
       if (parent != null) {
         var parentName = AppLocalizations.of(context)!
             .itemTypeSubtitle(parent.baseItemType.name, parent.name);
@@ -410,7 +410,7 @@ class _TrackMenuState extends ConsumerState<TrackMenu> {
               enabled: downloadStatus.isRequired,
               onTap: () async {
                 var item = DownloadStub.fromItem(
-                    type: DownloadItemType.track, item: widget.item);
+                    type: DownloadItemType.song, item: widget.item);
                 await askBeforeDeleteDownloadFromDevice(context, item);
               })),
       Visibility(
@@ -425,7 +425,7 @@ class _TrackMenuState extends ConsumerState<TrackMenu> {
               downloadStatus == DownloadItemStatus.notNeeded,
           onTap: () async {
             var item = DownloadStub.fromItem(
-                type: DownloadItemType.track, item: widget.item);
+                type: DownloadItemType.song, item: widget.item);
             await DownloadDialog.show(context, item, null);
             if (context.mounted) {
               Navigator.pop(context);
@@ -446,7 +446,7 @@ class _TrackMenuState extends ConsumerState<TrackMenu> {
             enabled: !widget.isOffline && downloadStatus.isIncidental,
             onTap: () async {
               var item = DownloadStub.fromItem(
-                  type: DownloadItemType.track, item: widget.item);
+                  type: DownloadItemType.song, item: widget.item);
               await DownloadDialog.show(context, item, null);
               if (context.mounted) {
                 Navigator.pop(context);
@@ -598,7 +598,7 @@ class _TrackMenuState extends ConsumerState<TrackMenu> {
             enabled: canDeleteFromServer,
             onTap: () async {
               var item = DownloadStub.fromItem(
-                  type: DownloadItemType.track, item: widget.item);
+                  type: DownloadItemType.song, item: widget.item);
               await askBeforeDeleteFromServerAndDevice(context, item);
               final BaseItemDto newAlbumOrPlaylist =
                   await _jellyfinApiHelper.getItemById(widget.parentItem!.id);

--- a/lib/components/DownloadsScreen/item_file_size.dart
+++ b/lib/components/DownloadsScreen/item_file_size.dart
@@ -33,7 +33,7 @@ class ItemFileSize extends ConsumerWidget {
         case DownloadItemState.failed:
         case DownloadItemState.complete:
         case DownloadItemState.needsRedownloadComplete:
-          if (item!.type == DownloadItemType.track) {
+          if (item!.type == DownloadItemType.song) {
             String codec = "";
             String bitrate = "null";
             if (item.fileTranscodingProfile == null ||

--- a/lib/models/finamp_models.dart
+++ b/lib/models/finamp_models.dart
@@ -1312,7 +1312,11 @@ class DownloadItem extends DownloadStub {
 }
 
 /// The primary type of a DownloadItem.
+///
 /// Enumerated by Isar, do not modify order or delete existing entries.
+/// The enum name is used by `DownloadStub.getHash` to calculate the isarId for
+/// the downloads system, DO NOT RENAME ANY ENTRIES IN HERE.
+/// New entries must be appended at the end of this list.
 enum DownloadItemType {
   collection(true, false),
   song(true, true),

--- a/lib/models/finamp_models.dart
+++ b/lib/models/finamp_models.dart
@@ -987,8 +987,8 @@ class DownloadStub {
             BaseItemDtoType.fromItem(baseItem!) == baseItemType &&
             baseItemType.downloadType == DownloadItemType.collection &&
             baseItemType != BaseItemDtoType.noItem;
-      case DownloadItemType.track:
-        return baseItemType.downloadType == DownloadItemType.track &&
+      case DownloadItemType.song:
+        return baseItemType.downloadType == DownloadItemType.song &&
             baseItem != null &&
             BaseItemDtoType.fromItem(baseItem!) == baseItemType;
       case DownloadItemType.image:
@@ -1315,7 +1315,7 @@ class DownloadItem extends DownloadStub {
 /// Enumerated by Isar, do not modify order or delete existing entries.
 enum DownloadItemType {
   collection(true, false),
-  track(true, true),
+  song(true, true),
   image(true, true),
   anchor(false, false),
   finampCollection(false, false);
@@ -1432,16 +1432,16 @@ enum BaseItemDtoType {
   artist("MusicArtist", true, [album, track], DownloadItemType.collection),
   playlist("Playlist", true, [track], DownloadItemType.collection),
   genre("MusicGenre", true, [album, track], DownloadItemType.collection),
-  track("Audio", false, [], DownloadItemType.track),
+  track("Audio", false, [], DownloadItemType.song),
   library(
       "CollectionFolder", true, [album, track], DownloadItemType.collection),
   folder("Folder", true, null, DownloadItemType.collection),
-  musicVideo("MusicVideo", false, [], DownloadItemType.track),
-  audioBook("AudioBook", false, [], DownloadItemType.track),
-  tvEpisode("Episode", false, [], DownloadItemType.track),
-  video("Video", false, [], DownloadItemType.track),
-  movie("Movie", false, [], DownloadItemType.track),
-  trailer("Trailer", false, [], DownloadItemType.track),
+  musicVideo("MusicVideo", false, [], DownloadItemType.song),
+  audioBook("AudioBook", false, [], DownloadItemType.song),
+  tvEpisode("Episode", false, [], DownloadItemType.song),
+  video("Video", false, [], DownloadItemType.song),
+  movie("Movie", false, [], DownloadItemType.song),
+  trailer("Trailer", false, [], DownloadItemType.song),
   unknown(null, true, null, DownloadItemType.collection);
 
   // All possible types in Jellyfin as of 10.9:

--- a/lib/models/finamp_models.g.dart
+++ b/lib/models/finamp_models.g.dart
@@ -3835,14 +3835,14 @@ const _DownloadItemstateValueEnumMap = {
 };
 const _DownloadItemtypeEnumValueMap = {
   'collection': 0,
-  'track': 1,
+  'song': 1,
   'image': 2,
   'anchor': 3,
   'finampCollection': 4,
 };
 const _DownloadItemtypeValueEnumMap = {
   0: DownloadItemType.collection,
-  1: DownloadItemType.track,
+  1: DownloadItemType.song,
   2: DownloadItemType.image,
   3: DownloadItemType.anchor,
   4: DownloadItemType.finampCollection,
@@ -7071,7 +7071,7 @@ Map<String, dynamic> _$DownloadStubToJson(DownloadStub instance) =>
 
 const _$DownloadItemTypeEnumMap = {
   DownloadItemType.collection: 'collection',
-  DownloadItemType.track: 'track',
+  DownloadItemType.song: 'song',
   DownloadItemType.image: 'image',
   DownloadItemType.anchor: 'anchor',
   DownloadItemType.finampCollection: 'finampCollection',

--- a/lib/services/downloads_service.dart
+++ b/lib/services/downloads_service.dart
@@ -163,7 +163,7 @@ class DownloadsService {
           .optional(
               state != DownloadItemState.syncFailed,
               (q) => q
-                  .typeEqualTo(DownloadItemType.track)
+                  .typeEqualTo(DownloadItemType.song)
                   .or()
                   .typeEqualTo(DownloadItemType.image))
           .filter()
@@ -410,7 +410,7 @@ class DownloadsService {
     _isar.txnSync(() {
       downloadCounts["track"] = _isar.downloadItems
           .where()
-          .typeEqualTo(DownloadItemType.track)
+          .typeEqualTo(DownloadItemType.song)
           .filter()
           .not()
           .stateEqualTo(DownloadItemState.notDownloaded)
@@ -583,7 +583,7 @@ class DownloadsService {
           (q) => q.anyOf([BaseItemDtoType.album, BaseItemDtoType.playlist],
               (q, element) => q.baseItemTypeEqualTo(element))
         ),
-        (DownloadItemType.track, null),
+        (DownloadItemType.song, null),
         (DownloadItemType.image, null),
       ];
       // Objects matching a require filter cannot require elements matching earlier filters or the current filter.
@@ -620,12 +620,12 @@ class DownloadsService {
                 (q, element) => q.baseItemTypeEqualTo(element))
             .not()
             .info((q) => q.not().group((q) => q
-                .typeEqualTo(DownloadItemType.track)
+                .typeEqualTo(DownloadItemType.song)
                 .or()
                 .typeEqualTo(DownloadItemType.image))),
         // Select required tracks that only link collections or images
         (q) => q
-            .typeEqualTo(DownloadItemType.track)
+            .typeEqualTo(DownloadItemType.song)
             .requiredByIsNotEmpty()
             .not()
             .info((q) => q.not().group((q) => q
@@ -660,7 +660,7 @@ class DownloadsService {
     downloadCounts[repairStepTrackingName] = 2;
     var itemsWithFiles = _isar.downloadItems
         .where()
-        .typeEqualTo(DownloadItemType.track)
+        .typeEqualTo(DownloadItemType.song)
         .or()
         .typeEqualTo(DownloadItemType.image)
         .findAllSync();
@@ -694,7 +694,7 @@ class DownloadsService {
     _isar.writeTxnSync(() {
       var itemsWithFiles = _isar.downloadItems
           .where()
-          .typeEqualTo(DownloadItemType.track)
+          .typeEqualTo(DownloadItemType.song)
           .or()
           .typeEqualTo(DownloadItemType.image)
           .findAllSync();
@@ -720,7 +720,7 @@ class DownloadsService {
         .where()
         .stateNotEqualTo(DownloadItemState.notDownloaded)
         .filter()
-        .typeEqualTo(DownloadItemType.track)
+        .typeEqualTo(DownloadItemType.song)
         .findAllSync();
     final JellyfinApiHelper jellyfinApiData =
         GetIt.instance<JellyfinApiHelper>();
@@ -795,7 +795,7 @@ class DownloadsService {
     }
     for (var item in _isar.downloadItems
         .where()
-        .typeEqualTo(DownloadItemType.track)
+        .typeEqualTo(DownloadItemType.song)
         .or()
         .typeEqualTo(DownloadItemType.image)
         .filter()
@@ -880,7 +880,7 @@ class DownloadsService {
       _isar.downloadItems.putSync(item);
       List<DownloadItem> parents = _isar.downloadItems
           .where()
-          .typeNotEqualTo(DownloadItemType.track)
+          .typeNotEqualTo(DownloadItemType.song)
           .filter()
           .requires((q) => q.isarIdEqualTo(item.isarId))
           .or()
@@ -994,7 +994,7 @@ class DownloadsService {
     _isar.writeTxnSync(() {
       var items = _isar.downloadItems
           .where()
-          .typeEqualTo(DownloadItemType.track)
+          .typeEqualTo(DownloadItemType.song)
           .or()
           .typeEqualTo(DownloadItemType.image)
           .filter()
@@ -1109,7 +1109,7 @@ class DownloadsService {
       var baseItem = track.track;
       baseItem.mediaSources = [track.mediaSourceInfo];
       var isarItem =
-          DownloadStub.fromItem(type: DownloadItemType.track, item: baseItem)
+          DownloadStub.fromItem(type: DownloadItemType.song, item: baseItem)
               .asItem(DownloadProfile(
                   transcodeCodec: FinampTranscodingCodec.original,
                   downloadLocationId: track.downloadLocationId));
@@ -1200,7 +1200,7 @@ class DownloadsService {
       // This should only be used for IDs/links and does not need real download items.
       List<DownloadItem> required = parent.downloadedChildren.values
           .map((e) =>
-              DownloadStub.fromItem(type: DownloadItemType.track, item: e)
+              DownloadStub.fromItem(type: DownloadItemType.song, item: e)
                   .asItem(null))
           .toList();
       isarItem.orderedChildren = required.map((e) => e.isarId).toList();
@@ -1298,7 +1298,7 @@ class DownloadsService {
     var id = DownloadStub.getHash(item.id, DownloadItemType.collection);
     var query = _isar.downloadItems
         .where()
-        .typeEqualTo(DownloadItemType.track)
+        .typeEqualTo(DownloadItemType.song)
         .filter()
         .infoFor((q) => q.isarIdEqualTo(id))
         .optional(
@@ -1344,7 +1344,7 @@ class DownloadsService {
     }
     return _isar.downloadItems
         .where()
-        .typeEqualTo(DownloadItemType.track)
+        .typeEqualTo(DownloadItemType.song)
         .filter()
         .group((q) => q
             .stateEqualTo(DownloadItemState.complete)
@@ -1404,7 +1404,7 @@ class DownloadsService {
         .optional(
             baseTypeFilter == BaseItemDtoType.playlist,
             (q) => q.info((q) =>
-                q.typeEqualTo(DownloadItemType.track).requiredByIsNotEmpty()))
+                q.typeEqualTo(DownloadItemType.song).requiredByIsNotEmpty()))
         .optional(
             relatedTo != null,
             (q) => q.infoFor((q) => q.info((q) => q.isarIdEqualTo(
@@ -1432,7 +1432,7 @@ class DownloadsService {
   Future<DownloadStub?> getTrackInfo({BaseItemDto? item, String? id}) {
     assert((item == null) != (id == null));
     return _isar.downloadItems
-        .get(DownloadStub.getHash(id ?? item!.id, DownloadItemType.track));
+        .get(DownloadStub.getHash(id ?? item!.id, DownloadItemType.song));
   }
 
   /// Get information about a downloaded collection by BaseItemDto or id.
@@ -1449,7 +1449,7 @@ class DownloadsService {
   /// be used instead.  Exactly one of the two arguments should be provided.
   DownloadItem? getTrackDownload({BaseItemDto? item, String? id}) {
     assert((item == null) != (id == null));
-    return _getDownloadByID(id ?? item!.id, DownloadItemType.track);
+    return _getDownloadByID(id ?? item!.id, DownloadItemType.song);
   }
 
   /// Get an image's DownloadItem by BaseItemDto or id.  This method performs file
@@ -1469,7 +1469,7 @@ class DownloadsService {
   Future<DownloadedLyrics?> getLyricsDownload(
       {required BaseItemDto baseItem}) async {
     var item = _isar.downloadedLyrics
-        .getSync(DownloadStub.getHash(baseItem.id, DownloadItemType.track));
+        .getSync(DownloadStub.getHash(baseItem.id, DownloadItemType.song));
     return item;
   }
 
@@ -1502,7 +1502,7 @@ class DownloadsService {
         .optional(
             state != DownloadItemState.syncFailed,
             (q) => q
-                .typeEqualTo(DownloadItemType.track)
+                .typeEqualTo(DownloadItemType.song)
                 .or()
                 .typeEqualTo(DownloadItemType.image))
         .filter()
@@ -1541,13 +1541,13 @@ class DownloadsService {
         info.add(item);
       }
     }
-    if (isRequired || item.type == DownloadItemType.track) {
+    if (isRequired || item.type == DownloadItemType.song) {
       var children = item.requires.filter().findAllSync();
       for (var child in children) {
         _getFileChildren(child, required, info, isRequired);
       }
     }
-    if (isRequired || item.type != DownloadItemType.track) {
+    if (isRequired || item.type != DownloadItemType.song) {
       var children = item.info.filter().findAllSync();
       for (var child in children) {
         _getFileChildren(child, required, info, false);
@@ -1557,7 +1557,7 @@ class DownloadsService {
 
   /// Recursive subcomponent of [getFileSize].
   Future<int> _getFileSize(DownloadItem item, bool required) async {
-    if (item.type == DownloadItemType.track &&
+    if (item.type == DownloadItemType.song &&
         item.state.isComplete &&
         required) {
       if (item.fileTranscodingProfile == null ||

--- a/lib/services/downloads_service_backend.dart
+++ b/lib/services/downloads_service_backend.dart
@@ -261,7 +261,7 @@ class IsarTaskQueue implements TaskQueue {
         .or()
         .stateEqualTo(DownloadItemState.downloading)
         .filter()
-        .typeEqualTo(DownloadItemType.track)
+        .typeEqualTo(DownloadItemType.song)
         .or()
         .typeEqualTo(DownloadItemType.image)
         .findAllSync()) {
@@ -345,7 +345,7 @@ class IsarTaskQueue implements TaskQueue {
             // Base URL shouldn't be null at this point (user has to be logged in
             // to get to the point where they can add downloads).
             var url = switch (task.type) {
-              DownloadItemType.track => _jellyfinApiData
+              DownloadItemType.song => _jellyfinApiData
                   .getTrackDownloadUrl(
                       item: task.baseItem!,
                       transcodingProfile: task.fileTranscodingProfile)
@@ -623,7 +623,7 @@ class DownloadsDeleteService {
           return;
         }
         if (infoForCount > 0) {
-          if (transactionItem.type == DownloadItemType.track) {
+          if (transactionItem.type == DownloadItemType.song) {
             // Non-required tracks cannot have info links to collections, but they
             // can still require their images.
             childIds.addAll(
@@ -697,7 +697,7 @@ class DownloadsDeleteService {
             transactionItem, DownloadItemState.notDownloaded);
       }
 
-      if (item.type == DownloadItemType.track) {
+      if (item.type == DownloadItemType.song) {
         // delete corresponding lyrics if they exist, using the same ID
         if (_isar.downloadedLyrics.deleteSync(item.isarId)) {
           _deleteLogger.finer("Deleted lyrics for ${item.name}");
@@ -979,7 +979,7 @@ class DownloadsSyncService {
           infoChildren.add(
               DownloadStub.fromItem(type: DownloadItemType.image, item: item));
         }
-      case DownloadItemType.track:
+      case DownloadItemType.song:
         var item = newBaseItem ?? parent.baseItem!;
         if ((item.blurHash ?? item.imageId) != null) {
           requiredChildren.add(
@@ -1090,7 +1090,7 @@ class DownloadsSyncService {
           requiredChanges =
               _updateChildren(canonParent!, true, requiredChildren);
           infoChanges = _updateChildren(canonParent!, false, infoChildren);
-        } else if (canonParent!.type == DownloadItemType.track) {
+        } else if (canonParent!.type == DownloadItemType.song) {
           // For info only tracks, we put image link into required so that we can delete
           // all info links in _syncDelete, so if not processing as required only
           // update that and ignore info links
@@ -1276,7 +1276,7 @@ class DownloadsSyncService {
     assert(parent.baseItemType.downloadType == DownloadItemType.collection);
     switch (parent.baseItemType) {
       case BaseItemDtoType.playlist || BaseItemDtoType.album:
-        childType = DownloadItemType.track;
+        childType = DownloadItemType.song;
         childFilter = BaseItemDtoType.track;
         fields =
             "${_jellyfinApiData.defaultFields},MediaSources,MediaStreams,SortName";
@@ -1327,7 +1327,7 @@ class DownloadsSyncService {
             [];
         childItems.addAll(trackChildItems);
         var trackChildStubs = trackChildItems.map((e) =>
-            DownloadStub.fromItem(type: DownloadItemType.track, item: e));
+            DownloadStub.fromItem(type: DownloadItemType.song, item: e));
         childStubs.addAll(trackChildStubs);
       }
       itemFetch.complete(childItems.map((e) => e.id).toList());
@@ -1464,7 +1464,7 @@ class DownloadsSyncService {
     if (stub.baseItem?.sortName == null) {
       return true;
     }
-    if (stub.type == DownloadItemType.track &&
+    if (stub.type == DownloadItemType.song &&
         (stub.baseItem?.mediaSources == null ||
             stub.baseItem?.mediaStreams == null)) {
       return true;
@@ -1495,7 +1495,7 @@ class DownloadsSyncService {
     }
 
     switch (item.type) {
-      case DownloadItemType.track:
+      case DownloadItemType.song:
         return _downloadTrack(item);
       case DownloadItemType.image:
         return _downloadImage(item);
@@ -1512,7 +1512,7 @@ class DownloadsSyncService {
   /// Prepares for downloading of a given track by filling in the path information
   /// and media sources, and marking item as enqueued in isar.
   Future<void> _downloadTrack(DownloadItem downloadItem) async {
-    assert(downloadItem.type == DownloadItemType.track &&
+    assert(downloadItem.type == DownloadItemType.song &&
         downloadItem.syncDownloadLocation != null);
     var item = downloadItem.baseItem!;
     var downloadLocation = downloadItem.syncDownloadLocation!;


### PR DESCRIPTION
The rename caused the entire library to be re-downloaded when repairing downloads, as Finamp uses the download type for the hash when computing the isarId.