### PR TITLE
[Redesign] Fix missing internal downloads location

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -184,7 +184,7 @@ Future<void> _setupDownloadsHelper() async {
       _mainLog
           .info("Internal Storage download location is missing.  Recreating.");
       final downloadLocation = await DownloadLocation.create(
-          name: "Internal Storage",
+          name: DownloadLocation.internalStorageName,
           baseDirectory: DownloadLocationType.platformDefaultDirectory);
       FinampSettingsHelper.addDownloadLocation(downloadLocation);
       // There may be old downloads present due to skipping the migration

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -77,33 +77,34 @@ import 'services/music_player_background_task.dart';
 import 'services/theme_mode_helper.dart';
 import 'setup_logging.dart';
 
+final _mainLog = Logger("Main()");
+
 void main() async {
   // If the app has failed, this is set to true. If true, we don't attempt to run the main app since the error app has started.
   bool hasFailed = false;
-  final mainLog = Logger("Main()");
   try {
     await setupLogging();
     await _setupEdgeToEdgeOverlayStyle();
-    mainLog.info("Setup edge-to-edge overlay");
+    _mainLog.info("Setup edge-to-edge overlay");
     await setupHive();
-    mainLog.info("Setup hive and isar");
+    _mainLog.info("Setup hive and isar");
     _migrateDownloadLocations();
     _migrateSortOptions();
-    mainLog.info("Completed applicable migrations");
+    _mainLog.info("Completed applicable migrations");
     await _setupFinampUserHelper();
-    mainLog.info("Setup user helper");
+    _mainLog.info("Setup user helper");
     await _setupJellyfinApiData();
-    mainLog.info("setup jellyfin api");
+    _mainLog.info("setup jellyfin api");
     _setupOfflineListenLogHelper();
-    mainLog.info("Setup offline listen tracking");
+    _mainLog.info("Setup offline listen tracking");
     await _setupDownloadsHelper();
-    mainLog.info("Setup downloads service");
+    _mainLog.info("Setup downloads service");
     await _setupOSIntegration();
-    mainLog.info("Setup os integrations");
+    _mainLog.info("Setup os integrations");
     await _setupPlaybackServices();
-    mainLog.info("Setup audio player");
+    _mainLog.info("Setup audio player");
     await _setupKeepScreenOnHelper();
-    mainLog.info("Setup KeepScreenOnHelper");
+    _mainLog.info("Setup KeepScreenOnHelper");
   } catch (error, trace) {
     hasFailed = true;
     Logger("ErrorApp").severe(error, null, trace);
@@ -127,7 +128,7 @@ void main() async {
     await findSystemLocale();
     await initializeDateFormatting();
 
-    mainLog.info("Launching main app");
+    _mainLog.info("Launching main app");
 
     runApp(const Finamp());
   }
@@ -172,6 +173,26 @@ Future<void> _setupDownloadsHelper() async {
       .finampSettings.hasCompletedDownloadsServiceMigration) {
     await downloadsService.migrateFromHive();
     FinampSetters.setHasCompletedDownloadsServiceMigration(true);
+  } else {
+    // Some users may have missed migration due to a bug in the flag setting and
+    // are therefore missing an internal directory
+    if (FinampSettingsHelper.finampSettings.downloadLocationsMap.values
+        .where((element) =>
+            element.baseDirectory ==
+            DownloadLocationType.platformDefaultDirectory)
+        .isEmpty) {
+      _mainLog
+          .info("Internal Storage download location is missing.  Recreating.");
+      final downloadLocation = await DownloadLocation.create(
+          name: "Internal Storage",
+          baseDirectory: DownloadLocationType.platformDefaultDirectory);
+      FinampSettingsHelper.addDownloadLocation(downloadLocation);
+      // There may be old downloads present due to skipping the migration
+      // Run a repair to make sure they all get cleaned up.
+      unawaited(downloadsService
+          .repairAllDownloads()
+          .then((value) => null, onError: GlobalSnackbar.error));
+    }
   }
 
   await FileDownloader()

--- a/lib/models/finamp_models.dart
+++ b/lib/models/finamp_models.dart
@@ -319,7 +319,7 @@ class FinampSettings {
   @HiveField(14, defaultValue: DefaultSettings.sleepTimerSeconds)
   int sleepTimerSeconds;
 
-  @HiveField(15, defaultValue: {})
+  @HiveField(15, defaultValue: <String, DownloadLocation>{})
   @FinampSetterIgnore()
   Map<String, DownloadLocation> downloadLocationsMap;
 
@@ -333,11 +333,11 @@ class FinampSettings {
   @HiveField(19, defaultValue: DefaultSettings.disableGesture)
   bool disableGesture = DefaultSettings.disableGesture;
 
-  @HiveField(20, defaultValue: {})
+  @HiveField(20, defaultValue: <TabContentType, SortBy>{})
   @FinampSetterIgnore()
   Map<TabContentType, SortBy> tabSortBy;
 
-  @HiveField(21, defaultValue: {})
+  @HiveField(21, defaultValue: <TabContentType, SortOrder>{})
   @FinampSetterIgnore()
   Map<TabContentType, SortOrder> tabSortOrder;
 
@@ -596,8 +596,10 @@ class DownloadLocation {
       required this.baseDirectory}) {
     assert(baseDirectory.needsPath == (relativePath != null));
     assert(baseDirectory == DownloadLocationType.migrated ||
+        // ignore: deprecated_member_use_from_same_package
         (legacyUseHumanReadableNames == null && legacyDeletable == null));
     assert(baseDirectory != DownloadLocationType.migrated ||
+        // ignore: deprecated_member_use_from_same_package
         (legacyUseHumanReadableNames != null && legacyDeletable != null));
   }
 
@@ -643,16 +645,20 @@ class DownloadLocation {
   /// every time the app starts up.
   Future<void> updateCurrentPath() async {
     if (baseDirectory == DownloadLocationType.migrated) {
+      // ignore: deprecated_member_use_from_same_package
       if (!legacyDeletable!) {
         baseDirectory = DownloadLocationType.internalDocuments;
         relativePath = null;
         name = "Legacy Internal Storage";
+        // ignore: deprecated_member_use_from_same_package
       } else if (!legacyUseHumanReadableNames!) {
         baseDirectory = DownloadLocationType.external;
       } else {
         baseDirectory = DownloadLocationType.custom;
       }
+      // ignore: deprecated_member_use_from_same_package
       legacyDeletable = null;
+      // ignore: deprecated_member_use_from_same_package
       legacyUseHumanReadableNames = null;
     }
     switch (baseDirectory) {

--- a/lib/models/finamp_models.dart
+++ b/lib/models/finamp_models.dart
@@ -537,9 +537,7 @@ class FinampSettings {
     final downloadLocation = await DownloadLocation.create(
       name: "Internal Storage",
       // default download location moved to support dir based on existing comment
-      baseDirectory: (Platform.isIOS || Platform.isAndroid)
-          ? DownloadLocationType.internalSupport
-          : DownloadLocationType.cache,
+      baseDirectory: DownloadLocationType.platformDefaultDirectory,
     );
     return FinampSettings(
       downloadLocations: [],
@@ -565,9 +563,7 @@ class FinampSettings {
   DownloadLocation get internalTrackDir =>
       downloadLocationsMap.values.firstWhere((element) =>
           element.baseDirectory ==
-          ((Platform.isIOS || Platform.isAndroid)
-              ? DownloadLocationType.internalSupport
-              : DownloadLocationType.cache));
+          DownloadLocationType.platformDefaultDirectory);
 
   Duration get bufferDuration => Duration(seconds: bufferDurationSeconds);
 
@@ -1994,6 +1990,11 @@ enum DownloadLocationType {
   final bool needsPath;
   final bool useHumanReadableNames;
   final BaseDirectory baseDirectory;
+
+  static DownloadLocationType get platformDefaultDirectory =>
+      (Platform.isIOS || Platform.isAndroid)
+          ? DownloadLocationType.internalSupport
+          : DownloadLocationType.cache;
 }
 
 @HiveType(typeId: 65)

--- a/lib/models/finamp_models.dart
+++ b/lib/models/finamp_models.dart
@@ -535,7 +535,7 @@ class FinampSettings {
 
   static Future<FinampSettings> create() async {
     final downloadLocation = await DownloadLocation.create(
-      name: "Internal Storage",
+      name: DownloadLocation.internalStorageName,
       // default download location moved to support dir based on existing comment
       baseDirectory: DownloadLocationType.platformDefaultDirectory,
     );
@@ -687,6 +687,8 @@ class DownloadLocation {
     await downloadLocation.updateCurrentPath();
     return downloadLocation;
   }
+
+  static const String internalStorageName = "Internal Storage";
 }
 
 /// Class used in AddDownloadLocationScreen. Basically just a DownloadLocation

--- a/lib/screens/view_selector.dart
+++ b/lib/screens/view_selector.dart
@@ -77,9 +77,9 @@ class _ViewSelectorState extends State<ViewSelector> {
                   _submitChoice();
                 } else {
                   if (mounted) {
-                    setState(() {
-                      isSubmitButtonEnabled = _views.values.contains(true);
-                    });
+                    Future.microtask(() => setState(() {
+                          isSubmitButtonEnabled = _views.values.contains(true);
+                        }));
                   }
                 }
               }
@@ -139,7 +139,6 @@ class _ViewSelectorState extends State<ViewSelector> {
                   )
                 ]),
               );
-              return const Center(child: Icon(Icons.error));
             } else {
               return const Center(child: CircularProgressIndicator.adaptive());
             }
@@ -158,7 +157,8 @@ class _ViewSelectorState extends State<ViewSelector> {
             .where((element) => element.value == true)
             .map((e) => e.key)
             .toList());
-        // allow navigation to music screen while selector is being built
+        // allow calling _submitChoice() while selector is being built by delaying
+        // navigation changes
         Future.microtask(() => Navigator.of(context)
             .pushNamedAndRemoveUntil(MusicScreen.routeName, (route) => false));
       } catch (e) {

--- a/lib/services/downloads_service.dart
+++ b/lib/services/downloads_service.dart
@@ -1050,8 +1050,11 @@ class DownloadsService {
       FinampSettingsHelper.addDownloadLocation(downloadLocation);
     }
     await Future.wait([
+      // ignore: deprecated_member_use_from_same_package
       Hive.openBox<DownloadedParent>("DownloadedParents"),
+      // ignore: deprecated_member_use_from_same_package
       Hive.openBox<DownloadedTrack>("DownloadedItems"),
+      // ignore: deprecated_member_use_from_same_package
       Hive.openBox<DownloadedImage>("DownloadedImages"),
     ]);
     _migrateImages();
@@ -1069,9 +1072,12 @@ class DownloadsService {
   /// Substep 1 of [migrateFromHive].
   void _migrateImages() {
     _downloadsLogger.info("Migrating images from Hive");
+    // ignore: deprecated_member_use_from_same_package
     final downloadedItemsBox = Hive.box<DownloadedTrack>("DownloadedItems");
     final downloadedParentsBox =
+        // ignore: deprecated_member_use_from_same_package
         Hive.box<DownloadedParent>("DownloadedParents");
+    // ignore: deprecated_member_use_from_same_package
     final downloadedImagesBox = Hive.box<DownloadedImage>("DownloadedImages");
 
     List<DownloadItem> nodes = [];
@@ -1121,6 +1127,7 @@ class DownloadsService {
   /// Substep 2 of [migrateFromHive].
   void _migrateTracks() {
     _downloadsLogger.info("Migrating tracks from Hive");
+    // ignore: deprecated_member_use_from_same_package
     final downloadedItemsBox = Hive.box<DownloadedTrack>("DownloadedItems");
 
     List<DownloadItem> nodes = [];
@@ -1194,7 +1201,9 @@ class DownloadsService {
   void _migrateParents() {
     _downloadsLogger.info("Migrating parents from Hive");
     final downloadedParentsBox =
+        // ignore: deprecated_member_use_from_same_package
         Hive.box<DownloadedParent>("DownloadedParents");
+    // ignore: deprecated_member_use_from_same_package
     final downloadedItemsBox = Hive.box<DownloadedTrack>("DownloadedItems");
 
     for (final parent in downloadedParentsBox.values) {
@@ -1334,14 +1343,14 @@ class DownloadsService {
           .thenByBaseIndexNumber()
           .thenByName()
           .findAll();
-      return items.map((e) => e.baseItem).whereNotNull().toList();
+      return items.map((e) => e.baseItem).nonNulls.toList();
     } else {
       List<DownloadItem> playlist = await query.findAll();
       Map<int, DownloadItem> childMap =
           Map.fromIterable(playlist, key: (e) => (e as DownloadItem).isarId);
       return canonItem!.orderedChildren!
           .map((e) => childMap[e]?.baseItem)
-          .whereNotNull()
+          .nonNulls
           .toList();
     }
   }

--- a/lib/services/downloads_service.dart
+++ b/lib/services/downloads_service.dart
@@ -391,7 +391,7 @@ class DownloadsService {
     await downloadTaskQueue.initializeQueue();
 
     // Wait a few seconds to not slow initial library load
-    unawaited(Future.delayed(const Duration(seconds: 5), () async {
+    unawaited(Future.delayed(const Duration(seconds: 10), () async {
       try {
         await syncBuffer.executeSyncs();
         await deleteBuffer.executeDeletes();
@@ -1041,12 +1041,12 @@ class DownloadsService {
   Future<void> migrateFromHive() async {
     if (FinampSettingsHelper.finampSettings.downloadLocationsMap.values
         .where((element) =>
-            element.baseDirectory == DownloadLocationType.internalSupport)
+            element.baseDirectory ==
+            DownloadLocationType.platformDefaultDirectory)
         .isEmpty) {
       final downloadLocation = await DownloadLocation.create(
-        name: "Internal Storage",
-        baseDirectory: DownloadLocationType.internalSupport,
-      );
+          name: "Internal Storage",
+          baseDirectory: DownloadLocationType.platformDefaultDirectory);
       FinampSettingsHelper.addDownloadLocation(downloadLocation);
     }
     await Future.wait([

--- a/lib/services/downloads_service.dart
+++ b/lib/services/downloads_service.dart
@@ -1045,7 +1045,7 @@ class DownloadsService {
             DownloadLocationType.platformDefaultDirectory)
         .isEmpty) {
       final downloadLocation = await DownloadLocation.create(
-          name: "Internal Storage",
+          name: DownloadLocation.internalStorageName,
           baseDirectory: DownloadLocationType.platformDefaultDirectory);
       FinampSettingsHelper.addDownloadLocation(downloadLocation);
     }


### PR DESCRIPTION
Due to the errors with setting the migration flags, some users are coming from existing installs but skipping the downloads migration, resulting in the new internal downloads storage location never being created.  This will recreate it for those cases, fixing the issue where users don't have any available download locations.  I considered running the full migration, but I'm pretty sure that would just break things if done after the new download system has potentially already had other changes committed.