### PR TITLE
Refactor DownloadStub hash calculation and rename DownloadItemType.song to track

### DIFF
--- a/lib/components/AlbumScreen/track_list_tile.dart
+++ b/lib/components/AlbumScreen/track_list_tile.dart
@@ -413,7 +413,7 @@ class TrackListItemState extends ConsumerState<TrackListItem>
     if (FinampSettingsHelper.finampSettings.isOffline) {
       playable = ref.watch(GetIt.instance<DownloadsService>()
           .stateProvider(DownloadStub.fromItem(
-              type: DownloadItemType.song, item: widget.baseItem))
+              type: DownloadItemType.track, item: widget.baseItem))
           .select((value) => value.value?.isComplete ?? false));
     } else {
       playable = true;
@@ -717,7 +717,7 @@ class TrackListItemTile extends StatelessWidget {
                           offset: const Offset(-1.5, 2.5),
                           child: DownloadedIndicator(
                             item: DownloadStub.fromItem(
-                                item: baseItem, type: DownloadItemType.song),
+                                item: baseItem, type: DownloadItemType.track),
                             size: Theme.of(context)
                                     .textTheme
                                     .bodyMedium!

--- a/lib/components/AlbumScreen/track_menu.dart
+++ b/lib/components/AlbumScreen/track_menu.dart
@@ -215,7 +215,7 @@ class _TrackMenuState extends ConsumerState<TrackMenu> {
   List<Widget> _menuEntries(BuildContext context) {
     final downloadsService = GetIt.instance<DownloadsService>();
     final downloadStatus = downloadsService.getStatus(
-        DownloadStub.fromItem(type: DownloadItemType.song, item: widget.item),
+        DownloadStub.fromItem(type: DownloadItemType.track, item: widget.item),
         null);
     var iconColor = Theme.of(context).colorScheme.primary;
 
@@ -231,7 +231,7 @@ class _TrackMenuState extends ConsumerState<TrackMenu> {
     String? parentTooltip;
     if (downloadStatus.isIncidental) {
       var parent = downloadsService.getFirstRequiringItem(DownloadStub.fromItem(
-          type: DownloadItemType.song, item: widget.item));
+          type: DownloadItemType.track, item: widget.item));
       if (parent != null) {
         var parentName = AppLocalizations.of(context)!
             .itemTypeSubtitle(parent.baseItemType.name, parent.name);
@@ -399,7 +399,7 @@ class _TrackMenuState extends ConsumerState<TrackMenu> {
               enabled: downloadStatus.isRequired,
               onTap: () async {
                 var item = DownloadStub.fromItem(
-                    type: DownloadItemType.song, item: widget.item);
+                    type: DownloadItemType.track, item: widget.item);
                 await askBeforeDeleteDownloadFromDevice(context, item);
               })),
       Visibility(
@@ -414,7 +414,7 @@ class _TrackMenuState extends ConsumerState<TrackMenu> {
               downloadStatus == DownloadItemStatus.notNeeded,
           onTap: () async {
             var item = DownloadStub.fromItem(
-                type: DownloadItemType.song, item: widget.item);
+                type: DownloadItemType.track, item: widget.item);
             await DownloadDialog.show(context, item, null);
             if (context.mounted) {
               Navigator.pop(context);
@@ -435,7 +435,7 @@ class _TrackMenuState extends ConsumerState<TrackMenu> {
             enabled: !widget.isOffline && downloadStatus.isIncidental,
             onTap: () async {
               var item = DownloadStub.fromItem(
-                  type: DownloadItemType.song, item: widget.item);
+                  type: DownloadItemType.track, item: widget.item);
               await DownloadDialog.show(context, item, null);
               if (context.mounted) {
                 Navigator.pop(context);
@@ -588,7 +588,7 @@ class _TrackMenuState extends ConsumerState<TrackMenu> {
               enabled: canDelete,
               onTap: () async {
                 var item = DownloadStub.fromItem(
-                    type: DownloadItemType.song, item: widget.item);
+                    type: DownloadItemType.track, item: widget.item);
                 await askBeforeDeleteFromServerAndDevice(context, item);
                 final BaseItemDto newAlbumOrPlaylist =
                     await _jellyfinApiHelper.getItemById(widget.parentItem!.id);

--- a/lib/components/DownloadsScreen/item_file_size.dart
+++ b/lib/components/DownloadsScreen/item_file_size.dart
@@ -33,7 +33,7 @@ class ItemFileSize extends ConsumerWidget {
         case DownloadItemState.failed:
         case DownloadItemState.complete:
         case DownloadItemState.needsRedownloadComplete:
-          if (item!.type == DownloadItemType.song) {
+          if (item!.type == DownloadItemType.track) {
             String codec = "";
             String bitrate = "null";
             if (item.fileTranscodingProfile == null ||

--- a/lib/models/finamp_models.dart
+++ b/lib/models/finamp_models.dart
@@ -1115,7 +1115,7 @@ class DownloadStub {
 
   /// Calculate a DownloadStub's isarId
   static int getHash(String id, DownloadItemType type) {
-    return _fastHash(type.name + id);
+    return _fastHash(type.isarType + id);
   }
 
   @override
@@ -1302,17 +1302,21 @@ class DownloadItem extends DownloadStub {
 /// The primary type of a DownloadItem.
 ///
 /// Enumerated by Isar, do not modify order or delete existing entries.
-/// The enum name is used by `DownloadStub.getHash` to calculate the isarId for
-/// the downloads system, DO NOT RENAME ANY ENTRIES IN HERE.
 /// New entries must be appended at the end of this list.
 enum DownloadItemType {
-  collection(true, false),
-  song(true, true),
-  image(true, true),
-  anchor(false, false),
-  finampCollection(false, false);
+  collection("collection", true, false),
+  song("song", true, true),
+  image("image", true, true),
+  anchor("anchor", false, false),
+  finampCollection("finampCollection", false, false);
 
-  const DownloadItemType(this.requiresItem, this.hasFiles);
+  const DownloadItemType(this.isarType, this.requiresItem, this.hasFiles);
+
+  ///!!! Used by `DownloadStub.getHash` to calculate the isarId for
+  ///!!! the downloads system, DO NOT EDIT for any existing entries.
+  ///!!! Doing so would invalidate existing downloads
+  ///!!! and cause them to be deleted and re-downloaded.
+  final String isarType;
 
   final bool requiresItem;
   final bool hasFiles;

--- a/lib/models/finamp_models.dart
+++ b/lib/models/finamp_models.dart
@@ -975,8 +975,8 @@ class DownloadStub {
             BaseItemDtoType.fromItem(baseItem!) == baseItemType &&
             baseItemType.downloadType == DownloadItemType.collection &&
             baseItemType != BaseItemDtoType.noItem;
-      case DownloadItemType.song:
-        return baseItemType.downloadType == DownloadItemType.song &&
+      case DownloadItemType.track:
+        return baseItemType.downloadType == DownloadItemType.track &&
             baseItem != null &&
             BaseItemDtoType.fromItem(baseItem!) == baseItemType;
       case DownloadItemType.image:
@@ -1305,7 +1305,7 @@ class DownloadItem extends DownloadStub {
 /// New entries must be appended at the end of this list.
 enum DownloadItemType {
   collection("collection", true, false),
-  song("song", true, true),
+  track("song", true, true),
   image("image", true, true),
   anchor("anchor", false, false),
   finampCollection("finampCollection", false, false);
@@ -1428,16 +1428,16 @@ enum BaseItemDtoType {
   artist("MusicArtist", true, [album, track], DownloadItemType.collection),
   playlist("Playlist", true, [track], DownloadItemType.collection),
   genre("MusicGenre", true, [album, track], DownloadItemType.collection),
-  track("Audio", false, [], DownloadItemType.song),
+  track("Audio", false, [], DownloadItemType.track),
   library(
       "CollectionFolder", true, [album, track], DownloadItemType.collection),
   folder("Folder", true, null, DownloadItemType.collection),
-  musicVideo("MusicVideo", false, [], DownloadItemType.song),
-  audioBook("AudioBook", false, [], DownloadItemType.song),
-  tvEpisode("Episode", false, [], DownloadItemType.song),
-  video("Video", false, [], DownloadItemType.song),
-  movie("Movie", false, [], DownloadItemType.song),
-  trailer("Trailer", false, [], DownloadItemType.song),
+  musicVideo("MusicVideo", false, [], DownloadItemType.track),
+  audioBook("AudioBook", false, [], DownloadItemType.track),
+  tvEpisode("Episode", false, [], DownloadItemType.track),
+  video("Video", false, [], DownloadItemType.track),
+  movie("Movie", false, [], DownloadItemType.track),
+  trailer("Trailer", false, [], DownloadItemType.track),
   unknown(null, true, null, DownloadItemType.collection);
 
   // All possible types in Jellyfin as of 10.9:

--- a/lib/models/finamp_models.g.dart
+++ b/lib/models/finamp_models.g.dart
@@ -3827,14 +3827,14 @@ const _DownloadItemstateValueEnumMap = {
 };
 const _DownloadItemtypeEnumValueMap = {
   'collection': 0,
-  'song': 1,
+  'track': 1,
   'image': 2,
   'anchor': 3,
   'finampCollection': 4,
 };
 const _DownloadItemtypeValueEnumMap = {
   0: DownloadItemType.collection,
-  1: DownloadItemType.song,
+  1: DownloadItemType.track,
   2: DownloadItemType.image,
   3: DownloadItemType.anchor,
   4: DownloadItemType.finampCollection,
@@ -7063,7 +7063,7 @@ Map<String, dynamic> _$DownloadStubToJson(DownloadStub instance) =>
 
 const _$DownloadItemTypeEnumMap = {
   DownloadItemType.collection: 'collection',
-  DownloadItemType.song: 'song',
+  DownloadItemType.track: 'track',
   DownloadItemType.image: 'image',
   DownloadItemType.anchor: 'anchor',
   DownloadItemType.finampCollection: 'finampCollection',

--- a/lib/services/downloads_service.dart
+++ b/lib/services/downloads_service.dart
@@ -163,7 +163,7 @@ class DownloadsService {
           .optional(
               state != DownloadItemState.syncFailed,
               (q) => q
-                  .typeEqualTo(DownloadItemType.song)
+                  .typeEqualTo(DownloadItemType.track)
                   .or()
                   .typeEqualTo(DownloadItemType.image))
           .filter()
@@ -410,7 +410,7 @@ class DownloadsService {
     _isar.txnSync(() {
       downloadCounts["track"] = _isar.downloadItems
           .where()
-          .typeEqualTo(DownloadItemType.song)
+          .typeEqualTo(DownloadItemType.track)
           .filter()
           .not()
           .stateEqualTo(DownloadItemState.notDownloaded)
@@ -583,7 +583,7 @@ class DownloadsService {
           (q) => q.anyOf([BaseItemDtoType.album, BaseItemDtoType.playlist],
               (q, element) => q.baseItemTypeEqualTo(element))
         ),
-        (DownloadItemType.song, null),
+        (DownloadItemType.track, null),
         (DownloadItemType.image, null),
       ];
       // Objects matching a require filter cannot require elements matching earlier filters or the current filter.
@@ -620,12 +620,12 @@ class DownloadsService {
                 (q, element) => q.baseItemTypeEqualTo(element))
             .not()
             .info((q) => q.not().group((q) => q
-                .typeEqualTo(DownloadItemType.song)
+                .typeEqualTo(DownloadItemType.track)
                 .or()
                 .typeEqualTo(DownloadItemType.image))),
         // Select required tracks that only link collections or images
         (q) => q
-            .typeEqualTo(DownloadItemType.song)
+            .typeEqualTo(DownloadItemType.track)
             .requiredByIsNotEmpty()
             .not()
             .info((q) => q.not().group((q) => q
@@ -660,7 +660,7 @@ class DownloadsService {
     downloadCounts[repairStepTrackingName] = 2;
     var itemsWithFiles = _isar.downloadItems
         .where()
-        .typeEqualTo(DownloadItemType.song)
+        .typeEqualTo(DownloadItemType.track)
         .or()
         .typeEqualTo(DownloadItemType.image)
         .findAllSync();
@@ -694,7 +694,7 @@ class DownloadsService {
     _isar.writeTxnSync(() {
       var itemsWithFiles = _isar.downloadItems
           .where()
-          .typeEqualTo(DownloadItemType.song)
+          .typeEqualTo(DownloadItemType.track)
           .or()
           .typeEqualTo(DownloadItemType.image)
           .findAllSync();
@@ -720,7 +720,7 @@ class DownloadsService {
         .where()
         .stateNotEqualTo(DownloadItemState.notDownloaded)
         .filter()
-        .typeEqualTo(DownloadItemType.song)
+        .typeEqualTo(DownloadItemType.track)
         .findAllSync();
     final JellyfinApiHelper jellyfinApiData =
         GetIt.instance<JellyfinApiHelper>();
@@ -797,7 +797,7 @@ class DownloadsService {
     }
     for (var item in _isar.downloadItems
         .where()
-        .typeEqualTo(DownloadItemType.song)
+        .typeEqualTo(DownloadItemType.track)
         .or()
         .typeEqualTo(DownloadItemType.image)
         .filter()
@@ -882,7 +882,7 @@ class DownloadsService {
       _isar.downloadItems.putSync(item);
       List<DownloadItem> parents = _isar.downloadItems
           .where()
-          .typeNotEqualTo(DownloadItemType.song)
+          .typeNotEqualTo(DownloadItemType.track)
           .filter()
           .requires((q) => q.isarIdEqualTo(item.isarId))
           .or()
@@ -996,7 +996,7 @@ class DownloadsService {
     _isar.writeTxnSync(() {
       var items = _isar.downloadItems
           .where()
-          .typeEqualTo(DownloadItemType.song)
+          .typeEqualTo(DownloadItemType.track)
           .or()
           .typeEqualTo(DownloadItemType.image)
           .filter()
@@ -1111,7 +1111,7 @@ class DownloadsService {
       var baseItem = track.track;
       baseItem.mediaSources = [track.mediaSourceInfo];
       var isarItem =
-          DownloadStub.fromItem(type: DownloadItemType.song, item: baseItem)
+          DownloadStub.fromItem(type: DownloadItemType.track, item: baseItem)
               .asItem(DownloadProfile(
                   transcodeCodec: FinampTranscodingCodec.original,
                   downloadLocationId: track.downloadLocationId));
@@ -1203,7 +1203,7 @@ class DownloadsService {
       // This should only be used for IDs/links and does not need real download items.
       List<DownloadItem> required = parent.downloadedChildren.values
           .map((e) =>
-              DownloadStub.fromItem(type: DownloadItemType.song, item: e)
+              DownloadStub.fromItem(type: DownloadItemType.track, item: e)
                   .asItem(null))
           .toList();
       isarItem.orderedChildren = required.map((e) => e.isarId).toList();
@@ -1301,7 +1301,7 @@ class DownloadsService {
     var id = DownloadStub.getHash(item.id, DownloadItemType.collection);
     var query = _isar.downloadItems
         .where()
-        .typeEqualTo(DownloadItemType.song)
+        .typeEqualTo(DownloadItemType.track)
         .filter()
         .infoFor((q) => q.isarIdEqualTo(id))
         .optional(
@@ -1347,7 +1347,7 @@ class DownloadsService {
     }
     return _isar.downloadItems
         .where()
-        .typeEqualTo(DownloadItemType.song)
+        .typeEqualTo(DownloadItemType.track)
         .filter()
         .group((q) => q
             .stateEqualTo(DownloadItemState.complete)
@@ -1407,7 +1407,7 @@ class DownloadsService {
         .optional(
             baseTypeFilter == BaseItemDtoType.playlist,
             (q) => q.info((q) =>
-                q.typeEqualTo(DownloadItemType.song).requiredByIsNotEmpty()))
+                q.typeEqualTo(DownloadItemType.track).requiredByIsNotEmpty()))
         .optional(
             relatedTo != null,
             (q) => q.infoFor((q) => q.info((q) => q.isarIdEqualTo(
@@ -1435,7 +1435,7 @@ class DownloadsService {
   Future<DownloadStub?> getTrackInfo({BaseItemDto? item, String? id}) {
     assert((item == null) != (id == null));
     return _isar.downloadItems
-        .get(DownloadStub.getHash(id ?? item!.id, DownloadItemType.song));
+        .get(DownloadStub.getHash(id ?? item!.id, DownloadItemType.track));
   }
 
   /// Get information about a downloaded collection by BaseItemDto or id.
@@ -1452,7 +1452,7 @@ class DownloadsService {
   /// be used instead.  Exactly one of the two arguments should be provided.
   DownloadItem? getTrackDownload({BaseItemDto? item, String? id}) {
     assert((item == null) != (id == null));
-    return _getDownloadByID(id ?? item!.id, DownloadItemType.song);
+    return _getDownloadByID(id ?? item!.id, DownloadItemType.track);
   }
 
   /// Get an image's DownloadItem by BaseItemDto or id.  This method performs file
@@ -1472,7 +1472,7 @@ class DownloadsService {
   Future<DownloadedLyrics?> getLyricsDownload(
       {required BaseItemDto baseItem}) async {
     var item = _isar.downloadedLyrics
-        .getSync(DownloadStub.getHash(baseItem.id, DownloadItemType.song));
+        .getSync(DownloadStub.getHash(baseItem.id, DownloadItemType.track));
     return item;
   }
 
@@ -1505,7 +1505,7 @@ class DownloadsService {
         .optional(
             state != DownloadItemState.syncFailed,
             (q) => q
-                .typeEqualTo(DownloadItemType.song)
+                .typeEqualTo(DownloadItemType.track)
                 .or()
                 .typeEqualTo(DownloadItemType.image))
         .filter()
@@ -1544,13 +1544,13 @@ class DownloadsService {
         info.add(item);
       }
     }
-    if (isRequired || item.type == DownloadItemType.song) {
+    if (isRequired || item.type == DownloadItemType.track) {
       var children = item.requires.filter().findAllSync();
       for (var child in children) {
         _getFileChildren(child, required, info, isRequired);
       }
     }
-    if (isRequired || item.type != DownloadItemType.song) {
+    if (isRequired || item.type != DownloadItemType.track) {
       var children = item.info.filter().findAllSync();
       for (var child in children) {
         _getFileChildren(child, required, info, false);
@@ -1560,7 +1560,7 @@ class DownloadsService {
 
   /// Recursive subcomponent of [getFileSize].
   Future<int> _getFileSize(DownloadItem item, bool required) async {
-    if (item.type == DownloadItemType.song &&
+    if (item.type == DownloadItemType.track &&
         item.state.isComplete &&
         required) {
       if (item.fileTranscodingProfile == null ||

--- a/lib/services/downloads_service_backend.dart
+++ b/lib/services/downloads_service_backend.dart
@@ -262,7 +262,7 @@ class IsarTaskQueue implements TaskQueue {
         .or()
         .stateEqualTo(DownloadItemState.downloading)
         .filter()
-        .typeEqualTo(DownloadItemType.song)
+        .typeEqualTo(DownloadItemType.track)
         .or()
         .typeEqualTo(DownloadItemType.image)
         .findAllSync()) {
@@ -346,7 +346,7 @@ class IsarTaskQueue implements TaskQueue {
             // Base URL shouldn't be null at this point (user has to be logged in
             // to get to the point where they can add downloads).
             var url = switch (task.type) {
-              DownloadItemType.song => _jellyfinApiData
+              DownloadItemType.track => _jellyfinApiData
                   .getTrackDownloadUrl(
                       item: task.baseItem!,
                       transcodingProfile: task.fileTranscodingProfile)
@@ -624,7 +624,7 @@ class DownloadsDeleteService {
           return;
         }
         if (infoForCount > 0) {
-          if (transactionItem.type == DownloadItemType.song) {
+          if (transactionItem.type == DownloadItemType.track) {
             // Non-required tracks cannot have info links to collections, but they
             // can still require their images.
             childIds.addAll(
@@ -698,7 +698,7 @@ class DownloadsDeleteService {
             transactionItem, DownloadItemState.notDownloaded);
       }
 
-      if (item.type == DownloadItemType.song) {
+      if (item.type == DownloadItemType.track) {
         // delete corresponding lyrics if they exist, using the same ID
         if (_isar.downloadedLyrics.deleteSync(item.isarId)) {
           _deleteLogger.finer("Deleted lyrics for ${item.name}");
@@ -980,7 +980,7 @@ class DownloadsSyncService {
           infoChildren.add(
               DownloadStub.fromItem(type: DownloadItemType.image, item: item));
         }
-      case DownloadItemType.song:
+      case DownloadItemType.track:
         var item = newBaseItem ?? parent.baseItem!;
         if ((item.blurHash ?? item.imageId) != null) {
           requiredChildren.add(
@@ -1091,7 +1091,7 @@ class DownloadsSyncService {
           requiredChanges =
               _updateChildren(canonParent!, true, requiredChildren);
           infoChanges = _updateChildren(canonParent!, false, infoChildren);
-        } else if (canonParent!.type == DownloadItemType.song) {
+        } else if (canonParent!.type == DownloadItemType.track) {
           // For info only tracks, we put image link into required so that we can delete
           // all info links in _syncDelete, so if not processing as required only
           // update that and ignore info links
@@ -1277,7 +1277,7 @@ class DownloadsSyncService {
     assert(parent.baseItemType.downloadType == DownloadItemType.collection);
     switch (parent.baseItemType) {
       case BaseItemDtoType.playlist || BaseItemDtoType.album:
-        childType = DownloadItemType.song;
+        childType = DownloadItemType.track;
         childFilter = BaseItemDtoType.track;
         fields =
             "${_jellyfinApiData.defaultFields},MediaSources,MediaStreams,SortName";
@@ -1328,7 +1328,7 @@ class DownloadsSyncService {
             [];
         childItems.addAll(trackChildItems);
         var trackChildStubs = trackChildItems.map(
-            (e) => DownloadStub.fromItem(type: DownloadItemType.song, item: e));
+            (e) => DownloadStub.fromItem(type: DownloadItemType.track, item: e));
         childStubs.addAll(trackChildStubs);
       }
       itemFetch.complete(childItems.map((e) => e.id).toList());
@@ -1465,7 +1465,7 @@ class DownloadsSyncService {
     if (stub.baseItem?.sortName == null) {
       return true;
     }
-    if (stub.type == DownloadItemType.song &&
+    if (stub.type == DownloadItemType.track &&
         (stub.baseItem?.mediaSources == null ||
             stub.baseItem?.mediaStreams == null)) {
       return true;
@@ -1496,7 +1496,7 @@ class DownloadsSyncService {
     }
 
     switch (item.type) {
-      case DownloadItemType.song:
+      case DownloadItemType.track:
         return _downloadTrack(item);
       case DownloadItemType.image:
         return _downloadImage(item);
@@ -1513,7 +1513,7 @@ class DownloadsSyncService {
   /// Prepares for downloading of a given track by filling in the path information
   /// and media sources, and marking item as enqueued in isar.
   Future<void> _downloadTrack(DownloadItem downloadItem) async {
-    assert(downloadItem.type == DownloadItemType.song &&
+    assert(downloadItem.type == DownloadItemType.track &&
         downloadItem.syncDownloadLocation != null);
     var item = downloadItem.baseItem!;
     var downloadLocation = downloadItem.syncDownloadLocation!;


### PR DESCRIPTION
Haven't yet verified my claim that this doesn't break anything, so draft for now. Should be rebase-merged to keep the history later on.