### PR TITLE
Allow clearing the queue from within the queue

### DIFF
--- a/lib/components/AlbumScreen/track_menu.dart
+++ b/lib/components/AlbumScreen/track_menu.dart
@@ -7,6 +7,7 @@ import 'package:finamp/components/PlayerScreen/sleep_timer_cancel_dialog.dart';
 import 'package:finamp/components/PlayerScreen/sleep_timer_dialog.dart';
 import 'package:finamp/components/delete_prompts.dart';
 import 'package:finamp/components/themed_bottom_sheet.dart';
+import 'package:finamp/l10n/app_localizations.dart';
 import 'package:finamp/models/finamp_models.dart';
 import 'package:finamp/screens/artist_screen.dart';
 import 'package:finamp/services/current_track_metadata_provider.dart';
@@ -15,7 +16,6 @@ import 'package:finamp/services/metadata_provider.dart';
 import 'package:finamp/services/music_player_background_task.dart';
 import 'package:finamp/services/queue_service.dart';
 import 'package:flutter/material.dart';
-import 'package:finamp/l10n/app_localizations.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_tabler_icons/flutter_tabler_icons.dart';
 import 'package:get_it/get_it.dart';
@@ -48,6 +48,7 @@ Future<void> showModalTrackMenu({
   BaseItemDto? parentItem,
   Function? onRemoveFromList,
   bool confirmPlaylistRemoval = true,
+  bool showClearQueue = false,
 }) async {
   final isOffline = FinampSettingsHelper.finampSettings.isOffline;
   final canGoToAlbum = item.parentId != null;
@@ -71,6 +72,7 @@ Future<void> showModalTrackMenu({
           canGoToGenre: canGoToGenre,
           onRemoveFromList: onRemoveFromList,
           confirmPlaylistRemoval: confirmPlaylistRemoval,
+          showClearQueue: showClearQueue,
           childBuilder: childBuilder,
           dragController: dragController,
         );
@@ -91,6 +93,7 @@ class TrackMenu extends ConsumerStatefulWidget {
     required this.canGoToGenre,
     required this.onRemoveFromList,
     required this.confirmPlaylistRemoval,
+    required this.showClearQueue,
     this.parentItem,
     required this.childBuilder,
     required this.dragController,
@@ -106,6 +109,7 @@ class TrackMenu extends ConsumerStatefulWidget {
   final bool canGoToGenre;
   final Function? onRemoveFromList;
   final bool confirmPlaylistRemoval;
+  final bool showClearQueue;
   final ScrollBuilder childBuilder;
   final DraggableScrollableController dragController;
 
@@ -583,6 +587,20 @@ class _TrackMenuState extends ConsumerState<TrackMenu> {
               },
             ));
       }),
+      Visibility(
+        visible: widget.showClearQueue,
+        child: ListTile(
+          leading: Icon(
+            Icons.clear_all,
+            color: iconColor,
+          ),
+          title: Text(AppLocalizations.of(context)!.clearQueue),
+          onTap: () async {
+            if (context.mounted) Navigator.pop(context);
+            await _queueService.stopPlayback();
+          },
+        ),
+      ),
     ];
   }
 

--- a/lib/components/AlbumScreen/track_menu.dart
+++ b/lib/components/AlbumScreen/track_menu.dart
@@ -594,7 +594,7 @@ class _TrackMenuState extends ConsumerState<TrackMenu> {
             Icons.clear_all,
             color: iconColor,
           ),
-          title: Text(AppLocalizations.of(context)!.clearQueue),
+          title: Text(AppLocalizations.of(context)!.stopAndClearQueue),
           onTap: () async {
             if (context.mounted) Navigator.pop(context);
             await _queueService.stopPlayback();

--- a/lib/components/AlbumScreen/track_menu.dart
+++ b/lib/components/AlbumScreen/track_menu.dart
@@ -591,7 +591,7 @@ class _TrackMenuState extends ConsumerState<TrackMenu> {
         visible: widget.showClearQueue,
         child: ListTile(
           leading: Icon(
-            Icons.clear_all,
+            TablerIcons.clear_all,
             color: iconColor,
           ),
           title: Text(AppLocalizations.of(context)!.stopAndClearQueue),

--- a/lib/components/PlayerScreen/player_buttons_more.dart
+++ b/lib/components/PlayerScreen/player_buttons_more.dart
@@ -44,6 +44,7 @@ class PlayerButtonsMore extends ConsumerWidget {
               showPlaybackControls: true, // show controls on player screen
               parentItem: inPlaylist ? queueItem!.source.item : null,
               isInPlaylist: inPlaylist,
+              showClearQueue: true,
             );
           },
         ),

--- a/lib/components/PlayerScreen/queue_list.dart
+++ b/lib/components/PlayerScreen/queue_list.dart
@@ -704,9 +704,10 @@ class _CurrentTrackState extends State<CurrentTrack> {
           _queueService.getQueueStream(),
           (a, b) => _QueueListStreamState(a, b)),
       builder: (context, snapshot) {
-        if (snapshot.hasData) {
-          currentTrack = snapshot.data!.queueInfo?.currentTrack;
-          mediaState = snapshot.data!.mediaState;
+        var data = snapshot.data;
+        currentTrack = data?.queueInfo?.currentTrack;
+        if (data != null && currentTrack != null) {
+          mediaState = data.mediaState;
 
           final currentTrackBaseItem = jellyfin_models.BaseItemDto.fromJson(
               currentTrack!.item.extras?["itemJson"] as Map<String, dynamic>);

--- a/lib/components/PlayerScreen/queue_list.dart
+++ b/lib/components/PlayerScreen/queue_list.dart
@@ -980,6 +980,7 @@ class _CurrentTrackState extends State<CurrentTrack> {
                                               queueItemInPlaylist(currentTrack),
                                           parentItem: currentTrack?.source.item,
                                           confirmPlaylistRemoval: true,
+                                          showClearQueue: true,
                                         );
                                       })
                                 ],
@@ -1170,12 +1171,14 @@ class NextUpSectionHeader extends StatelessWidget {
         crossAxisAlignment: CrossAxisAlignment.center,
         children: [
           Expanded(
-              child: Flex(
-                  direction: Axis.horizontal,
-                  crossAxisAlignment: CrossAxisAlignment.center,
-                  children: [
+            child: Flex(
+              direction: Axis.horizontal,
+              crossAxisAlignment: CrossAxisAlignment.center,
+              children: [
                 Text(AppLocalizations.of(context)!.nextUp),
-              ])),
+              ],
+            ),
+          ),
           if (controls)
             SimpleButton(
               text: AppLocalizations.of(context)!.clearNextUp,
@@ -1214,9 +1217,12 @@ class PreviousTracksSectionHeader extends SliverPersistentHeaderDelegate {
   @override
   Widget build(context, double shrinkOffset, bool overlapsContent) {
     return Padding(
-      // color: Colors.black.withOpacity(0.5),
       padding: const EdgeInsets.only(
-          left: 14.0, right: 14.0, bottom: 12.0, top: 8.0),
+        left: 14.0,
+        right: 14.0,
+        bottom: 12.0,
+        top: 8.0,
+      ),
       child: GestureDetector(
         onTap: () {
           try {
@@ -1238,26 +1244,29 @@ class PreviousTracksSectionHeader extends SliverPersistentHeaderDelegate {
             ),
             const SizedBox(width: 4.0),
             StreamBuilder<bool>(
-                stream: isRecentTracksExpanded,
-                builder: (context, snapshot) {
-                  if (snapshot.hasData && snapshot.data!) {
-                    return Icon(
-                      TablerIcons.chevron_up,
-                      size: 28.0,
-                      color: Theme.of(context).brightness == Brightness.light
-                          ? Colors.black
-                          : Colors.white,
-                    );
-                  } else {
-                    return Icon(
-                      TablerIcons.chevron_down,
-                      size: 28.0,
-                      color: Theme.of(context).brightness == Brightness.light
-                          ? Colors.black
-                          : Colors.white,
-                    );
-                  }
-                }),
+              stream: isRecentTracksExpanded,
+              builder: (context, snapshot) {
+                if (snapshot.hasData && snapshot.data!) {
+                  return Icon(
+                    TablerIcons.chevron_up,
+                    size: 28.0,
+                    color:
+                    Theme.of(context).brightness == Brightness.light
+                        ? Colors.black
+                        : Colors.white,
+                  );
+                } else {
+                  return Icon(
+                    TablerIcons.chevron_down,
+                    size: 28.0,
+                    color:
+                    Theme.of(context).brightness == Brightness.light
+                        ? Colors.black
+                        : Colors.white,
+                  );
+                }
+              },
+            ),
           ],
         ),
       ),

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -877,6 +877,10 @@
   "@clearNextUp": {
     "description": "Label for the action that deletes all tracks added to Next Up"
   },
+  "clearQueue": "Clear Queue",
+  "@clearQueue": {
+    "description": "Label for a button that stops playback and removes all tracks from the queue."
+  },
   "playingFrom": "Playing from",
   "@playingFrom": {
     "description": "Prefix shown before the name of the main queue source, like the album or playlist that was used to start playback. Example: \"Playing from {My Nice Playlist}\""

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -877,8 +877,8 @@
   "@clearNextUp": {
     "description": "Label for the action that deletes all tracks added to Next Up"
   },
-  "clearQueue": "Clear Queue",
-  "@clearQueue": {
+  "stopAndClearQueue": "Stop playback and clear queue",
+  "@stopAndClearQueue": {
     "description": "Label for a button that stops playback and removes all tracks from the queue."
   },
   "playingFrom": "Playing from",


### PR DESCRIPTION
This change adds a button in the queue sheet to clear the current queue (and stop playback). Currently, you can do this only by swipe-dismissing the now playing bar, but this only works while not in dual-pane mode (e.g. in landscape mode or on large devices) and isn't as obvious. Another alternative is dismissing the playback notification. The new button should provide a more explicit way to invoke this action.

<details>
<summary>Screenshots</summary>

![Screenshot_20250329_185418_Finamp Debug.png](https://github.com/user-attachments/assets/1e4e4953-7704-4418-9f09-07e9eaef65c1)

![Screenshot_20250329_182957_Finamp Debug.png](https://github.com/user-attachments/assets/3b8dd98b-c47a-4cea-b50a-3af4c1ac1a17)
</details>

Unfortunately, I currently get a flutter error when invoking the button, but only while on debug builds in portrait mode:

<details>
<summary>Error message</summary>

![Screenshot_20250329_185337_Finamp Debug.png](https://github.com/user-attachments/assets/092c8f29-7bb0-427f-ba8c-011bc557183e)
</details>

However, I can reproduce the same issue while being on the queue list and dismissing the playback notification, so it doesn't appear to be caused by my changes and instead seems to be a general bug within Finamp.

Currently, the queue is cleared immediately when tapping the button, we may or may not want to ask the user to confirm first.