### PR TITLE
Remove blank space when 'show album before lyrics' is disabled

### DIFF
--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -1713,7 +1713,7 @@
   "@lyricsFontSizeSubtitle": {
     "description": "Subtitle for the setting that controls the font size of lyrics in the lyrics view"
   },
-  "showLyricsScreenAlbumPreludeTitle": "Show album before lyrics",
+  "showLyricsScreenAlbumPreludeTitle": "Show album cover before lyrics",
   "@showLyricsScreenAlbumPreludeTitle": {
     "description": "Title for the setting that controls if the album cover is shown before the lyrics in the lyrics view"
   },

--- a/lib/screens/lyrics_screen.dart
+++ b/lib/screens/lyrics_screen.dart
@@ -235,7 +235,9 @@ class _LyricsViewState extends ConsumerState<LyricsView>
                   constraints: BoxConstraints(
                     maxHeight: constraints.maxHeight - 180,
                   ),
-                  child: const PlayerScreenAlbumImage()),
+                  child: (finampSettings?.showLyricsScreenAlbumPrelude ?? true)
+                      ? const PlayerScreenAlbumImage()
+                      : SizedBox()),
               const SizedBox(height: 24),
               Icon(
                 icon,
@@ -354,20 +356,20 @@ class _LyricsViewState extends ConsumerState<LyricsView>
                         if (index == 0)
                           AutoScrollTag(
                             key: const ValueKey(-1),
-                            controller: autoScrollController,
-                            index: -1,
-                            child: SizedBox(
-                              height: constraints.maxHeight * 0.65,
-                              child: Center(
-                                  child: SizedBox(
-                                      height: constraints.maxHeight * 0.55,
-                                      child: (finampSettings
-                                                  ?.showLyricsScreenAlbumPrelude ??
-                                              true)
-                                          ? const PlayerScreenAlbumImage()
-                                          : null)),
-                            ),
-                          ),
+                              controller: autoScrollController,
+                              index: -1,
+                              child: (finampSettings
+                                          ?.showLyricsScreenAlbumPrelude ??
+                                      true)
+                                  ? SizedBox(
+                                      height: constraints.maxHeight * 0.65,
+                                      child: Center(
+                                          child: SizedBox(
+                                        height: constraints.maxHeight * 0.55,
+                                        child: const PlayerScreenAlbumImage(),
+                                      )),
+                                    )
+                                  : Text("\n")),                           
                         AutoScrollTag(
                           key: ValueKey(index),
                           controller: autoScrollController,

--- a/lib/screens/lyrics_screen.dart
+++ b/lib/screens/lyrics_screen.dart
@@ -369,7 +369,9 @@ class _LyricsViewState extends ConsumerState<LyricsView>
                                         child: const PlayerScreenAlbumImage(),
                                       )),
                                     )
-                                  : Text("\n")),                           
+                                  : SizedBox(
+                                    height: MediaQuery.of(context).size.height * 0.05,
+                                  )),                           
                         AutoScrollTag(
                           key: ValueKey(index),
                           controller: autoScrollController,

--- a/lib/screens/lyrics_screen.dart
+++ b/lib/screens/lyrics_screen.dart
@@ -370,7 +370,7 @@ class _LyricsViewState extends ConsumerState<LyricsView>
                                       )),
                                     )
                                   : SizedBox(
-                                    height: MediaQuery.of(context).size.height * 0.05,
+                                    height: constraints.maxHeight * 0.2,
                                   )),                           
                         AutoScrollTag(
                           key: ValueKey(index),


### PR DESCRIPTION
When the 'Show album before lyrics' setting in the Layout & Theme lyrics view tab is ~~enabled~~ disabled, the album cover is hidden, resulting in a blank space being left behind. Now the lyrics start at the top of the screen. 

Before:
![image](https://github.com/user-attachments/assets/4346494c-b9a1-4e51-8f3b-d83c0696331e)

After:
![image](https://github.com/user-attachments/assets/2d712e95-ddd8-47b2-886b-b532655d48c3)

I also removed the album cover when no lyrics are available becuase I think it makes a bit more scenes:
![image](https://github.com/user-attachments/assets/57b1c147-ef5b-45a1-b4ec-b6c65dd47ca9)

