### PR TITLE
Tap to enlarge `AlbumImage` on `AlbumScreen`

### DIFF
--- a/lib/components/AlbumScreen/album_screen_content_flexible_space_bar.dart
+++ b/lib/components/AlbumScreen/album_screen_content_flexible_space_bar.dart
@@ -232,7 +232,8 @@ class AlbumScreenContentFlexibleSpaceBar extends StatelessWidget {
                   children: [
                     SizedBox(
                       height: 125,
-                      child: AlbumImage(item: parentItem),
+                      child: TapToZoomImage(
+                          albumImage: AlbumImage(item: parentItem)),
                     ),
                     const Padding(
                       padding: EdgeInsets.symmetric(horizontal: 4),

--- a/lib/components/AlbumScreen/track_menu.dart
+++ b/lib/components/AlbumScreen/track_menu.dart
@@ -849,10 +849,11 @@ class _TrackInfoState extends ConsumerState<TrackInfo> {
             children: [
               AspectRatio(
                 aspectRatio: 1.0,
-                child: AlbumImage(
+                child: TapToZoomImage(
+                    albumImage: AlbumImage(
                   item: widget.item,
                   borderRadius: BorderRadius.zero,
-                ),
+                )),
               ),
               Expanded(
                 child: Container(

--- a/lib/components/ArtistScreen/artist_screen_content_flexible_space_bar.dart
+++ b/lib/components/ArtistScreen/artist_screen_content_flexible_space_bar.dart
@@ -322,7 +322,8 @@ class ArtistScreenContentFlexibleSpaceBar extends StatelessWidget {
                   children: [
                     SizedBox(
                       height: 125,
-                      child: AlbumImage(item: parentItem),
+                      child: TapToZoomImage(
+                          albumImage: AlbumImage(item: parentItem)),
                     ),
                     const Padding(
                       padding: EdgeInsets.symmetric(horizontal: 4),

--- a/lib/components/album_image.dart
+++ b/lib/components/album_image.dart
@@ -1,5 +1,6 @@
 import 'dart:io';
 import 'dart:math';
+import 'dart:ui';
 
 import 'package:finamp/components/PlayerScreen/player_split_screen_scaffold.dart';
 import 'package:finamp/models/finamp_models.dart';
@@ -265,6 +266,7 @@ class _TapToZoomImageState extends State<TapToZoomImage> {
         child: Hero(
           tag: zoomedImageHeroTag,
           child: widget.albumImage,
+          placeholderBuilder: (context, heroSize, child) => widget.albumImage,
         ),
       ),
     );
@@ -287,6 +289,10 @@ class ZoomedImage extends StatelessWidget {
           child: IgnorePointer(
             child: Container(
               color: Colors.black.withOpacity(0.5),
+              child: BackdropFilter(
+                filter: ImageFilter.blur(sigmaX: 5.0, sigmaY: 5.0),
+                child: Container(),
+              ),
             ),
           ),
         ),

--- a/lib/components/album_image.dart
+++ b/lib/components/album_image.dart
@@ -4,9 +4,11 @@ import 'dart:math';
 import 'package:finamp/components/PlayerScreen/player_split_screen_scaffold.dart';
 import 'package:finamp/models/finamp_models.dart';
 import 'package:finamp/services/finamp_settings_helper.dart';
+import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_blurhash/flutter_blurhash.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_tabler_icons/flutter_tabler_icons.dart';
 import 'package:octo_image/octo_image.dart';
 
 import '../models/jellyfin_models.dart';
@@ -220,6 +222,104 @@ class _AlbumImageErrorPlaceholder extends StatelessWidget {
     return Container(
       color: Theme.of(context).cardColor,
       child: const Icon(Icons.album),
+    );
+  }
+}
+
+class TapToZoomImage extends StatefulWidget {
+  final AlbumImage albumImage;
+  final bool isDisabled;
+
+  const TapToZoomImage({
+    super.key,
+    required this.albumImage,
+    this.isDisabled = false,
+  });
+
+  @override
+  _TapToZoomImageState createState() => _TapToZoomImageState();
+}
+
+final zoomedImageHeroTag = "zoomed-image";
+
+class _TapToZoomImageState extends State<TapToZoomImage> {
+  @override
+  Widget build(BuildContext context) {
+    if (widget.isDisabled) {
+      return widget.albumImage;
+    }
+
+    return MouseRegion(
+      cursor: SystemMouseCursors.click,
+      child: GestureDetector(
+        onTap: () => Navigator.of(context).push(PageRouteBuilder<ZoomedImage>(
+            opaque: false,
+            barrierDismissible: true,
+            transitionDuration: MediaQuery.of(context).disableAnimations
+                ? Duration.zero
+                : const Duration(milliseconds: 500),
+            pageBuilder: (BuildContext context, Animation<double> animation1,
+                Animation<double> animation2) {
+              return ZoomedImage(albumImage: widget.albumImage);
+            })),
+        child: Hero(
+          tag: zoomedImageHeroTag,
+          child: widget.albumImage,
+        ),
+      ),
+    );
+  }
+}
+
+class ZoomedImage extends StatelessWidget {
+  final AlbumImage albumImage;
+
+  const ZoomedImage({
+    super.key,
+    required this.albumImage,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Stack(
+      children: [
+        Positioned.fill(
+          child: IgnorePointer(
+            child: Container(
+              color: Colors.black.withOpacity(0.5),
+            ),
+          ),
+        ),
+        Center(
+            child: Dismissible(
+          key: const Key("zoomed-image-dismiss"),
+          direction: DismissDirection.vertical,
+          onDismissed: (direction) {
+            Navigator.of(context).pop();
+          },
+          child: InteractiveViewer(
+            constrained: true,
+            panEnabled: true,
+            clipBehavior: Clip.none,
+            child: Hero(
+              tag: zoomedImageHeroTag,
+              child: albumImage,
+            ),
+          ),
+        )),
+        Positioned(
+          top: 8,
+          right: 16,
+          child: IconButton(
+            icon: const Icon(TablerIcons.x),
+            color: Colors.white,
+            iconSize: 32.0,
+            onPressed: () {
+              Navigator.of(context).pop();
+            },
+          ),
+        ),
+      ],
     );
   }
 }


### PR DESCRIPTION
## Album Art Tap to Magnify
The goal is to be able to tap the small album art image in the FlexibleSpaceBar header to reveal a larger version of the album art that is full-width on a mobile device.

### Objectives
- reuse the same image (ideally cached) rather than pulling over the network again
- incorporate a smooth animation as the image magnifies
- keep the area above and below the enlarged image transparent, to view the AlbumScreen behind
- use a "throw away" gesture to get rid of the album art
  - also tapping outside the bounds of the image will dismiss it

### Related Issue
- https://github.com/jmshrv/finamp/issues/785