### PR TITLE
fix: playback fails to resume from media notification after app is killed (android)

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -388,7 +388,6 @@ Future<void> _setupPlaybackServices() async {
   GetIt.instance.registerSingleton<MusicPlayerBackgroundTask>(audioHandler);
   var queueService = QueueService();
   GetIt.instance.registerSingleton(queueService);
-  await GetIt.instance<QueueService>().initializePlayer();
   GetIt.instance.registerSingleton(PlaybackHistoryService());
   GetIt.instance.registerSingleton(AudioServiceHelper());
 

--- a/lib/services/queue_service.dart
+++ b/lib/services/queue_service.dart
@@ -501,9 +501,6 @@ class QueueService {
         }
       }
 
-      //await stopPlayback(); //TODO is this really needed?
-      // await _audioHandler.initializeAudioSource(_queueAudioSource);
-      await _audioHandler.stopPlayback();
       await _queueAudioSource.clear();
 
       List<AudioSource> audioSources = [];
@@ -547,8 +544,6 @@ class QueueService {
       if (beginPlaying) {
         // don't await this, because it will not return until playback is finished
         unawaited(_audioHandler.play(disableFade: true));
-      } else {
-        unawaited(_audioHandler.pause(disableFade: true));
       }
 
       _audioHandler.nextInitialIndex = null;

--- a/lib/services/queue_service.dart
+++ b/lib/services/queue_service.dart
@@ -146,9 +146,6 @@ class QueueService {
     // );
   }
 
-  Future initializePlayer() =>
-      _audioHandler.initializeAudioSource(_queueAudioSource, preload: true);
-
   void _queueFromConcatenatingAudioSource({
     bool logUpdate = true,
   }) {


### PR DESCRIPTION
Fixes: #1132

When the app is restarted from the notification to continue playback, `AudioService.onPlay` will be called, and the play state propagates through various async queues.

This change attempts to avoid anything cancelling out that play state.

- `initializePlayer` could do that by playing an empty queue, which immediately stops.
- `_replaceWholeQueue` could do that via its `pause` and `stopPlayback` calls.

I'm worried the potential problems this could cause, but I haven't found anything obviously broken on android yet.

Qs

- is there anything in `stopPlayback` that still needs to be done in `_replaceWholeQueue`?

```
  Future<void> stopPlayback() async {
    queueServiceLogger.info("Stopping playback");

    archiveSavedQueue();
    if (_savedQueueState == SavedQueueState.pendingSave) {
      _savedQueueState = SavedQueueState.saving;
    }

    await _queueAudioSource.clear();

    _queueFromConcatenatingAudioSource();

    await _audioHandler.stopPlayback();

    // await _audioHandler.initializeAudioSource(_queueAudioSource,
    //     preload: false);

    return;
  }
```

- what are the consequences of not calling `initializePlayer`?

Playback still seems to work when queue loading is completely disabled.

TODOs

- [ ] testing
- [x] better commit messages
