### PR TITLE
Remove useless ItemFields from defaultFields

### DIFF
--- a/lib/services/jellyfin_api.dart
+++ b/lib/services/jellyfin_api.dart
@@ -14,7 +14,7 @@ import 'jellyfin_api_helper.dart';
 part 'jellyfin_api.chopper.dart';
 
 const String defaultFields =
-    "ChildCount,DateCreated,DateLastMediaAdded,Etag,Genres,IndexNumber,ParentId,ProviderIds,Tags,albumPrimaryImageTag,parentPrimaryImageItemId,songCount";
+    "ChildCount,DateCreated,DateLastMediaAdded,Etag,Genres,ParentId,ProviderIds,Tags";
 
 @ChopperApi()
 abstract class JellyfinApi extends ChopperService {


### PR DESCRIPTION
Fixes some errors on when running JF master branch
```
2025-04-04 00:00:01.523 +02:00] [DBG] [19] Jellyfin.Api.ModelBinders.CommaDelimitedCollectionModelBinder: Error converting value.
System.FormatException: IndexNumber is not a valid value for ItemFields.
 ---> System.ArgumentException: Requested value 'IndexNumber' was not found.
   at System.Enum.TryParseByName[TStorage](RuntimeType enumType, ReadOnlySpan`1 value, Boolean ignoreCase, Boolean throwOnFailure, TStorage& result)
   at System.Enum.TryParseByValueOrName[TUnderlying,TStorage](RuntimeType enumType, ReadOnlySpan`1 value, Boolean ignoreCase, Boolean throwOnFailure, TUnderlying& result)
   at System.Enum.TryParse(Type enumType, ReadOnlySpan`1 value, Boolean ignoreCase, Boolean throwOnFailure, Object& result)
   at System.ComponentModel.EnumConverter.ConvertFrom(ITypeDescriptorContext context, CultureInfo culture, Object value)
   --- End of inner exception stack trace ---
   at System.ComponentModel.EnumConverter.ConvertFrom(ITypeDescriptorContext context, CultureInfo culture, Object value)
   at System.ComponentModel.TypeConverter.ConvertFromString(String text)
   at Jellyfin.Api.ModelBinders.CommaDelimitedCollectionModelBinder.GetParsedResult(IReadOnlyList`1 values, Type elementType, TypeConverter converter) in /home/loma/dev/jellyfin/Jellyfin.Api/ModelBinders/CommaDelimitedCollectionModelBinder.cs:line 67
[2025-04-04 00:00:01.524 +02:00] [DBG] [19] Jellyfin.Api.ModelBinders.CommaDelimitedCollectionModelBinder: Error converting value.
System.FormatException: albumPrimaryImageTag is not a valid value for ItemFields.
 ---> System.ArgumentException: Requested value 'albumPrimaryImageTag' was not found.
   at System.Enum.TryParseByName[TStorage](RuntimeType enumType, ReadOnlySpan`1 value, Boolean ignoreCase, Boolean throwOnFailure, TStorage& result)
   at System.Enum.TryParseByValueOrName[TUnderlying,TStorage](RuntimeType enumType, ReadOnlySpan`1 value, Boolean ignoreCase, Boolean throwOnFailure, TUnderlying& result)
   at System.Enum.TryParse(Type enumType, ReadOnlySpan`1 value, Boolean ignoreCase, Boolean throwOnFailure, Object& result)
   at System.ComponentModel.EnumConverter.ConvertFrom(ITypeDescriptorContext context, CultureInfo culture, Object value)
   --- End of inner exception stack trace ---
   at System.ComponentModel.EnumConverter.ConvertFrom(ITypeDescriptorContext context, CultureInfo culture, Object value)
   at System.ComponentModel.TypeConverter.ConvertFromString(String text)
   at Jellyfin.Api.ModelBinders.CommaDelimitedCollectionModelBinder.GetParsedResult(IReadOnlyList`1 values, Type elementType, TypeConverter converter) in /home/loma/dev/jellyfin/Jellyfin.Api/ModelBinders/CommaDelimitedCollectionModelBinder.cs:line 67
[2025-04-04 00:00:01.524 +02:00] [DBG] [19] Jellyfin.Api.ModelBinders.CommaDelimitedCollectionModelBinder: Error converting value.
System.FormatException: parentPrimaryImageItemId is not a valid value for ItemFields.
 ---> System.ArgumentException: Requested value 'parentPrimaryImageItemId' was not found.
   at System.Enum.TryParseByName[TStorage](RuntimeType enumType, ReadOnlySpan`1 value, Boolean ignoreCase, Boolean throwOnFailure, TStorage& result)
   at System.Enum.TryParseByValueOrName[TUnderlying,TStorage](RuntimeType enumType, ReadOnlySpan`1 value, Boolean ignoreCase, Boolean throwOnFailure, TUnderlying& result)
   at System.Enum.TryParse(Type enumType, ReadOnlySpan`1 value, Boolean ignoreCase, Boolean throwOnFailure, Object& result)
   at System.ComponentModel.EnumConverter.ConvertFrom(ITypeDescriptorContext context, CultureInfo culture, Object value)
   --- End of inner exception stack trace ---
   at System.ComponentModel.EnumConverter.ConvertFrom(ITypeDescriptorContext context, CultureInfo culture, Object value)
   at System.ComponentModel.TypeConverter.ConvertFromString(String text)
   at Jellyfin.Api.ModelBinders.CommaDelimitedCollectionModelBinder.GetParsedResult(IReadOnlyList`1 values, Type elementType, TypeConverter converter) in /home/loma/dev/jellyfin/Jellyfin.Api/ModelBinders/CommaDelimitedCollectionModelBinder.cs:line 67
[2025-04-04 00:00:01.524 +02:00] [DBG] [19] Jellyfin.Api.ModelBinders.CommaDelimitedCollectionModelBinder: Error converting value.
System.FormatException: songCount is not a valid value for ItemFields.
 ---> System.ArgumentException: Requested value 'songCount' was not found.
   at System.Enum.TryParseByName[TStorage](RuntimeType enumType, ReadOnlySpan`1 value, Boolean ignoreCase, Boolean throwOnFailure, TStorage& result)
   at System.Enum.TryParseByValueOrName[TUnderlying,TStorage](RuntimeType enumType, ReadOnlySpan`1 value, Boolean ignoreCase, Boolean throwOnFailure, TUnderlying& result)
   at System.Enum.TryParse(Type enumType, ReadOnlySpan`1 value, Boolean ignoreCase, Boolean throwOnFailure, Object& result)
   at System.ComponentModel.EnumConverter.ConvertFrom(ITypeDescriptorContext context, CultureInfo culture, Object value)
   --- End of inner exception stack trace ---
   at System.ComponentModel.EnumConverter.ConvertFrom(ITypeDescriptorContext context, CultureInfo culture, Object value)
   at System.ComponentModel.TypeConverter.ConvertFromString(String text)
   at Jellyfin.Api.ModelBinders.CommaDelimitedCollectionModelBinder.GetParsedResult(IReadOnlyList`1 values, Type elementType, TypeConverter converter) in /home/loma/dev/jellyfin/Jellyfin.Api/ModelBinders/CommaDelimitedCollectionModelBinder.cs:line 67
```

Related: https://github.com/jellyfin/jellyfin/pull/13818