### PR TITLE
[Redesign] Improve Queue Restore Speed

### DIFF
--- a/lib/components/QueueRestoreScreen/queue_restore_tile.dart
+++ b/lib/components/QueueRestoreScreen/queue_restore_tile.dart
@@ -75,12 +75,11 @@ class QueueRestoreTile extends StatelessWidget {
                     ])),
         trailing: IconButton(
             icon: const Icon(Icons.arrow_circle_right_outlined),
-            onPressed: () async {
-              await queueService.archiveSavedQueue();
+            onPressed: () {
+              queueService.archiveSavedQueue();
               unawaited(queueService
                   .loadSavedQueue(info)
                   .catchError(GlobalSnackbar.error));
-              if (!context.mounted) return;
               Navigator.of(context).popUntil(
                   (route) => route.isFirst && !route.willHandlePopInternally);
             }),

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -352,10 +352,16 @@ Future<void> _setupPlaybackServices() async {
   );
 
   GetIt.instance.registerSingleton<MusicPlayerBackgroundTask>(audioHandler);
-  GetIt.instance.registerSingleton(QueueService());
+  var queueService = QueueService();
+  GetIt.instance.registerSingleton(queueService);
   await GetIt.instance<QueueService>().initializePlayer();
   GetIt.instance.registerSingleton(PlaybackHistoryService());
   GetIt.instance.registerSingleton(AudioServiceHelper());
+
+  // Begin to restore queue
+  unawaited(queueService
+      .performInitialQueueLoad()
+      .catchError((x) => GlobalSnackbar.error(x)));
 }
 
 /// Migrates the old DownloadLocations list to a map

--- a/lib/screens/music_screen.dart
+++ b/lib/screens/music_screen.dart
@@ -2,7 +2,6 @@ import 'dart:async';
 import 'dart:io';
 
 import 'package:finamp/services/downloads_service.dart';
-import 'package:finamp/services/queue_service.dart';
 import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
@@ -27,7 +26,6 @@ final _musicScreenLogger = Logger("MusicScreen");
 
 void postLaunchHook(WidgetRef ref) async {
   final downloadsService = GetIt.instance<DownloadsService>();
-  final queueService = GetIt.instance<QueueService>();
 
   // make sure playlist info is downloaded for users upgrading from older versions and new installations AFTER logging in and selecting their libraries/views
   if (!FinampSettingsHelper.finampSettings.hasDownloadedPlaylistInfo) {
@@ -37,11 +35,6 @@ void postLaunchHook(WidgetRef ref) async {
     });
     FinampSettingsHelper.setHasDownloadedPlaylistInfo(true);
   }
-
-  // Restore queue
-  unawaited(queueService
-      .performInitialQueueLoad()
-      .catchError((x) => GlobalSnackbar.error(x)));
 }
 
 class MusicScreen extends ConsumerStatefulWidget {


### PR DESCRIPTION
Improves the delay between app startup and queue restore completion by moving the call slightly earlier in the boot sequence and skipping an uneeded wait for the saved queues to be committed to disk.  This allows reasonably sized queues to complete their server queries before the music screen queries start instead of after.