### PR TITLE
Add audio fade-in and fade-out with corresponding settings

### DIFF
--- a/lib/components/PlayerScreen/player_buttons.dart
+++ b/lib/components/PlayerScreen/player_buttons.dart
@@ -10,6 +10,7 @@ import 'package:flutter_tabler_icons/flutter_tabler_icons.dart';
 import 'package:flutter_vibrate/flutter_vibrate.dart';
 import 'package:get_it/get_it.dart';
 import 'package:finamp/l10n/app_localizations.dart';
+import 'package:progress_border/progress_border.dart';
 
 import '../../services/media_state_stream.dart';
 import '../../services/music_player_background_task.dart';
@@ -30,6 +31,7 @@ class PlayerButtons extends StatelessWidget {
         builder: (context, snapshot) {
           final mediaState = snapshot.data!;
           final playbackState = mediaState.playbackState;
+          final fadeState = mediaState.fadeState;
 
           return Row(
             mainAxisSize: MainAxisSize.max,
@@ -77,14 +79,28 @@ class PlayerButtons extends StatelessWidget {
                     FeedbackHelper.feedback(FeedbackType.light);
                     unawaited(audioHandler.togglePlayback());
                   },
-                  icon: Icon(
-                      mediaState.playbackState.playing
-                          ? mediaState.fadeState.fadeDirection !=
-                                  FadeDirection.fadeOut
-                              ? TablerIcons.player_pause
-                              : TablerIcons.player_play
-                          : TablerIcons.player_play,
-                      size: 28),
+                  icon: Container(
+                      decoration: BoxDecoration(
+                        borderRadius: BorderRadius.all(Radius.circular(
+                            controller.shouldShow(PlayerHideable.bigPlayButton)
+                                ? 16
+                                : 12)),
+                        border: fadeState.fadeDirection != FadeDirection.none
+                            ? ProgressBorder.all(
+                                color:
+                                    IconTheme.of(context).color!.withAlpha(128),
+                                width: 4,
+                                progress: fadeState.fadeVolumePercent,
+                              )
+                            : null,
+                      ),
+                      child: Icon(
+                          playbackState.playing
+                              ? fadeState.fadeDirection != FadeDirection.fadeOut
+                                  ? TablerIcons.player_pause
+                                  : TablerIcons.player_play
+                              : TablerIcons.player_play,
+                          size: 32)),
                 ),
               ),
               Semantics.fromProperties(

--- a/lib/components/PlayerScreen/player_buttons.dart
+++ b/lib/components/PlayerScreen/player_buttons.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:finamp/components/PlayerScreen/player_buttons_repeating.dart';
 import 'package:finamp/components/PlayerScreen/player_buttons_shuffle.dart';
 import 'package:finamp/screens/player_screen.dart';
@@ -23,9 +25,11 @@ class PlayerButtons extends StatelessWidget {
 
     return StreamBuilder<MediaState>(
         stream: mediaStateStream,
+        initialData: MediaState(audioHandler.mediaItem.valueOrNull,
+            audioHandler.playbackState.value, audioHandler.fading.value),
         builder: (context, snapshot) {
-          final mediaState = snapshot.data;
-          final playbackState = mediaState?.playbackState;
+          final mediaState = snapshot.data!;
+          final playbackState = mediaState.playbackState;
 
           return Row(
             mainAxisSize: MainAxisSize.max,
@@ -44,12 +48,10 @@ class PlayerButtons extends StatelessWidget {
                 excludeSemantics: true,
                 child: IconButton(
                   icon: const Icon(TablerIcons.player_skip_back),
-                  onPressed: playbackState != null
-                      ? () async {
-                          FeedbackHelper.feedback(FeedbackType.light);
-                          await audioHandler.skipToPrevious();
-                        }
-                      : null,
+                  onPressed: () async {
+                    FeedbackHelper.feedback(FeedbackType.light);
+                    await audioHandler.skipToPrevious();
+                  },
                 ),
               ),
               Semantics.fromProperties(
@@ -71,21 +73,17 @@ class PlayerButtons extends StatelessWidget {
                       controller.shouldShow(PlayerHideable.bigPlayButton)
                           ? 16
                           : 12),
-                  onTap: playbackState != null
-                      ? () async {
-                          FeedbackHelper.feedback(FeedbackType.light);
-                          if (playbackState.playing) {
-                            await audioHandler.pause();
-                          } else {
-                            await audioHandler.play();
-                          }
-                        }
-                      : null,
-                  icon: Icon(
-                      playbackState == null || playbackState.playing
-                          ? TablerIcons.player_pause
-                          : TablerIcons.player_play,
-                      size: 28),
+                  onTap: () async {
+                    FeedbackHelper.feedback(FeedbackType.light);
+                    unawaited(audioHandler.togglePlayback());
+                  },
+                  icon: mediaState.audioFading
+                      ? const Center(child: CircularProgressIndicator())
+                      : Icon(
+                          playbackState.playing
+                              ? TablerIcons.player_pause
+                              : TablerIcons.player_play,
+                          size: 28),
                 ),
               ),
               Semantics.fromProperties(
@@ -98,12 +96,10 @@ class PlayerButtons extends StatelessWidget {
                 excludeSemantics: true,
                 child: IconButton(
                   icon: const Icon(TablerIcons.player_skip_forward),
-                  onPressed: playbackState != null
-                      ? () async {
-                          FeedbackHelper.feedback(FeedbackType.light);
-                          await audioHandler.skipToNext();
-                        }
-                      : null,
+                  onPressed: () async {
+                    FeedbackHelper.feedback(FeedbackType.light);
+                    await audioHandler.skipToNext();
+                  },
                 ),
               ),
               if (controller.shouldShow(PlayerHideable.loopShuffleButtons))

--- a/lib/components/PlayerScreen/player_buttons.dart
+++ b/lib/components/PlayerScreen/player_buttons.dart
@@ -80,7 +80,9 @@ class PlayerButtons extends StatelessWidget {
                       FeedbackHelper.feedback(FeedbackType.light);
                       unawaited(audioHandler.togglePlayback());
                     },
-                    icon: FadeProgressContainer(
+                    icon: AudioFadeProgressVisualizerContainer(
+                        key: const Key(
+                            "PlayerButtonAudioFadeProgressVisualizer"),
                         borderRadius: BorderRadius.all(Radius.circular(
                             controller.shouldShow(PlayerHideable.bigPlayButton)
                                 ? 16

--- a/lib/components/PlayerScreen/player_buttons.dart
+++ b/lib/components/PlayerScreen/player_buttons.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 
 import 'package:finamp/components/PlayerScreen/player_buttons_repeating.dart';
 import 'package:finamp/components/PlayerScreen/player_buttons_shuffle.dart';
+import 'package:finamp/components/audio_fade_progress_visualizer_container.dart';
 import 'package:finamp/screens/player_screen.dart';
 import 'package:finamp/services/feedback_helper.dart';
 import 'package:flutter/material.dart';
@@ -65,43 +66,33 @@ class PlayerButtons extends StatelessWidget {
                 container: true,
                 excludeSemantics: true,
                 child: _RoundedIconButton(
-                  width: controller.shouldShow(PlayerHideable.bigPlayButton)
-                      ? 62
-                      : 48,
-                  height: controller.shouldShow(PlayerHideable.bigPlayButton)
-                      ? 62
-                      : 48,
-                  borderRadius: BorderRadius.circular(
-                      controller.shouldShow(PlayerHideable.bigPlayButton)
-                          ? 16
-                          : 12),
-                  onTap: () {
-                    FeedbackHelper.feedback(FeedbackType.light);
-                    unawaited(audioHandler.togglePlayback());
-                  },
-                  icon: Container(
-                      decoration: BoxDecoration(
+                    width: controller.shouldShow(PlayerHideable.bigPlayButton)
+                        ? 62
+                        : 48,
+                    height: controller.shouldShow(PlayerHideable.bigPlayButton)
+                        ? 62
+                        : 48,
+                    borderRadius: BorderRadius.circular(
+                        controller.shouldShow(PlayerHideable.bigPlayButton)
+                            ? 16
+                            : 12),
+                    onTap: () {
+                      FeedbackHelper.feedback(FeedbackType.light);
+                      unawaited(audioHandler.togglePlayback());
+                    },
+                    icon: FadeProgressContainer(
                         borderRadius: BorderRadius.all(Radius.circular(
                             controller.shouldShow(PlayerHideable.bigPlayButton)
                                 ? 16
                                 : 12)),
-                        border: fadeState.fadeDirection != FadeDirection.none
-                            ? ProgressBorder.all(
-                                color:
-                                    IconTheme.of(context).color!.withAlpha(128),
-                                width: 4,
-                                progress: fadeState.fadeVolumePercent,
-                              )
-                            : null,
-                      ),
-                      child: Icon(
-                          playbackState.playing
-                              ? fadeState.fadeDirection != FadeDirection.fadeOut
-                                  ? TablerIcons.player_pause
-                                  : TablerIcons.player_play
-                              : TablerIcons.player_play,
-                          size: 32)),
-                ),
+                        child: Icon(
+                            playbackState.playing
+                                ? fadeState.fadeDirection !=
+                                        FadeDirection.fadeOut
+                                    ? TablerIcons.player_pause
+                                    : TablerIcons.player_play
+                                : TablerIcons.player_play,
+                            size: 32))),
               ),
               Semantics.fromProperties(
                 properties: SemanticsProperties(

--- a/lib/components/PlayerScreen/player_buttons.dart
+++ b/lib/components/PlayerScreen/player_buttons.dart
@@ -26,7 +26,7 @@ class PlayerButtons extends StatelessWidget {
     return StreamBuilder<MediaState>(
         stream: mediaStateStream,
         initialData: MediaState(audioHandler.mediaItem.valueOrNull,
-            audioHandler.playbackState.value, audioHandler.fading.value),
+            audioHandler.playbackState.value, audioHandler.fadeState.value),
         builder: (context, snapshot) {
           final mediaState = snapshot.data!;
           final playbackState = mediaState.playbackState;
@@ -73,17 +73,18 @@ class PlayerButtons extends StatelessWidget {
                       controller.shouldShow(PlayerHideable.bigPlayButton)
                           ? 16
                           : 12),
-                  onTap: () async {
+                  onTap: () {
                     FeedbackHelper.feedback(FeedbackType.light);
                     unawaited(audioHandler.togglePlayback());
                   },
-                  icon: mediaState.audioFading
-                      ? const Center(child: CircularProgressIndicator())
-                      : Icon(
-                          playbackState.playing
+                  icon: Icon(
+                      mediaState.playbackState.playing
+                          ? mediaState.fadeState.fadeDirection !=
+                                  FadeDirection.fadeOut
                               ? TablerIcons.player_pause
-                              : TablerIcons.player_play,
-                          size: 28),
+                              : TablerIcons.player_play
+                          : TablerIcons.player_play,
+                      size: 28),
                 ),
               ),
               Semantics.fromProperties(

--- a/lib/components/PlayerScreen/player_screen_album_image.dart
+++ b/lib/components/PlayerScreen/player_screen_album_image.dart
@@ -26,6 +26,7 @@ class PlayerScreenAlbumImage extends ConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final queueService = GetIt.instance<QueueService>();
+    final audioService = GetIt.instance<MusicPlayerBackgroundTask>();
     return StreamBuilder<FinampQueueInfo?>(
       stream: queueService.getQueueStream(),
       builder: (context, snapshot) {
@@ -62,8 +63,6 @@ class PlayerScreenAlbumImage extends ConsumerWidget {
             child: SimpleGestureDetector(
               //TODO replace with PageView, this is just a placeholder
               onTap: () {
-                final audioService =
-                    GetIt.instance<MusicPlayerBackgroundTask>();
                 unawaited(audioService.togglePlayback());
                 FeedbackHelper.feedback(FeedbackType.selection);
               },
@@ -77,7 +76,6 @@ class PlayerScreenAlbumImage extends ConsumerWidget {
                 }
               },
               onHorizontalSwipe: (direction) {
-                final queueService = GetIt.instance<QueueService>();
                 if (direction == SwipeDirection.left) {
                   if (!FinampSettingsHelper.finampSettings.disableGesture) {
                     queueService.skipByOffset(1);

--- a/lib/components/PlayerScreen/player_screen_album_image.dart
+++ b/lib/components/PlayerScreen/player_screen_album_image.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:finamp/components/PlayerScreen/queue_source_helper.dart';
 import 'package:finamp/models/finamp_models.dart';
 import 'package:finamp/services/feedback_helper.dart';
@@ -62,7 +64,7 @@ class PlayerScreenAlbumImage extends ConsumerWidget {
               onTap: () {
                 final audioService =
                     GetIt.instance<MusicPlayerBackgroundTask>();
-                audioService.togglePlayback();
+                unawaited(audioService.togglePlayback());
                 FeedbackHelper.feedback(FeedbackType.selection);
               },
               onDoubleTap: () {

--- a/lib/components/PlayerScreen/queue_list.dart
+++ b/lib/components/PlayerScreen/queue_list.dart
@@ -769,15 +769,17 @@ class _CurrentTrackState extends State<CurrentTrack> {
                                 FeedbackHelper.feedback(FeedbackType.success);
                                 _audioHandler.togglePlayback();
                               },
-                              icon: mediaState!.playbackState.playing
-                                  ? const Icon(
-                                      TablerIcons.player_pause,
-                                      size: 32,
-                                    )
-                                  : const Icon(
-                                      TablerIcons.player_play,
-                                      size: 32,
-                                    ),
+                              icon: mediaState!.audioFading
+                                  ? const CircularProgressIndicator()
+                                  : mediaState!.playbackState.playing
+                                      ? const Icon(
+                                          TablerIcons.player_pause,
+                                          size: 32,
+                                        )
+                                      : const Icon(
+                                          TablerIcons.player_play,
+                                          size: 32,
+                                        ),
                               color: Colors.white,
                             )),
                       ],

--- a/lib/components/PlayerScreen/queue_list.dart
+++ b/lib/components/PlayerScreen/queue_list.dart
@@ -769,17 +769,15 @@ class _CurrentTrackState extends State<CurrentTrack> {
                                 FeedbackHelper.feedback(FeedbackType.success);
                                 _audioHandler.togglePlayback();
                               },
-                              icon: mediaState!.audioFading
-                                  ? const CircularProgressIndicator()
-                                  : mediaState!.playbackState.playing
-                                      ? const Icon(
-                                          TablerIcons.player_pause,
-                                          size: 32,
-                                        )
-                                      : const Icon(
-                                          TablerIcons.player_play,
-                                          size: 32,
-                                        ),
+                              icon: mediaState!.playbackState.playing
+                                  ? const Icon(
+                                      TablerIcons.player_pause,
+                                      size: 32,
+                                    )
+                                  : const Icon(
+                                      TablerIcons.player_play,
+                                      size: 32,
+                                    ),
                               color: Colors.white,
                             )),
                       ],

--- a/lib/components/audio_fade_progress_visualizer_container.dart
+++ b/lib/components/audio_fade_progress_visualizer_container.dart
@@ -9,7 +9,7 @@ import 'package:visibility_detector/visibility_detector.dart';
 
 class AudioFadeProgressVisualizerContainer extends StatefulWidget {
   const AudioFadeProgressVisualizerContainer({
-    super.key,
+    required super.key,
     required this.child,
     this.border,
     this.borderRadius,
@@ -89,14 +89,14 @@ class _AudioFadeProgressVisualizerContainerState
   }
 
   void startFadeIn({double? from}) {
-    final duration = FinampSettingsHelper.finampSettings.audioFadeInDuration;
-    _controller.duration = from != null ? duration * (1.0 - from) : duration;
+    _controller.duration =
+        FinampSettingsHelper.finampSettings.audioFadeInDuration;
     _controller.forward(from: from ?? 0.0);
   }
 
   void startFadeOut({double? from}) {
-    final duration = FinampSettingsHelper.finampSettings.audioFadeOutDuration;
-    _controller.duration = from != null ? duration * (1.0 - from) : duration;
+    _controller.duration =
+        FinampSettingsHelper.finampSettings.audioFadeOutDuration;
     _controller.reverse(from: from ?? 1.0);
   }
 

--- a/lib/components/audio_fade_progress_visualizer_container.dart
+++ b/lib/components/audio_fade_progress_visualizer_container.dart
@@ -1,0 +1,122 @@
+import 'dart:async';
+
+import 'package:finamp/services/finamp_settings_helper.dart';
+import 'package:finamp/services/music_player_background_task.dart';
+import 'package:flutter/material.dart';
+import 'package:get_it/get_it.dart';
+import 'package:progress_border/progress_border.dart';
+
+class FadeProgressContainer extends StatefulWidget {
+  const FadeProgressContainer({
+    super.key,
+    required this.child,
+    this.border,
+    this.borderRadius,
+    this.width,
+    this.height,
+  });
+
+  final Widget child;
+  final Border? border;
+  final BorderRadius? borderRadius;
+  final double? width;
+  final double? height;
+
+  @override
+  State<FadeProgressContainer> createState() => _FadeProgressContainerState();
+}
+
+class _FadeProgressContainerState extends State<FadeProgressContainer>
+    with SingleTickerProviderStateMixin {
+  final audioHandler = GetIt.instance<MusicPlayerBackgroundTask>();
+
+  late FadeState _state;
+  late Animation<double> _animation;
+  late StreamSubscription<FadeState> _stateSubscription;
+  late AnimationController _controller;
+
+  @override
+  void initState() {
+    super.initState();
+    _state = audioHandler.fadeState.value;
+
+    _controller = AnimationController(
+        duration: FinampSettingsHelper.finampSettings.audioFadeInDuration,
+        vsync: this);
+
+    if (_state.fadeDirection != FadeDirection.none) {
+      if (_state.fadeDirection == FadeDirection.fadeOut) {
+        startFadeOut(from: _state.fadeVolumePercent);
+      } else if (_state.fadeDirection == FadeDirection.fadeIn) {
+        startFadeIn(from: _state.fadeVolumePercent);
+      }
+    }
+
+    _animation = Tween<double>(begin: 0.0, end: 1.0)
+        .animate(CurvedAnimation(parent: _controller, curve: Curves.easeInOut));
+
+    _stateSubscription = audioHandler.fadeState.listen((state) {
+      if (state.fadeDirection != _state.fadeDirection) {
+        if (state.fadeDirection == FadeDirection.fadeOut) {
+          if (_state.fadeDirection == FadeDirection.fadeIn) {
+            startFadeOut(from: state.fadeVolumePercent);
+          } else {
+            startFadeOut();
+          }
+        } else if (state.fadeDirection == FadeDirection.fadeIn) {
+          if (_state.fadeDirection == FadeDirection.fadeOut) {
+            startFadeIn(from: state.fadeVolumePercent);
+          } else {
+            startFadeIn();
+          }
+        }
+      }
+      setState(() {
+        _state = state;
+      });
+    });
+  }
+
+  void startFadeIn({double? from}) {
+    final duration = FinampSettingsHelper.finampSettings.audioFadeInDuration;
+    _controller.duration = from != null ? duration * (1.0 - from) : duration;
+    _controller.forward(from: from ?? 0.0);
+  }
+
+  void startFadeOut({double? from}) {
+    final duration = FinampSettingsHelper.finampSettings.audioFadeOutDuration;
+    _controller.duration = from != null ? duration * (1.0 - from) : duration;
+    _controller.reverse(from: from ?? 1.0);
+  }
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    _stateSubscription.cancel();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return AnimatedBuilder(
+      animation: _controller,
+      builder: (context, child) {
+        return Container(
+            width: widget.width,
+            height: widget.height,
+            decoration: BoxDecoration(
+              borderRadius: widget.borderRadius,
+              border: _controller.status != AnimationStatus.dismissed &&
+                      _controller.status != AnimationStatus.completed
+                  ? ProgressBorder.all(
+                      color: IconTheme.of(context).color!.withAlpha(128),
+                      width: 4,
+                      progress: _animation.value,
+                    )
+                  : null,
+            ),
+            child: widget.child);
+      },
+    );
+  }
+}

--- a/lib/components/now_playing_bar.dart
+++ b/lib/components/now_playing_bar.dart
@@ -239,8 +239,10 @@ class NowPlayingBar extends ConsumerWidget {
                   child: StreamBuilder<MediaState>(
                     stream: mediaStateStream
                         .where((event) => event.mediaItem != null),
-                    initialData: MediaState(audioHandler.mediaItem.valueOrNull,
-                        audioHandler.playbackState.value),
+                    initialData: MediaState(
+                        audioHandler.mediaItem.valueOrNull,
+                        audioHandler.playbackState.value,
+                        audioHandler.fading.value),
                     builder: (context, snapshot) {
                       final MediaState mediaState = snapshot.data!;
                       // If we have a media item and the player hasn't finished, show
@@ -282,24 +284,26 @@ class NowPlayingBar extends ConsumerWidget {
                                           color: Color.fromRGBO(0, 0, 0, 0.3),
                                         ),
                                         child: IconButton(
-                                          tooltip: AppLocalizations.of(context)!
-                                              .togglePlaybackButtonTooltip,
-                                          onPressed: () {
-                                            FeedbackHelper.feedback(
-                                                FeedbackType.light);
-                                            audioHandler.togglePlayback();
-                                          },
-                                          icon: mediaState.playbackState.playing
-                                              ? const Icon(
-                                                  TablerIcons.player_pause,
-                                                  size: 32,
-                                                )
-                                              : const Icon(
-                                                  TablerIcons.player_play,
-                                                  size: 32,
-                                                ),
-                                          color: Colors.white,
-                                        )),
+                                            tooltip: AppLocalizations
+                                                    .of(context)!
+                                                .togglePlaybackButtonTooltip,
+                                            onPressed: () {
+                                              FeedbackHelper.feedback(
+                                                  FeedbackType.light);
+                                              audioHandler.togglePlayback();
+                                            },
+                                            color: Colors.white,
+                                            icon: mediaState
+                                                    .audioFading
+                                                ? const CircularProgressIndicator()
+                                                : Icon(
+                                                    mediaState.playbackState
+                                                            .playing
+                                                        ? TablerIcons
+                                                            .player_pause
+                                                        : TablerIcons
+                                                            .player_play,
+                                                    size: 32))),
                                   ],
                                 ),
                                 Expanded(

--- a/lib/components/now_playing_bar.dart
+++ b/lib/components/now_playing_bar.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'dart:math';
 
 import 'package:audio_service/audio_service.dart';
@@ -242,7 +243,7 @@ class NowPlayingBar extends ConsumerWidget {
                     initialData: MediaState(
                         audioHandler.mediaItem.valueOrNull,
                         audioHandler.playbackState.value,
-                        audioHandler.fading.value),
+                        audioHandler.fadeState.value),
                     builder: (context, snapshot) {
                       final MediaState mediaState = snapshot.data!;
                       // If we have a media item and the player hasn't finished, show
@@ -284,26 +285,28 @@ class NowPlayingBar extends ConsumerWidget {
                                           color: Color.fromRGBO(0, 0, 0, 0.3),
                                         ),
                                         child: IconButton(
-                                            tooltip: AppLocalizations
-                                                    .of(context)!
+                                            tooltip: AppLocalizations.of(
+                                                    context)!
                                                 .togglePlaybackButtonTooltip,
                                             onPressed: () {
                                               FeedbackHelper.feedback(
                                                   FeedbackType.light);
-                                              audioHandler.togglePlayback();
+                                              unawaited(audioHandler
+                                                  .togglePlayback());
                                             },
                                             color: Colors.white,
-                                            icon: mediaState
-                                                    .audioFading
-                                                ? const CircularProgressIndicator()
-                                                : Icon(
-                                                    mediaState.playbackState
-                                                            .playing
+                                            icon: Icon(
+                                                mediaState.playbackState.playing
+                                                    ? mediaState.fadeState
+                                                                .fadeDirection !=
+                                                            FadeDirection
+                                                                .fadeOut
                                                         ? TablerIcons
                                                             .player_pause
                                                         : TablerIcons
-                                                            .player_play,
-                                                    size: 32))),
+                                                            .player_play
+                                                    : TablerIcons.player_play,
+                                                size: 32))),
                                   ],
                                 ),
                                 Expanded(

--- a/lib/components/now_playing_bar.dart
+++ b/lib/components/now_playing_bar.dart
@@ -19,6 +19,7 @@ import 'package:flutter_tabler_icons/flutter_tabler_icons.dart';
 import 'package:flutter_vibrate/flutter_vibrate.dart';
 import 'package:get_it/get_it.dart';
 import 'package:simple_gesture_detector/simple_gesture_detector.dart';
+import 'package:progress_border/progress_border.dart';
 
 import '../models/jellyfin_models.dart' as jellyfin_models;
 import '../screens/player_screen.dart';
@@ -246,6 +247,8 @@ class NowPlayingBar extends ConsumerWidget {
                         audioHandler.fadeState.value),
                     builder: (context, snapshot) {
                       final MediaState mediaState = snapshot.data!;
+                      final playbackState = mediaState.playbackState;
+                      final fadeState = mediaState.fadeState;
                       // If we have a media item and the player hasn't finished, show
                       // the now playing bar.
                       if (mediaState.mediaItem != null) {
@@ -280,33 +283,41 @@ class NowPlayingBar extends ConsumerWidget {
                                     Container(
                                         width: albumImageSize,
                                         height: albumImageSize,
-                                        decoration: const ShapeDecoration(
-                                          shape: Border(),
-                                          color: Color.fromRGBO(0, 0, 0, 0.3),
+                                        decoration: BoxDecoration(
+                                          borderRadius: BorderRadius.only(
+                                              topLeft: Radius.circular(12.0),
+                                              bottomLeft:
+                                                  Radius.circular(12.0)),
+                                          border: fadeState.fadeDirection !=
+                                                  FadeDirection.none
+                                              ? ProgressBorder.all(
+                                                  color: Colors.white
+                                                      .withAlpha(128),
+                                                  width: 4,
+                                                  progress: fadeState
+                                                      .fadeVolumePercent,
+                                                )
+                                              : null,
                                         ),
                                         child: IconButton(
-                                            tooltip: AppLocalizations.of(
-                                                    context)!
-                                                .togglePlaybackButtonTooltip,
-                                            onPressed: () {
-                                              FeedbackHelper.feedback(
-                                                  FeedbackType.light);
-                                              unawaited(audioHandler
-                                                  .togglePlayback());
-                                            },
-                                            color: Colors.white,
-                                            icon: Icon(
-                                                mediaState.playbackState.playing
-                                                    ? mediaState.fadeState
-                                                                .fadeDirection !=
-                                                            FadeDirection
-                                                                .fadeOut
-                                                        ? TablerIcons
-                                                            .player_pause
-                                                        : TablerIcons
-                                                            .player_play
-                                                    : TablerIcons.player_play,
-                                                size: 32))),
+                                          tooltip: AppLocalizations.of(context)!
+                                              .togglePlaybackButtonTooltip,
+                                          onPressed: () {
+                                            FeedbackHelper.feedback(
+                                                FeedbackType.light);
+                                            unawaited(
+                                                audioHandler.togglePlayback());
+                                          },
+                                          color: Colors.white,
+                                          icon: Icon(
+                                              playbackState.playing
+                                                  ? fadeState.fadeDirection !=
+                                                          FadeDirection.fadeOut
+                                                      ? TablerIcons.player_pause
+                                                      : TablerIcons.player_play
+                                                  : TablerIcons.player_play,
+                                              size: 32),
+                                        ))
                                   ],
                                 ),
                                 Expanded(

--- a/lib/components/now_playing_bar.dart
+++ b/lib/components/now_playing_bar.dart
@@ -5,6 +5,7 @@ import 'package:audio_service/audio_service.dart';
 import 'package:finamp/color_schemes.g.dart';
 import 'package:finamp/components/AddToPlaylistScreen/add_to_playlist_button.dart';
 import 'package:finamp/components/print_duration.dart';
+import 'package:finamp/components/audio_fade_progress_visualizer_container.dart';
 import 'package:finamp/models/finamp_models.dart';
 import 'package:finamp/services/current_track_metadata_provider.dart';
 import 'package:finamp/services/feedback_helper.dart';
@@ -19,7 +20,6 @@ import 'package:flutter_tabler_icons/flutter_tabler_icons.dart';
 import 'package:flutter_vibrate/flutter_vibrate.dart';
 import 'package:get_it/get_it.dart';
 import 'package:simple_gesture_detector/simple_gesture_detector.dart';
-import 'package:progress_border/progress_border.dart';
 
 import '../models/jellyfin_models.dart' as jellyfin_models;
 import '../screens/player_screen.dart';
@@ -280,26 +280,14 @@ class NowPlayingBar extends ConsumerWidget {
                                           currentAlbumImageProvider,
                                       borderRadius: BorderRadius.zero,
                                     ),
-                                    Container(
-                                        width: albumImageSize,
-                                        height: albumImageSize,
-                                        decoration: BoxDecoration(
-                                          borderRadius: BorderRadius.only(
-                                              topLeft: Radius.circular(12.0),
-                                              bottomLeft:
-                                                  Radius.circular(12.0)),
-                                          border: fadeState.fadeDirection !=
-                                                  FadeDirection.none
-                                              ? ProgressBorder.all(
-                                                  color: Colors.white
-                                                      .withAlpha(128),
-                                                  width: 4,
-                                                  progress: fadeState
-                                                      .fadeVolumePercent,
-                                                )
-                                              : null,
-                                        ),
-                                        child: IconButton(
+                                    FadeProgressContainer(
+                                      width: albumImageSize,
+                                      height: albumImageSize,
+                                      borderRadius: BorderRadius.only(
+                                        topLeft: Radius.circular(12.0),
+                                        bottomLeft: Radius.circular(12.0),
+                                      ),
+                                      child: IconButton(
                                           tooltip: AppLocalizations.of(context)!
                                               .togglePlaybackButtonTooltip,
                                           onPressed: () {
@@ -316,8 +304,8 @@ class NowPlayingBar extends ConsumerWidget {
                                                       ? TablerIcons.player_pause
                                                       : TablerIcons.player_play
                                                   : TablerIcons.player_play,
-                                              size: 32),
-                                        ))
+                                              size: 32)),
+                                    ),
                                   ],
                                 ),
                                 Expanded(

--- a/lib/components/now_playing_bar.dart
+++ b/lib/components/now_playing_bar.dart
@@ -139,6 +139,7 @@ class NowPlayingBar extends ConsumerWidget {
   Widget buildNowPlayingBar(
       BuildContext context, FinampQueueItem currentTrack) {
     final audioHandler = GetIt.instance<MusicPlayerBackgroundTask>();
+    final queueService = GetIt.instance<QueueService>();
 
     Duration? playbackPosition;
 
@@ -193,7 +194,6 @@ class NowPlayingBar extends ConsumerWidget {
                 : DismissDirection.vertical,
             confirmDismiss: (direction) async {
               if (direction == DismissDirection.down) {
-                final queueService = GetIt.instance<QueueService>();
                 FeedbackHelper.feedback(FeedbackType.success);
                 await queueService.stopPlayback();
               } else {
@@ -280,7 +280,9 @@ class NowPlayingBar extends ConsumerWidget {
                                           currentAlbumImageProvider,
                                       borderRadius: BorderRadius.zero,
                                     ),
-                                    FadeProgressContainer(
+                                    AudioFadeProgressVisualizerContainer(
+                                      key: const Key(
+                                          "AlbumArtAudioFadeProgressVisualizer"),
                                       width: albumImageSize,
                                       height: albumImageSize,
                                       borderRadius: BorderRadius.only(

--- a/lib/l10n/app_de.arb
+++ b/lib/l10n/app_de.arb
@@ -1942,5 +1942,21 @@
   "allowDeleteFromServerTitle": "Serverseitiges Löschen von Medien erlauben",
   "@allowDeleteFromServerTitle": {
     "description": "Title for the setting that controls if items can be deleted from the server"
+  },
+  "audioFadeOutDurationSettingTitle": "Audioausblendungsdauer",
+  "@audioFadeOutDurationSettingTitle": {
+      "description": "Title for the audio fade out duration setting."
+  },
+  "audioFadeOutDurationSettingSubtitle": "Die Dauer der Audioausblendung in millisekunden. Auf 0 setzen zum Deaktivieren der Audioausblendung.",
+  "@audioFadeOutDurationSettingSubtitle": {
+      "description": "Subtitle for the audio fade out duration setting."
+  },
+  "audioFadeInDurationSettingTitle": "Audioeinblendungsdauer",
+  "@audioFadeOutDurationSettingTitle": {
+      "description": "Title for the audio fade-in duration setting."
+  },
+  "audioFadeInDurationSettingSubtitle": "Die Dauer der Audioeinblendung in millisekunden. Auf 0 setzen zum Deaktivieren der Audioeinblendung.",
+  "@audioFadeOutDurationSettingSubtitle": {
+      "description": "Subtitle for the audio fade-in duration setting."
   }
 }

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -1935,5 +1935,21 @@
   "librarySelectError": "Error loading available libraries for user",
   "@librarySelectError": {
     "description": "Error shown when the library select screen fails to load."
+  },
+  "audioFadeOutDurationSettingTitle": "Audio fade-out duration",
+  "@audioFadeOutDurationSettingTitle": {
+      "description": "Title for the audio fade-out duration setting."
+  },
+  "audioFadeOutDurationSettingSubtitle": "The duration of the audio fade out in milliseconds.",
+  "@audioFadeOutDurationSettingSubtitle": {
+      "description": "Subtitle for the audio fade-out duration setting. Set to 0 to disable fade-out."
+  },
+  "audioFadeInDurationSettingTitle": "Audio fade-in duration",
+  "@audioFadeOutDurationSettingTitle": {
+      "description": "Title for the audio fade-in duration setting."
+  },
+  "audioFadeInDurationSettingSubtitle": "The duration of the audio fade-in in milliseconds. Set to 0 to disable fade-in.",
+  "@audioFadeOutDurationSettingSubtitle": {
+      "description": "Subtitle for the audio fade-in duration setting. Set to 0 to disable fade-in."
   }
 }

--- a/lib/models/finamp_models.dart
+++ b/lib/models/finamp_models.dart
@@ -152,112 +152,119 @@ class DefaultSettings {
   static const oneLineMarqueeTextButton = false;
   static const showAlbumReleaseDateOnPlayerScreen = false;
   static const releaseDateFormat = ReleaseDateFormat.year;
+  static const audioFadeOutDuration = Duration(milliseconds: 0);
+  static const audioFadeInDuration = Duration(milliseconds: 0);
 }
 
 @HiveType(typeId: 28)
 class FinampSettings {
-  FinampSettings({
-    this.isOffline = DefaultSettings.isOffline,
-    this.shouldTranscode = DefaultSettings.shouldTranscode,
-    this.transcodeBitrate = DefaultSettings.transcodeBitrate,
-    // downloadLocations is required since the other values can be created with
-    // default values. create() is used to return a FinampSettings with
-    // downloadLocations.
-    required this.downloadLocations,
-    this.androidStopForegroundOnPause =
-        DefaultSettings.androidStopForegroundOnPause,
-    required this.showTabs,
-    this.onlyShowFavourites = DefaultSettings.onlyShowFavourites,
-    this.sortBy = SortBy.sortName,
-    this.sortOrder = SortOrder.ascending,
-    this.trackShuffleItemCount = DefaultSettings.trackShuffleItemCount,
-    this.volumeNormalizationActive = DefaultSettings.volumeNormalizationActive,
-    this.volumeNormalizationIOSBaseGain =
-        DefaultSettings.volumeNormalizationIOSBaseGain,
-    this.volumeNormalizationMode = DefaultSettings.volumeNormalizationMode,
-    this.contentViewType = DefaultSettings.contentViewType,
-    this.playbackSpeedVisibility = DefaultSettings.playbackSpeedVisibility,
-    this.contentGridViewCrossAxisCountPortrait =
-        DefaultSettings.contentGridViewCrossAxisCountPortrait,
-    this.contentGridViewCrossAxisCountLandscape =
-        DefaultSettings.contentGridViewCrossAxisCountLandscape,
-    this.showTextOnGridView = DefaultSettings.showTextOnGridView,
-    this.sleepTimerSeconds = DefaultSettings.sleepTimerSeconds,
-    required this.downloadLocationsMap,
-    this.useCoverAsBackground = DefaultSettings.useCoverAsBackground,
-    this.playerScreenCoverMinimumPadding =
-        DefaultSettings.playerScreenCoverMinimumPadding,
-    this.showArtistsTopTracks = DefaultSettings.showArtistsTopTracks,
-    this.bufferDisableSizeConstraints =
-        DefaultSettings.bufferDisableSizeConstraints,
-    this.bufferDurationSeconds = DefaultSettings.bufferDurationSeconds,
-    this.bufferSizeMegabytes = DefaultSettings.bufferSizeMegabytes,
-    required this.tabSortBy,
-    required this.tabSortOrder,
-    this.loopMode = DefaultSettings.loopMode,
-    this.playbackSpeed = DefaultSettings.playbackSpeed,
-    this.tabOrder = DefaultSettings.tabOrder,
-    this.autoloadLastQueueOnStartup =
-        DefaultSettings.autoLoadLastQueueOnStartup,
-    this.hasCompletedDownloadsServiceMigration =
-        true, //!!! don't touch this default value, it's supposed to be hard coded to run the migration only once
-    this.requireWifiForDownloads = DefaultSettings.requireWifiForDownloads,
-    this.onlyShowFullyDownloaded = DefaultSettings.onlyShowFullyDownloaded,
-    this.showDownloadsWithUnknownLibrary =
-        DefaultSettings.showDownloadsWithUnknownLibrary,
-    this.maxConcurrentDownloads = DefaultSettings.maxConcurrentDownloads,
-    this.downloadWorkers = DefaultSettings.downloadWorkers,
-    this.resyncOnStartup = DefaultSettings.resyncOnStartup,
-    this.preferQuickSyncs = DefaultSettings.preferQuickSyncs,
-    this.hasCompletedIsarUserMigration =
-        true, //!!! don't touch this default value, it's supposed to be hard coded to run the migration only once
-    this.downloadTranscodingCodec,
-    this.downloadTranscodeBitrate,
-    this.shouldTranscodeDownloads = DefaultSettings.shouldTranscodeDownloads,
-    this.shouldRedownloadTranscodes =
-        DefaultSettings.shouldRedownloadTranscodes,
-    this.swipeInsertQueueNext = DefaultSettings.swipeInsertQueueNext,
-    this.useFixedSizeGridTiles = DefaultSettings.useFixedSizeGridTiles,
-    this.fixedGridTileSize = DefaultSettings.fixedGridTileSize,
-    this.allowSplitScreen = DefaultSettings.allowSplitScreen,
-    this.splitScreenPlayerWidth = DefaultSettings.splitScreenPlayerWidth,
-    this.enableVibration = DefaultSettings.enableVibration,
-    this.prioritizeCoverFactor = DefaultSettings.prioritizeCoverFactor,
-    this.suppressPlayerPadding = DefaultSettings.suppressPlayerPadding,
-    this.hidePlayerBottomActions = DefaultSettings.hidePlayerBottomActions,
-    this.reportQueueToServer = DefaultSettings.reportQueueToServer,
-    this.periodicPlaybackSessionUpdateFrequencySeconds =
-        DefaultSettings.periodicPlaybackSessionUpdateFrequencySeconds,
-    this.showArtistChipImage = DefaultSettings.showArtistChipImage,
-    this.trackOfflineFavorites = DefaultSettings.trackOfflineFavorites,
-    this.showProgressOnNowPlayingBar =
-        DefaultSettings.showProgressOnNowPlayingBar,
-    this.startInstantMixForIndividualTracks =
-        DefaultSettings.startInstantMixForIndividualTracks,
-    this.showLyricsTimestamps = DefaultSettings.showLyricsTimestamps,
-    this.lyricsAlignment = DefaultSettings.lyricsAlignment,
-    this.lyricsFontSize = DefaultSettings.lyricsFontSize,
-    this.showLyricsScreenAlbumPrelude =
-        DefaultSettings.showLyricsScreenAlbumPrelude,
-    this.showStopButtonOnMediaNotification =
-        DefaultSettings.showStopButtonOnMediaNotification,
-    this.showSeekControlsOnMediaNotification =
-        DefaultSettings.showSeekControlsOnMediaNotification,
-    this.keepScreenOnOption = DefaultSettings.keepScreenOnOption,
-    this.keepScreenOnWhilePluggedIn =
-        DefaultSettings.keepScreenOnWhilePluggedIn,
-    this.featureChipsConfiguration = DefaultSettings.featureChipsConfiguration,
-    this.showCoversOnAlbumScreen = DefaultSettings.showCoversOnAlbumScreen,
-    this.hasDownloadedPlaylistInfo = DefaultSettings.hasDownloadedPlaylistInfo,
-    this.transcodingSegmentContainer =
-        DefaultSettings.transcodingSegmentContainer,
-    this.downloadSizeWarningCutoff = DefaultSettings.downloadSizeWarningCutoff,
-    this.allowDeleteFromServer = DefaultSettings.allowDeleteFromServer,
-    this.oneLineMarqueeTextButton = DefaultSettings.oneLineMarqueeTextButton,
-    this.showAlbumReleaseDateOnPlayerScreen =
-        DefaultSettings.showAlbumReleaseDateOnPlayerScreen,
-    this.releaseDateFormat = DefaultSettings.releaseDateFormat,
-  });
+  FinampSettings(
+      {this.isOffline = DefaultSettings.isOffline,
+      this.shouldTranscode = DefaultSettings.shouldTranscode,
+      this.transcodeBitrate = DefaultSettings.transcodeBitrate,
+      // downloadLocations is required since the other values can be created with
+      // default values. create() is used to return a FinampSettings with
+      // downloadLocations.
+      required this.downloadLocations,
+      this.androidStopForegroundOnPause =
+          DefaultSettings.androidStopForegroundOnPause,
+      required this.showTabs,
+      this.onlyShowFavourites = DefaultSettings.onlyShowFavourites,
+      this.sortBy = SortBy.sortName,
+      this.sortOrder = SortOrder.ascending,
+      this.trackShuffleItemCount = DefaultSettings.trackShuffleItemCount,
+      this.volumeNormalizationActive =
+          DefaultSettings.volumeNormalizationActive,
+      this.volumeNormalizationIOSBaseGain =
+          DefaultSettings.volumeNormalizationIOSBaseGain,
+      this.volumeNormalizationMode = DefaultSettings.volumeNormalizationMode,
+      this.contentViewType = DefaultSettings.contentViewType,
+      this.playbackSpeedVisibility = DefaultSettings.playbackSpeedVisibility,
+      this.contentGridViewCrossAxisCountPortrait =
+          DefaultSettings.contentGridViewCrossAxisCountPortrait,
+      this.contentGridViewCrossAxisCountLandscape =
+          DefaultSettings.contentGridViewCrossAxisCountLandscape,
+      this.showTextOnGridView = DefaultSettings.showTextOnGridView,
+      this.sleepTimerSeconds = DefaultSettings.sleepTimerSeconds,
+      required this.downloadLocationsMap,
+      this.useCoverAsBackground = DefaultSettings.useCoverAsBackground,
+      this.playerScreenCoverMinimumPadding =
+          DefaultSettings.playerScreenCoverMinimumPadding,
+      this.showArtistsTopTracks = DefaultSettings.showArtistsTopTracks,
+      this.bufferDisableSizeConstraints =
+          DefaultSettings.bufferDisableSizeConstraints,
+      this.bufferDurationSeconds = DefaultSettings.bufferDurationSeconds,
+      this.bufferSizeMegabytes = DefaultSettings.bufferSizeMegabytes,
+      required this.tabSortBy,
+      required this.tabSortOrder,
+      this.loopMode = DefaultSettings.loopMode,
+      this.playbackSpeed = DefaultSettings.playbackSpeed,
+      this.tabOrder = DefaultSettings.tabOrder,
+      this.autoloadLastQueueOnStartup =
+          DefaultSettings.autoLoadLastQueueOnStartup,
+      this.hasCompletedDownloadsServiceMigration =
+          true, //!!! don't touch this default value, it's supposed to be hard coded to run the migration only once
+      this.requireWifiForDownloads = DefaultSettings.requireWifiForDownloads,
+      this.onlyShowFullyDownloaded = DefaultSettings.onlyShowFullyDownloaded,
+      this.showDownloadsWithUnknownLibrary =
+          DefaultSettings.showDownloadsWithUnknownLibrary,
+      this.maxConcurrentDownloads = DefaultSettings.maxConcurrentDownloads,
+      this.downloadWorkers = DefaultSettings.downloadWorkers,
+      this.resyncOnStartup = DefaultSettings.resyncOnStartup,
+      this.preferQuickSyncs = DefaultSettings.preferQuickSyncs,
+      this.hasCompletedIsarUserMigration =
+          true, //!!! don't touch this default value, it's supposed to be hard coded to run the migration only once
+      this.downloadTranscodingCodec,
+      this.downloadTranscodeBitrate,
+      this.shouldTranscodeDownloads = DefaultSettings.shouldTranscodeDownloads,
+      this.shouldRedownloadTranscodes =
+          DefaultSettings.shouldRedownloadTranscodes,
+      this.swipeInsertQueueNext = DefaultSettings.swipeInsertQueueNext,
+      this.useFixedSizeGridTiles = DefaultSettings.useFixedSizeGridTiles,
+      this.fixedGridTileSize = DefaultSettings.fixedGridTileSize,
+      this.allowSplitScreen = DefaultSettings.allowSplitScreen,
+      this.splitScreenPlayerWidth = DefaultSettings.splitScreenPlayerWidth,
+      this.enableVibration = DefaultSettings.enableVibration,
+      this.prioritizeCoverFactor = DefaultSettings.prioritizeCoverFactor,
+      this.suppressPlayerPadding = DefaultSettings.suppressPlayerPadding,
+      this.hidePlayerBottomActions = DefaultSettings.hidePlayerBottomActions,
+      this.reportQueueToServer = DefaultSettings.reportQueueToServer,
+      this.periodicPlaybackSessionUpdateFrequencySeconds =
+          DefaultSettings.periodicPlaybackSessionUpdateFrequencySeconds,
+      this.showArtistChipImage = DefaultSettings.showArtistChipImage,
+      this.trackOfflineFavorites = DefaultSettings.trackOfflineFavorites,
+      this.showProgressOnNowPlayingBar =
+          DefaultSettings.showProgressOnNowPlayingBar,
+      this.startInstantMixForIndividualTracks =
+          DefaultSettings.startInstantMixForIndividualTracks,
+      this.showLyricsTimestamps = DefaultSettings.showLyricsTimestamps,
+      this.lyricsAlignment = DefaultSettings.lyricsAlignment,
+      this.lyricsFontSize = DefaultSettings.lyricsFontSize,
+      this.showLyricsScreenAlbumPrelude =
+          DefaultSettings.showLyricsScreenAlbumPrelude,
+      this.showStopButtonOnMediaNotification =
+          DefaultSettings.showStopButtonOnMediaNotification,
+      this.showSeekControlsOnMediaNotification =
+          DefaultSettings.showSeekControlsOnMediaNotification,
+      this.keepScreenOnOption = DefaultSettings.keepScreenOnOption,
+      this.keepScreenOnWhilePluggedIn =
+          DefaultSettings.keepScreenOnWhilePluggedIn,
+      this.featureChipsConfiguration =
+          DefaultSettings.featureChipsConfiguration,
+      this.showCoversOnAlbumScreen = DefaultSettings.showCoversOnAlbumScreen,
+      this.hasDownloadedPlaylistInfo =
+          DefaultSettings.hasDownloadedPlaylistInfo,
+      this.transcodingSegmentContainer =
+          DefaultSettings.transcodingSegmentContainer,
+      this.downloadSizeWarningCutoff =
+          DefaultSettings.downloadSizeWarningCutoff,
+      this.allowDeleteFromServer = DefaultSettings.allowDeleteFromServer,
+      this.oneLineMarqueeTextButton = DefaultSettings.oneLineMarqueeTextButton,
+      this.showAlbumReleaseDateOnPlayerScreen =
+          DefaultSettings.showAlbumReleaseDateOnPlayerScreen,
+      this.releaseDateFormat = DefaultSettings.releaseDateFormat,
+      this.audioFadeOutDuration = DefaultSettings.audioFadeOutDuration,
+      this.audioFadeInDuration = DefaultSettings.audioFadeInDuration});
 
   @HiveField(0, defaultValue: DefaultSettings.isOffline)
   bool isOffline;
@@ -536,6 +543,12 @@ class FinampSettings {
   @HiveField(85, defaultValue: null)
   String? lastUsedDownloadLocationId;
   
+  @HiveField(86, defaultValue: DefaultSettings.audioFadeOutDuration)
+  Duration audioFadeOutDuration;
+
+  @HiveField(87, defaultValue: DefaultSettings.audioFadeInDuration)
+  Duration audioFadeInDuration;
+
   static Future<FinampSettings> create() async {
     final downloadLocation = await DownloadLocation.create(
       name: DownloadLocation.internalStorageName,

--- a/lib/models/finamp_models.g.dart
+++ b/lib/models/finamp_models.g.dart
@@ -210,6 +210,10 @@ class FinampSettingsAdapter extends TypeAdapter<FinampSettings> {
       releaseDateFormat: fields[84] == null
           ? ReleaseDateFormat.year
           : fields[84] as ReleaseDateFormat,
+      audioFadeOutDuration:
+          fields[86] == null ? Duration.zero : fields[86] as Duration,
+      audioFadeInDuration:
+          fields[87] == null ? Duration.zero : fields[87] as Duration,
     )
       ..disableGesture = fields[19] == null ? false : fields[19] as bool
       ..showFastScroller = fields[25] == null ? true : fields[25] as bool
@@ -220,7 +224,7 @@ class FinampSettingsAdapter extends TypeAdapter<FinampSettings> {
   @override
   void write(BinaryWriter writer, FinampSettings obj) {
     writer
-      ..writeByte(81)
+      ..writeByte(83)
       ..writeByte(0)
       ..write(obj.isOffline)
       ..writeByte(1)
@@ -382,7 +386,11 @@ class FinampSettingsAdapter extends TypeAdapter<FinampSettings> {
       ..writeByte(84)
       ..write(obj.releaseDateFormat)
       ..writeByte(85)
-      ..write(obj.lastUsedDownloadLocationId);
+      ..write(obj.lastUsedDownloadLocationId)
+      ..writeByte(86)
+      ..write(obj.audioFadeOutDuration)
+      ..writeByte(87)
+      ..write(obj.audioFadeInDuration);
   }
 
   @override

--- a/lib/screens/audio_service_settings_screen.dart
+++ b/lib/screens/audio_service_settings_screen.dart
@@ -153,7 +153,7 @@ class _AudioFadeInDurationListTileState
             final valueInt = int.tryParse(value);
 
             if (valueInt != null && !valueInt.isNegative) {
-              FinampSettingsHelper.setAudioFadeInDuration(
+              FinampSetters.setAudioFadeInDuration(
                   Duration(milliseconds: valueInt));
             }
           },
@@ -195,7 +195,7 @@ class _AudioFadeOutDurationListTileState
             final valueInt = int.tryParse(value);
 
             if (valueInt != null && !valueInt.isNegative) {
-              FinampSettingsHelper.setAudioFadeOutDuration(
+              FinampSetters.setAudioFadeOutDuration(
                   Duration(milliseconds: valueInt));
             }
           },

--- a/lib/screens/audio_service_settings_screen.dart
+++ b/lib/screens/audio_service_settings_screen.dart
@@ -46,6 +46,8 @@ class _AudioServiceSettingsScreenState
         children: [
           if (Platform.isAndroid) StopForegroundSelector(key: _updateChildren),
           TrackShuffleItemCountEditor(key: _updateChildren),
+          AudioFadeInDurationListTile(key: _updateChildren),
+          AudioFadeOutDurationListTile(key: _updateChildren),
           if (Platform.isAndroid) BufferSizeListTile(key: _updateChildren),
           BufferDurationListTile(key: _updateChildren),
           BufferDisableSizeConstraintsSelector(key: _updateChildren),
@@ -111,6 +113,90 @@ class _BufferSizeListTileState extends State<BufferSizeListTile> {
                 valueInt = 60;
               }
               FinampSetters.setBufferSizeMegabytes(valueInt);
+            }
+          },
+        ),
+      ),
+    );
+  }
+}
+
+class AudioFadeInDurationListTile extends StatefulWidget {
+  const AudioFadeInDurationListTile({super.key});
+
+  @override
+  State<AudioFadeInDurationListTile> createState() =>
+      _AudioFadeInDurationListTileState();
+}
+
+class _AudioFadeInDurationListTileState
+    extends State<AudioFadeInDurationListTile> {
+  final _controller = TextEditingController(
+      text: FinampSettingsHelper
+          .finampSettings.audioFadeInDuration.inMilliseconds
+          .toString());
+
+  @override
+  Widget build(BuildContext context) {
+    return ListTile(
+      title:
+          Text(AppLocalizations.of(context)!.audioFadeInDurationSettingTitle),
+      subtitle: Text(
+          AppLocalizations.of(context)!.audioFadeInDurationSettingSubtitle),
+      trailing: SizedBox(
+        width: 50 * MediaQuery.of(context).textScaleFactor,
+        child: TextField(
+          controller: _controller,
+          textAlign: TextAlign.center,
+          keyboardType: TextInputType.number,
+          onChanged: (value) {
+            final valueInt = int.tryParse(value);
+
+            if (valueInt != null && !valueInt.isNegative) {
+              FinampSettingsHelper.setAudioFadeInDuration(
+                  Duration(milliseconds: valueInt));
+            }
+          },
+        ),
+      ),
+    );
+  }
+}
+
+class AudioFadeOutDurationListTile extends StatefulWidget {
+  const AudioFadeOutDurationListTile({super.key});
+
+  @override
+  State<AudioFadeOutDurationListTile> createState() =>
+      _AudioFadeOutDurationListTileState();
+}
+
+class _AudioFadeOutDurationListTileState
+    extends State<AudioFadeOutDurationListTile> {
+  final _controller = TextEditingController(
+      text: FinampSettingsHelper
+          .finampSettings.audioFadeOutDuration.inMilliseconds
+          .toString());
+
+  @override
+  Widget build(BuildContext context) {
+    return ListTile(
+      title:
+          Text(AppLocalizations.of(context)!.audioFadeOutDurationSettingTitle),
+      subtitle: Text(
+          AppLocalizations.of(context)!.audioFadeOutDurationSettingSubtitle),
+      trailing: SizedBox(
+        width: 50 * MediaQuery.of(context).textScaleFactor,
+        child: TextField(
+          controller: _controller,
+          textAlign: TextAlign.center,
+          keyboardType: TextInputType.number,
+          onChanged: (value) {
+            final valueInt = int.tryParse(value);
+
+            if (valueInt != null && !valueInt.isNegative) {
+              FinampSettingsHelper.setAudioFadeOutDuration(
+                  Duration(milliseconds: valueInt));
             }
           },
         ),

--- a/lib/services/finamp_settings_helper.dart
+++ b/lib/services/finamp_settings_helper.dart
@@ -222,6 +222,8 @@ class FinampSettingsHelper {
     FinampSetters.setPeriodicPlaybackSessionUpdateFrequencySeconds(DefaultSettings
         .periodicPlaybackSessionUpdateFrequencySeconds); // DOES NOT update UI
     FinampSetters.setReportQueueToServer(DefaultSettings.reportQueueToServer);
+    FinampSetters.setAudioFadeInDuration(DefaultSettings.audioFadeInDuration);
+    FinampSetters.setAudioFadeOutDuration(DefaultSettings.audioFadeOutDuration);
   }
 
   static void resetNormalizationSettings() {

--- a/lib/services/finamp_settings_helper.g.dart
+++ b/lib/services/finamp_settings_helper.g.dart
@@ -606,6 +606,20 @@ extension FinampSetters on FinampSettingsHelper {
         .put("FinampSettings", finampSettingsTemp);
   }
 
+  static void setAudioFadeOutDuration(Duration newAudioFadeOutDuration) {
+    FinampSettings finampSettingsTemp = FinampSettingsHelper.finampSettings;
+    finampSettingsTemp.audioFadeOutDuration = newAudioFadeOutDuration;
+    Hive.box<FinampSettings>("FinampSettings")
+        .put("FinampSettings", finampSettingsTemp);
+  }
+
+  static void setAudioFadeInDuration(Duration newAudioFadeInDuration) {
+    FinampSettings finampSettingsTemp = FinampSettingsHelper.finampSettings;
+    finampSettingsTemp.audioFadeInDuration = newAudioFadeInDuration;
+    Hive.box<FinampSettings>("FinampSettings")
+        .put("FinampSettings", finampSettingsTemp);
+  }
+
   static void setBufferDuration(Duration newBufferDuration) {
     FinampSettings finampSettingsTemp = FinampSettingsHelper.finampSettings;
     finampSettingsTemp.bufferDuration = newBufferDuration;
@@ -811,6 +825,11 @@ extension FinampSettingsProviderSelectors on StreamProvider<FinampSettings> {
   ProviderListenable<String?> get lastUsedDownloadLocationId =>
       finampSettingsProvider
           .select((value) => value.requireValue.lastUsedDownloadLocationId);
+  ProviderListenable<Duration> get audioFadeOutDuration =>
+      finampSettingsProvider
+          .select((value) => value.requireValue.audioFadeOutDuration);
+  ProviderListenable<Duration> get audioFadeInDuration => finampSettingsProvider
+      .select((value) => value.requireValue.audioFadeInDuration);
   ProviderListenable<DownloadProfile> get downloadTranscodingProfile =>
       finampSettingsProvider
           .select((value) => value.requireValue.downloadTranscodingProfile);

--- a/lib/services/media_state_stream.dart
+++ b/lib/services/media_state_stream.dart
@@ -7,16 +7,19 @@ import 'music_player_background_task.dart';
 class MediaState {
   final MediaItem? mediaItem;
   final PlaybackState playbackState;
+  final bool audioFading;
 
-  MediaState(this.mediaItem, this.playbackState);
+  MediaState(this.mediaItem, this.playbackState, this.audioFading);
 }
 
 /// A stream reporting the combined state of the current media item and its
 /// current position.
 Stream<MediaState> get mediaStateStream {
   final audioHandler = GetIt.instance<MusicPlayerBackgroundTask>();
-  return Rx.combineLatest2<MediaItem?, PlaybackState, MediaState>(
+  return Rx.combineLatest3<MediaItem?, PlaybackState, bool, MediaState>(
       audioHandler.mediaItem,
       audioHandler.playbackState,
-      (mediaItem, playbackState) => MediaState(mediaItem, playbackState));
+      audioHandler.fading,
+      (mediaItem, playbackState, fading) =>
+          MediaState(mediaItem, playbackState, fading));
 }

--- a/lib/services/media_state_stream.dart
+++ b/lib/services/media_state_stream.dart
@@ -7,19 +7,19 @@ import 'music_player_background_task.dart';
 class MediaState {
   final MediaItem? mediaItem;
   final PlaybackState playbackState;
-  final bool audioFading;
+  final FadeState fadeState;
 
-  MediaState(this.mediaItem, this.playbackState, this.audioFading);
+  MediaState(this.mediaItem, this.playbackState, this.fadeState);
 }
 
 /// A stream reporting the combined state of the current media item and its
 /// current position.
 Stream<MediaState> get mediaStateStream {
   final audioHandler = GetIt.instance<MusicPlayerBackgroundTask>();
-  return Rx.combineLatest3<MediaItem?, PlaybackState, bool, MediaState>(
+  return Rx.combineLatest3<MediaItem?, PlaybackState, FadeState, MediaState>(
       audioHandler.mediaItem,
       audioHandler.playbackState,
-      audioHandler.fading,
-      (mediaItem, playbackState, fading) =>
-          MediaState(mediaItem, playbackState, fading));
+      audioHandler.fadeState,
+      (mediaItem, playbackState, fadeState) =>
+          MediaState(mediaItem, playbackState, fadeState));
 }

--- a/lib/services/music_player_background_task.dart
+++ b/lib/services/music_player_background_task.dart
@@ -398,26 +398,22 @@ class MusicPlayerBackgroundTask extends BaseAudioHandler {
           await _player.setVolume(min(
               _player.volume + state.volumeFadeInStepSize,
               state.recoverVolume));
+          fadeState.add(state.copyWith(fadeVolume: _player.volume));
           if (_player.volume >= state.recoverVolume) {
-            fadeState.add(state.copyWith(
-                fadeDirection: FadeDirection.none, fadeVolume: _player.volume));
-          } else {
-            fadeState.add(state.copyWith(fadeVolume: _player.volume));
+            fadeState.add(state.copyWith(fadeDirection: FadeDirection.none));
           }
           break;
         case FadeDirection.fadeOut:
           await _player.setVolume(
               max(_player.volume - state.volumeFadeOutStepSize, 0.0));
+          fadeState.add(state.copyWith(fadeVolume: _player.volume));
           if (_player.volume <= 0.0) {
-            fadeState.add(state.copyWith(
-                fadeDirection: FadeDirection.none, fadeVolume: _player.volume));
+            fadeState.add(state.copyWith(fadeDirection: FadeDirection.none));
 
             fut = _player.pause();
 
             // restore volume
             await _player.setVolume(fadeState.value.recoverVolume);
-          } else {
-            fadeState.add(state.copyWith(fadeVolume: _player.volume));
           }
           break;
         default:

--- a/lib/services/music_player_background_task.dart
+++ b/lib/services/music_player_background_task.dart
@@ -2,7 +2,6 @@ import 'dart:async';
 import 'dart:convert';
 import 'dart:io';
 import 'dart:math';
-import 'dart:ui';
 
 import 'package:audio_service/audio_service.dart';
 import 'package:finamp/components/global_snackbar.dart';
@@ -12,6 +11,7 @@ import 'package:finamp/services/favorite_provider.dart';
 import 'package:finamp/services/jellyfin_api_helper.dart';
 import 'package:finamp/services/queue_service.dart';
 import 'package:flutter/foundation.dart';
+import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:finamp/l10n/app_localizations.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
@@ -24,6 +24,40 @@ import 'package:rxdart/rxdart.dart';
 import 'android_auto_helper.dart';
 import 'finamp_settings_helper.dart';
 import 'locale_helper.dart';
+
+enum FadeDirection { fadeIn, fadeOut, none }
+
+class FadeState {
+  // Volume value to recover after fading
+  final double recoverVolume;
+
+  // volume step sizes for fade-in and fade-out
+  final double volumeFadeOutStepSize;
+  final double volumeFadeInStepSize;
+
+  // current fade direction
+  final FadeDirection fadeDirection;
+
+  FadeState(
+      {required this.recoverVolume,
+      this.volumeFadeInStepSize = 0.0,
+      this.volumeFadeOutStepSize = 0.0,
+      this.fadeDirection = FadeDirection.none});
+
+  FadeState copyWith({
+    double? recoverVolume,
+    double? volumeFadeInStepSize,
+    double? volumeFadeOutStepSize,
+    FadeDirection? fadeDirection,
+  }) {
+    return FadeState(
+        recoverVolume: recoverVolume ?? this.recoverVolume,
+        volumeFadeInStepSize: volumeFadeInStepSize ?? this.volumeFadeInStepSize,
+        volumeFadeOutStepSize:
+            volumeFadeOutStepSize ?? this.volumeFadeOutStepSize,
+        fadeDirection: fadeDirection ?? this.fadeDirection);
+  }
+}
 
 /// This provider handles the currently playing music so that multiple widgets
 /// can control music.
@@ -65,7 +99,7 @@ class MusicPlayerBackgroundTask extends BaseAudioHandler {
   Duration minBufferDuration = Duration(seconds: 90);
 
   final _audioFadeStepDuration = Duration(milliseconds: 50);
-  BehaviorSubject<bool> fading = BehaviorSubject.seeded(false);
+  late final BehaviorSubject<FadeState> fadeState;
 
   final outputSwitcherChannel =
       MethodChannel('com.unicornsonlsd.finamp/output_switcher');
@@ -248,6 +282,9 @@ class MusicPlayerBackgroundTask extends BaseAudioHandler {
       final event = _transformEvent(_player.playbackEvent);
       playbackState.add(event);
     });
+
+    fadeState =
+        BehaviorSubject.seeded(FadeState(recoverVolume: _player.volume));
   }
 
   /// this could be useful for updating queue state from this player class, but isn't used right now due to limitations with just_audio
@@ -288,7 +325,7 @@ class MusicPlayerBackgroundTask extends BaseAudioHandler {
   Future<void> play() async {
     if (FinampSettingsHelper.finampSettings.audioFadeInDuration >
         Duration.zero) {
-      return fadeInAnPlay();
+      return fadeInAndPlay();
     } else {
       return _player.play();
     }
@@ -314,61 +351,97 @@ class MusicPlayerBackgroundTask extends BaseAudioHandler {
         .toInt();
   }
 
-  double getVolumeFadeInStepSize(double currentVolume) {
-    final duration = FinampSettingsHelper.finampSettings.audioFadeInDuration;
-    final steps = getFadeSteps(duration);
-    return currentVolume / steps;
+  double _getVolumeFadeInStepSize() {
+    final steps =
+        getFadeSteps(FinampSettingsHelper.finampSettings.audioFadeInDuration);
+    return fadeState.value.recoverVolume / steps;
   }
 
-  double getVolumeFadeOutStepSize(double currentVolume) {
-    final duration = FinampSettingsHelper.finampSettings.audioFadeOutDuration;
-    final steps = getFadeSteps(duration);
-    return currentVolume / steps;
+  double _getVolumeFadeOutStepSize() {
+    final steps =
+        getFadeSteps(FinampSettingsHelper.finampSettings.audioFadeOutDuration);
+    return fadeState.value.recoverVolume / steps;
+  }
+
+  Future<void> _fadeAudio(FadeDirection direction) async {
+    fadeState.add(FadeState(
+        recoverVolume: _player.volume,
+        volumeFadeInStepSize: _getVolumeFadeInStepSize(),
+        volumeFadeOutStepSize: _getVolumeFadeOutStepSize(),
+        fadeDirection: direction));
+
+    // Prepare fade-in
+    late Future fut;
+    if (direction == FadeDirection.fadeIn) {
+      await _player.setVolume(0.0);
+      fut = _player.play();
+    }
+
+    await Stream.periodic(
+            _audioFadeStepDuration, (_) => fadeState.value.fadeDirection)
+        .takeWhile((_) => fadeState.value.fadeDirection != FadeDirection.none)
+        .forEach((fadeDirection) async {
+      var state = fadeState.value;
+      switch (fadeDirection) {
+        case FadeDirection.fadeIn:
+          await _player.setVolume(min(
+              _player.volume + state.volumeFadeInStepSize,
+              state.recoverVolume));
+          if (_player.volume >= state.recoverVolume) {
+            fadeState.add(state.copyWith(fadeDirection: FadeDirection.none));
+          }
+          break;
+        case FadeDirection.fadeOut:
+          await _player.setVolume(
+              max(_player.volume - state.volumeFadeOutStepSize, 0.0));
+          if (_player.volume <= 0.0) {
+            fadeState.add(state.copyWith(fadeDirection: FadeDirection.none));
+
+            fut = _player.pause();
+
+            // restore volume
+            await _player.setVolume(fadeState.value.recoverVolume);
+          }
+          break;
+        default:
+          break;
+      }
+    });
+
+    return fut;
   }
 
   Future<void> fadeOutAndPause() async {
-    final currentVolume = _player.volume;
-
-    final volumeStep = getVolumeFadeOutStepSize(currentVolume);
-
-    fading.add(true);
-    var volume = currentVolume;
-    await Stream.periodic(_audioFadeStepDuration)
-        .takeWhile((_) => volume > 0.0)
-        .forEach((_) async {
-      volume = max(volume - volumeStep, 0.0);
-      await _player.setVolume(volume);
-    });
-
-    final pauseFut = _player.pause();
-    await _player.setVolume(currentVolume);
-    fading.add(false);
-    return pauseFut;
+    switch (fadeState.value.fadeDirection) {
+      case FadeDirection.fadeOut:
+        return;
+      case FadeDirection.fadeIn:
+        // change fade direction
+        fadeState.add(
+            fadeState.value.copyWith(fadeDirection: FadeDirection.fadeOut));
+        return;
+      case FadeDirection.none:
+        return _fadeAudio(FadeDirection.fadeOut);
+    }
   }
 
-  Future<void> fadeInAnPlay() async {
-    final currentVolume = _player.volume;
-
-    final volumeStep = getVolumeFadeInStepSize(currentVolume);
-
-    fading.add(true);
-    await _player.setVolume(0.0);
-    final playFut = _player.play();
-
-    var volume = _player.volume;
-    await Stream.periodic(_audioFadeStepDuration)
-        .takeWhile((_) => volume < currentVolume)
-        .forEach((_) async {
-      volume = min(volume + volumeStep, currentVolume);
-      await _player.setVolume(volume);
-    });
-    fading.add(false);
-
-    return playFut;
+  Future<void> fadeInAndPlay() async {
+    switch (fadeState.value.fadeDirection) {
+      case FadeDirection.fadeIn:
+        return;
+      case FadeDirection.fadeOut:
+        // change fade direction
+        fadeState
+            .add(fadeState.value.copyWith(fadeDirection: FadeDirection.fadeIn));
+        return;
+      case FadeDirection.none:
+        return _fadeAudio(FadeDirection.fadeIn);
+    }
   }
 
   Future<void> togglePlayback() {
-    if (_player.playing) {
+    if (_player.playing &&
+        fadeState.value.fadeDirection != FadeDirection.fadeOut) {
       return pause();
     } else {
       return play();

--- a/lib/services/music_player_background_task.dart
+++ b/lib/services/music_player_background_task.dart
@@ -332,7 +332,7 @@ class MusicPlayerBackgroundTask extends BaseAudioHandler {
   Future<void> dispose() => _player.dispose();
 
   @override
-  Future<void> play({disableFade = false}) async {
+  Future<void> play({bool disableFade = false}) async {
     if (!disableFade &&
         FinampSettingsHelper.finampSettings.audioFadeInDuration >
             Duration.zero) {
@@ -348,7 +348,7 @@ class MusicPlayerBackgroundTask extends BaseAudioHandler {
   }
 
   @override
-  Future<void> pause({disableFade = false}) async {
+  Future<void> pause({bool disableFade = false}) async {
     if (!disableFade &&
         FinampSettingsHelper.finampSettings.audioFadeOutDuration >
             Duration.zero) {
@@ -937,7 +937,7 @@ class MusicPlayerBackgroundTask extends BaseAudioHandler {
 
     _sleepTimer.value = Timer(duration, () async {
       _sleepTimer.value = null;
-      return await pause(disableFade: true);
+      return await pause(disableFade: false);
     });
     return _sleepTimer.value!;
   }

--- a/lib/services/music_player_background_task.dart
+++ b/lib/services/music_player_background_task.dart
@@ -332,9 +332,10 @@ class MusicPlayerBackgroundTask extends BaseAudioHandler {
   Future<void> dispose() => _player.dispose();
 
   @override
-  Future<void> play() async {
-    if (FinampSettingsHelper.finampSettings.audioFadeInDuration >
-        Duration.zero) {
+  Future<void> play({disableFade = false}) async {
+    if (!disableFade &&
+        FinampSettingsHelper.finampSettings.audioFadeInDuration >
+            Duration.zero) {
       return fadeInAndPlay();
     } else {
       return _player.play();
@@ -347,9 +348,10 @@ class MusicPlayerBackgroundTask extends BaseAudioHandler {
   }
 
   @override
-  Future<void> pause() async {
-    if (FinampSettingsHelper.finampSettings.audioFadeOutDuration >
-        Duration.zero) {
+  Future<void> pause({disableFade = false}) async {
+    if (!disableFade &&
+        FinampSettingsHelper.finampSettings.audioFadeOutDuration >
+            Duration.zero) {
       return fadeOutAndPause();
     } else {
       return _player.pause();
@@ -498,7 +500,7 @@ class MusicPlayerBackgroundTask extends BaseAudioHandler {
       _audioServiceBackgroundTaskLogger.info("Queue completed.");
       // A full stop will trigger a re-shuffle with an unshuffled first
       // item, so only pause.
-      await pause();
+      await pause(disableFade: true);
       // Skipping to zero with empty queue re-triggers queue complete event
       if (_player.effectiveIndices?.isNotEmpty ?? false) {
         await skipToIndex(0);
@@ -935,7 +937,7 @@ class MusicPlayerBackgroundTask extends BaseAudioHandler {
 
     _sleepTimer.value = Timer(duration, () async {
       _sleepTimer.value = null;
-      return await pause();
+      return await pause(disableFade: true);
     });
     return _sleepTimer.value!;
   }

--- a/lib/services/queue_service.dart
+++ b/lib/services/queue_service.dart
@@ -548,10 +548,10 @@ class QueueService {
       _queueFromConcatenatingAudioSource();
 
       if (beginPlaying) {
-        unawaited(_audioHandler
-            .play()); // don't await this, because it will not return until playback is finished
+        // don't await this, because it will not return until playback is finished
+        unawaited(_audioHandler.play(disableFade: true));
       } else {
-        unawaited(_audioHandler.pause());
+        unawaited(_audioHandler.pause(disableFade: true));
       }
 
       _audioHandler.nextInitialIndex = null;

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -1708,7 +1708,7 @@ packages:
     source: hosted
     version: "2.1.4"
   visibility_detector:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: visibility_detector
       sha256: dd5cc11e13494f432d15939c3aa8ae76844c42b723398643ce9addb88a5ed420

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -1181,6 +1181,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "6.0.1"
+  progress_border:
+    dependency: "direct main"
+    description:
+      name: progress_border
+      sha256: f47c2b951c29f04d7a2232d9f72210874df893ea45c7bd313076291d8c4d8a57
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.1.5"
   provider:
     dependency: "direct main"
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -109,6 +109,7 @@ dependencies:
   analyzer: ^6.0.0
   build: ^2.4.2
   source_gen: ^2.0.0
+  progress_border: ^0.1.5
 
 dev_dependencies:
   flutter_test:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -110,6 +110,7 @@ dependencies:
   build: ^2.4.2
   source_gen: ^2.0.0
   progress_border: ^0.1.5
+  visibility_detector: ^0.4.0+2
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
Hello, 
I tried implementing the feature requested in #799. I'm quite new to Flutter and Open Source so if there is anything I should improve just let me know :)
The huge diff in `finamp_models.dart` seems to be an issue with reformatting (?).
All in all this PR adds:

1. Fade-in setting, for fading in audio on resume. Fade-in is disabled by default by using a value of 0.
2. Fade-out setting, for fading out audio on pause. Fade-out is disabled by default by using a value of 0.

I could not figure out why, but on initial playback the fade-in does not seem to work, only on resume and pause.
I did not want to add too many new settings, thus the step size for fade-in and fade-out are hardcoded to 50ms for now.