### PR TITLE
[Redesign] Delete from Server Button Cleanup

### DIFF
--- a/lib/components/AlbumScreen/track_menu.dart
+++ b/lib/components/AlbumScreen/track_menu.dart
@@ -133,8 +133,6 @@ class _TrackMenuState extends ConsumerState<TrackMenu> {
   // Makes sure that widget doesn't just disappear after press while menu is visible
   bool speedWidgetWasVisible = false;
   bool showSpeedMenu = false;
-  bool canDeleteFromServer = false;
-  bool deletableGotUpdated = false;
 
   double initialSheetExtent = 0.0;
   double inputStep = 0.9;
@@ -207,15 +205,6 @@ class _TrackMenuState extends ConsumerState<TrackMenu> {
         56;
 
     return Consumer(builder: (context, ref, child) {
-      if (!deletableGotUpdated) {
-        deletableGotUpdated = true;
-        var deletable = GetIt.instance<JellyfinApiHelper>()
-            .canDeleteFromServer(widget.item);
-        canDeleteFromServer = deletable.initialValue;
-        deletable.realValue?.then((canDelete) => setState(() {
-              canDeleteFromServer = canDelete;
-            }));
-      }
       final metadata = ref.watch(currentTrackMetadataProvider).unwrapPrevious();
       return widget.childBuilder(
           stackHeight, menu(context, menuEntries, metadata.value));
@@ -586,36 +575,40 @@ class _TrackMenuState extends ConsumerState<TrackMenu> {
           },
         ),
       ),
-      Visibility(
-          visible: canDeleteFromServer,
-          child: ListTile(
-            leading: Icon(
-              Icons.delete_forever,
-              color: iconColor,
-            ),
-            title: Text(AppLocalizations.of(context)!
-                .deleteFromTargetConfirmButton("server")),
-            enabled: canDeleteFromServer,
-            onTap: () async {
-              var item = DownloadStub.fromItem(
-                  type: DownloadItemType.song, item: widget.item);
-              await askBeforeDeleteFromServerAndDevice(context, item);
-              final BaseItemDto newAlbumOrPlaylist =
-                  await _jellyfinApiHelper.getItemById(widget.parentItem!.id);
-              if (context.mounted) {
-                Navigator.pop(context); // close dialog
-                // pop current album screen and reload with new album data
-                Navigator.of(context).popUntil((route) {
-                  return route.settings.name != null // unnamed dialog
-                      &&
-                      route.settings.name !=
-                          AlbumScreen.routeName; // albums screen
-                });
-                await Navigator.of(context).pushNamed(AlbumScreen.routeName,
-                    arguments: newAlbumOrPlaylist);
-              }
-            },
-          )),
+      Consumer(builder: (context, ref, _) {
+        var canDelete = ref.watch(_jellyfinApiHelper
+            .canDeleteFromServerProvider(CanDeleteRequest(widget.item)));
+        return Visibility(
+            visible: canDelete,
+            child: ListTile(
+              leading: Icon(
+                Icons.delete_forever,
+                color: iconColor,
+              ),
+              title: Text(AppLocalizations.of(context)!
+                  .deleteFromTargetConfirmButton("server")),
+              enabled: canDelete,
+              onTap: () async {
+                var item = DownloadStub.fromItem(
+                    type: DownloadItemType.song, item: widget.item);
+                await askBeforeDeleteFromServerAndDevice(context, item);
+                final BaseItemDto newAlbumOrPlaylist =
+                    await _jellyfinApiHelper.getItemById(widget.parentItem!.id);
+                if (context.mounted) {
+                  Navigator.pop(context); // close dialog
+                  // pop current album screen and reload with new album data
+                  Navigator.of(context).popUntil((route) {
+                    return route.settings.name != null // unnamed dialog
+                        &&
+                        route.settings.name !=
+                            AlbumScreen.routeName; // albums screen
+                  });
+                  await Navigator.of(context).pushNamed(AlbumScreen.routeName,
+                      arguments: newAlbumOrPlaylist);
+                }
+              },
+            ));
+      }),
     ];
   }
 

--- a/lib/components/DownloadsScreen/downloaded_items_list.dart
+++ b/lib/components/DownloadsScreen/downloaded_items_list.dart
@@ -16,11 +16,11 @@ class DownloadedItemsList extends StatefulWidget {
 }
 
 class _DownloadedItemsListState extends State<DownloadedItemsList> {
-  final DownloadsService downloadsService = GetIt.instance<DownloadsService>();
+  final DownloadsService _downloadsService = GetIt.instance<DownloadsService>();
 
   @override
   Widget build(BuildContext context) {
-    var items = downloadsService.getUserDownloaded();
+    var items = _downloadsService.getUserDownloaded();
     return ListTileTheme(
       // Manually handle padding in leading/trailing icons
       horizontalTitleGap: 0,
@@ -44,7 +44,7 @@ class _DownloadedItemsListState extends State<DownloadedItemsList> {
                     IconButton(
                       icon: const Icon(Icons.sync),
                       onPressed: () {
-                        downloadsService.resync(album, null);
+                        _downloadsService.resync(album, null);
                       },
                     ),
                   IconButton(

--- a/lib/components/MusicScreen/album_item.dart
+++ b/lib/components/MusicScreen/album_item.dart
@@ -117,22 +117,14 @@ class _AlbumItemState extends ConsumerState<AlbumItem> {
   bool isOffline = FinampSettingsHelper.finampSettings.isOffline;
   final _jellyfinApiHelper = GetIt.instance<JellyfinApiHelper>();
   bool deletableGotUpdated = false;
-  bool canDeleteFromServer = false;
 
   @override
   Widget build(BuildContext context) {
     local = AppLocalizations.of(context)!;
 
     final screenSize = MediaQuery.of(context).size;
-
-    if (!deletableGotUpdated) {
-      deletableGotUpdated = true;
-      var deletable = _jellyfinApiHelper.canDeleteFromServer(widget.album);
-      canDeleteFromServer = deletable.initialValue;
-      deletable.realValue?.then((canDelete) => setState(() {
-            canDeleteFromServer = canDelete;
-          }));
-    }
+    var canDeleteFromServer = ref.watch(_jellyfinApiHelper
+        .canDeleteFromServerProvider(CanDeleteRequest(widget.album)));
 
     void menuCallback({
       required Offset localPosition,
@@ -309,7 +301,7 @@ class _AlbumItemState extends ConsumerState<AlbumItem> {
             ),
         ],
       );
-      if (!mounted) return;
+      if (!context.mounted) return;
 
       switch (selection) {
         case _AlbumListTileMenuItems.addFavourite:
@@ -655,8 +647,7 @@ class _AlbumItemState extends ConsumerState<AlbumItem> {
         case _AlbumListTileMenuItems.deleteFromDevice:
           var item = DownloadStub.fromItem(
               type: DownloadItemType.collection, item: widget.album);
-          await askBeforeDeleteDownloadFromDevice(context, item,
-              refresh: () => musicScreenRefreshStream.add(null));
+          await askBeforeDeleteDownloadFromDevice(context, item);
         case _AlbumListTileMenuItems.deleteFromServer:
           var item = DownloadStub.fromItem(
               type: DownloadItemType.collection, item: widget.album);

--- a/lib/components/MusicScreen/album_item.dart
+++ b/lib/components/MusicScreen/album_item.dart
@@ -123,8 +123,6 @@ class _AlbumItemState extends ConsumerState<AlbumItem> {
     local = AppLocalizations.of(context)!;
 
     final screenSize = MediaQuery.of(context).size;
-    var canDeleteFromServer = ref.watch(_jellyfinApiHelper
-        .canDeleteFromServerProvider(CanDeleteRequest(widget.album)));
 
     void menuCallback({
       required Offset localPosition,
@@ -133,6 +131,8 @@ class _AlbumItemState extends ConsumerState<AlbumItem> {
       unawaited(Feedback.forLongPress(context));
 
       final downloadsService = GetIt.instance<DownloadsService>();
+      final canDeleteFromServer = ref.watch(_jellyfinApiHelper
+          .canDeleteFromServerProvider(CanDeleteRequest(widget.album)));
       final downloadStatus = downloadsService.getStatus(
           DownloadStub.fromItem(
               type: DownloadItemType.collection, item: widget.album),

--- a/lib/components/delete_prompts.dart
+++ b/lib/components/delete_prompts.dart
@@ -6,8 +6,8 @@ import 'package:finamp/services/downloads_service.dart';
 import 'package:finamp/services/finamp_settings_helper.dart';
 import 'package:finamp/services/jellyfin_api_helper.dart';
 import 'package:flutter/material.dart';
-import 'package:get_it/get_it.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
+import 'package:get_it/get_it.dart';
 
 Future<void> askBeforeDeleteDownloadFromDevice(
     BuildContext context, DownloadStub stub,
@@ -70,13 +70,15 @@ Future<void> askBeforeDeleteFromServerAndDevice(
           onConfirmed: () async {
             try {
               await jellyfinApiHelper.deleteItem(stub.id);
-              GlobalSnackbar.message((_) => AppLocalizations.of(context)!
-                  .itemDeletedSnackbar("server", type));
+              GlobalSnackbar.message((scaffold) =>
+                  AppLocalizations.of(scaffold)!
+                      .itemDeletedSnackbar("server", type));
 
               if (status.isRequired) {
                 await downloadsService.deleteDownload(stub: stub);
-                GlobalSnackbar.message((_) => AppLocalizations.of(context)!
-                    .itemDeletedSnackbar("device", type));
+                GlobalSnackbar.message((scaffold) =>
+                    AppLocalizations.of(scaffold)!
+                        .itemDeletedSnackbar("device", type));
               }
 
               if (context.mounted) {

--- a/lib/screens/interaction_settings_screen.dart
+++ b/lib/screens/interaction_settings_screen.dart
@@ -1,6 +1,5 @@
 import 'package:finamp/components/InteractionSettingsScreen/keep_screen_on_dropdown_list_tile.dart';
 import 'package:finamp/components/InteractionSettingsScreen/keep_screen_on_while_charging_selector.dart';
-import 'package:finamp/components/MusicScreen/music_screen_tab_view.dart';
 import 'package:finamp/models/finamp_models.dart';
 import 'package:finamp/services/finamp_settings_helper.dart';
 import 'package:flutter/material.dart';
@@ -98,9 +97,6 @@ class ShowDeleteFromServerOptionToggle extends StatelessWidget {
             FinampSettings finampSettingsTemp = box.get("FinampSettings")!;
             finampSettingsTemp.allowDeleteFromServer = value;
             box.put("FinampSettings", finampSettingsTemp);
-
-            musicScreenRefreshStream
-                .add(null); // refresh current tab to show/hide delete button
           },
         );
       },

--- a/lib/services/downloads_service.dart
+++ b/lib/services/downloads_service.dart
@@ -1085,7 +1085,7 @@ class DownloadsService {
                       DownloadLocationType.internalDocuments)
                   .first
                   .id)
-          ? path_helper.join("tracks", image.path)
+          ? path_helper.join(FINAMP_BASE_DOWNLOAD_DIRECTORY, image.path)
           : image.path;
       isarItem.state = DownloadItemState.complete;
       isarItem.fileTranscodingProfile =
@@ -1144,7 +1144,8 @@ class DownloadsService {
                     DownloadLocationType.internalDocuments)
                 .first
                 .id) {
-          newPath = path_helper.join("tracks", track.path);
+          newPath =
+              path_helper.join(FINAMP_BASE_DOWNLOAD_DIRECTORY, track.path);
         } else {
           newPath = track.path;
         }

--- a/lib/services/downloads_service_backend.dart
+++ b/lib/services/downloads_service_backend.dart
@@ -24,8 +24,9 @@ import 'jellyfin_api_helper.dart';
 
 part 'downloads_service_backend.g.dart';
 
-const FINAMP_BASE_DOWNLOAD_DIRECTORY =
-    "songs"; //!!! don't ever change this without implementing a migration, it will break existing downloads
+// This is used during migration from the legacy hive download storage and cannot be changed without mitigations
+// Additionally, directory cleaning in downloads repair should cover all folders ever used.
+const FINAMP_BASE_DOWNLOAD_DIRECTORY = "songs";
 
 class IsarPersistentStorage implements PersistentStorage {
   final _isar = GetIt.instance<Isar>();
@@ -1326,8 +1327,8 @@ class DownloadsSyncService {
                     "${_jellyfinApiData.defaultFields},MediaSources,MediaStreams,SortName") ??
             [];
         childItems.addAll(trackChildItems);
-        var trackChildStubs = trackChildItems.map((e) =>
-            DownloadStub.fromItem(type: DownloadItemType.song, item: e));
+        var trackChildStubs = trackChildItems.map(
+            (e) => DownloadStub.fromItem(type: DownloadItemType.song, item: e));
         childStubs.addAll(trackChildStubs);
       }
       itemFetch.complete(childItems.map((e) => e.id).toList());

--- a/lib/services/finamp_settings_helper.dart
+++ b/lib/services/finamp_settings_helper.dart
@@ -4,6 +4,7 @@ import 'package:finamp/services/theme_mode_helper.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:hive_ce_flutter/hive_flutter.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 import 'package:rxdart/rxdart.dart';
@@ -14,10 +15,10 @@ import '../models/jellyfin_models.dart';
 part 'finamp_settings_helper.g.dart';
 
 @riverpod
-Stream<FinampSettings?> finampSettings(FinampSettingsRef ref) {
+Stream<FinampSettings> finampSettings(Ref ref) {
   return Hive.box<FinampSettings>("FinampSettings")
       .watch()
-      .map<FinampSettings?>((event) => event.value)
+      .map<FinampSettings>((event) => event.value!)
       .startWith(FinampSettingsHelper.finampSettings);
 }
 

--- a/lib/services/finamp_settings_helper.g.dart
+++ b/lib/services/finamp_settings_helper.g.dart
@@ -6,12 +6,12 @@ part of 'finamp_settings_helper.dart';
 // RiverpodGenerator
 // **************************************************************************
 
-String _$finampSettingsHash() => r'adf182d953f927977964f350f29ba11f6304a0a5';
+String _$finampSettingsHash() => r'da64f3dced318d770129a8e4c63e454786ef5050';
 
 /// See also [finampSettings].
 @ProviderFor(finampSettings)
 final finampSettingsProvider =
-    AutoDisposeStreamProvider<FinampSettings?>.internal(
+    AutoDisposeStreamProvider<FinampSettings>.internal(
   finampSettings,
   name: r'finampSettingsProvider',
   debugGetCreateSourceHash: const bool.fromEnvironment('dart.vm.product')
@@ -23,6 +23,6 @@ final finampSettingsProvider =
 
 @Deprecated('Will be removed in 3.0. Use Ref instead')
 // ignore: unused_element
-typedef FinampSettingsRef = AutoDisposeStreamProviderRef<FinampSettings?>;
+typedef FinampSettingsRef = AutoDisposeStreamProviderRef<FinampSettings>;
 // ignore_for_file: type=lint
 // ignore_for_file: subtype_of_sealed_class, invalid_use_of_internal_member, invalid_use_of_visible_for_testing_member, deprecated_member_use_from_same_package

--- a/lib/services/jellyfin_api_helper.dart
+++ b/lib/services/jellyfin_api_helper.dart
@@ -5,6 +5,7 @@ import 'dart:isolate';
 
 import 'package:chopper/chopper.dart';
 import 'package:flutter/services.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:get_it/get_it.dart';
 import 'package:isar/isar.dart';
 import 'package:logging/logging.dart';
@@ -865,31 +866,59 @@ class JellyfinApiHelper {
     return uri;
   }
 
-  CanDeleteFromServerResponse canDeleteFromServer(BaseItemDto item) {
-    // Cant delete from server when offline anyway
-    if (FinampSettingsHelper.finampSettings.isOffline) {
-      return CanDeleteFromServerResponse(false, null);
+  late final ProviderFamily<bool, CanDeleteRequest>
+      canDeleteFromServerProvider =
+      ProviderFamily((ref, CanDeleteRequest item) {
+    bool offline = ref.watch(
+        finampSettingsProvider.select((value) => value.requireValue.isOffline));
+    if (offline) {
+      return false;
     }
-
-    // Cant delete if setting is disabled anyway
-    if (!FinampSettingsHelper.finampSettings.allowDeleteFromServer) {
-      return CanDeleteFromServerResponse(false, null);
+    bool deleteEnabled = ref.watch(finampSettingsProvider
+        .select((value) => value.requireValue.allowDeleteFromServer));
+    if (!deleteEnabled) {
+      return false;
     }
+    // do not bother checking server for item types known to not be deletable
+    var itemType = BaseItemDtoType.fromItem(item.item);
+    if (itemType != BaseItemDtoType.album &&
+        itemType != BaseItemDtoType.playlist &&
+        itemType != BaseItemDtoType.track) {
+      return false;
+    }
+    bool? serverReturn =
+        ref.watch(_canDeleteFromServerAsyncProvider(item.item.id)).value;
+    if (serverReturn == null) {
+      // fallback to true in case the response is invalid but the user could delete still
+      // worst case would be an error messing when trying to delete
+      return item.item.canDelete ?? true;
+    } else {
+      return serverReturn;
+    }
+  });
 
-    // fallback to true in case the response is invalid but the user could delete still
-    // worst case would be an error messing when trying to delete
-    var request = getItemById(item.id).then((response) {
-      return response.canDelete ?? true;
+  late final AutoDisposeFutureProviderFamily<bool?, String>
+      _canDeleteFromServerAsyncProvider =
+      AutoDisposeFutureProviderFamily((ref, String id) {
+    return getItemById(id).then((response) {
+      return response.canDelete;
     }).catchError((_) {
       return false;
     });
-    return CanDeleteFromServerResponse(item.canDelete ?? true, request);
-  }
+  });
 }
 
-class CanDeleteFromServerResponse {
-  final bool initialValue;
-  final Future<bool>? realValue;
+/// All CanDeleteRequests with the same BaseItemDto id should be considered equal.
+class CanDeleteRequest {
+  final BaseItemDto item;
 
-  CanDeleteFromServerResponse(this.initialValue, this.realValue);
+  CanDeleteRequest(this.item);
+
+  @override
+  bool operator ==(Object other) {
+    return other is CanDeleteRequest && other.item.id == item.id;
+  }
+
+  @override
+  int get hashCode => item.id.hashCode;
 }


### PR DESCRIPTION
I've cleaned up the logic for the delete from server button on album/playlist screens and moved it all under DownloadButton.  We now properly show the lock button on incidental downloads.  I've refactored the canDeleteFromServer check into a provider while doing so to make usage cleaner and reduce repeated requests.

Also, I noticed we seemed to be using the 'tracks' directory in the download migration code, so I fixed that.