### PR TITLE
Wrong Navigation when Deleting

### DIFF
--- a/lib/components/AlbumScreen/album_screen_content.dart
+++ b/lib/components/AlbumScreen/album_screen_content.dart
@@ -1,3 +1,4 @@
+import 'package:finamp/components/MusicScreen/music_screen_tab_view.dart';
 import 'package:flutter/material.dart';
 import 'package:finamp/l10n/app_localizations.dart';
 import 'package:flutter_sticky_header/flutter_sticky_header.dart';
@@ -29,7 +30,17 @@ class AlbumScreenContent extends StatefulWidget {
   State<AlbumScreenContent> createState() => _AlbumScreenContentState();
 }
 
+var _listener;
 class _AlbumScreenContentState extends State<AlbumScreenContent> {
+  @override
+  void dispose() {
+    super.dispose();
+    if (_listener != null) {
+      _listener.cancel();
+      _listener = null;
+    }
+  }
+
   @override
   Widget build(BuildContext context) {
     final downloadStub = DownloadStub.fromItem(
@@ -45,6 +56,12 @@ class _AlbumScreenContentState extends State<AlbumScreenContent> {
         widget.displayChildren.removeWhere((element) => element.id == item.id);
       });
     }
+    if (_listener != null) {
+      _listener.cancel();
+    }
+    _listener = musicScreenRefreshStream.stream.listen((_) {
+      setState(() {});
+    });
 
     List<List<BaseItemDto>> childrenPerDisc = [];
     // if not in playlist, try splitting up tracks by disc numbers

--- a/lib/components/AlbumScreen/track_menu.dart
+++ b/lib/components/AlbumScreen/track_menu.dart
@@ -20,7 +20,6 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_tabler_icons/flutter_tabler_icons.dart';
 import 'package:flutter_vibrate/flutter_vibrate.dart';
 import 'package:get_it/get_it.dart';
-import 'package:logging/logging.dart';
 import 'package:rxdart/rxdart.dart';
 
 import '../../models/jellyfin_models.dart';
@@ -580,7 +579,7 @@ class _TrackMenuState extends ConsumerState<TrackMenu> {
                 var item = DownloadStub.fromItem(
                     type: DownloadItemType.track, item: widget.item);
                 await askBeforeDeleteFromServerAndDevice(context, item);
-                
+                Navigator.pop(context); // close popup
                 musicScreenRefreshStream.add(null);
               },
             ));

--- a/lib/components/AlbumScreen/track_menu.dart
+++ b/lib/components/AlbumScreen/track_menu.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 
 import 'package:finamp/components/AlbumScreen/speed_menu.dart';
+import 'package:finamp/components/MusicScreen/music_screen_tab_view.dart';
 import 'package:finamp/components/PlayerScreen/queue_list.dart';
 import 'package:finamp/components/PlayerScreen/sleep_timer_cancel_dialog.dart';
 import 'package:finamp/components/PlayerScreen/sleep_timer_dialog.dart';
@@ -19,6 +20,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_tabler_icons/flutter_tabler_icons.dart';
 import 'package:flutter_vibrate/flutter_vibrate.dart';
 import 'package:get_it/get_it.dart';
+import 'package:logging/logging.dart';
 import 'package:rxdart/rxdart.dart';
 
 import '../../models/jellyfin_models.dart';
@@ -578,20 +580,8 @@ class _TrackMenuState extends ConsumerState<TrackMenu> {
                 var item = DownloadStub.fromItem(
                     type: DownloadItemType.track, item: widget.item);
                 await askBeforeDeleteFromServerAndDevice(context, item);
-                final BaseItemDto newAlbumOrPlaylist =
-                    await _jellyfinApiHelper.getItemById(widget.parentItem!.id);
-                if (context.mounted) {
-                  Navigator.pop(context); // close dialog
-                  // pop current album screen and reload with new album data
-                  Navigator.of(context).popUntil((route) {
-                    return route.settings.name != null // unnamed dialog
-                        &&
-                        route.settings.name !=
-                            AlbumScreen.routeName; // albums screen
-                  });
-                  await Navigator.of(context).pushNamed(AlbumScreen.routeName,
-                      arguments: newAlbumOrPlaylist);
-                }
+                
+                musicScreenRefreshStream.add(null);
               },
             ));
       }),


### PR DESCRIPTION
>  I just noticed in the code that deleting something from the tracks tab will open the parent album instead of refreshing the tab. I think we might want to change that?
Also it seems like there's an error when deleting a track from the tracks tab. The deletion goes through, but the menu doesn't close and (flawed) navigation doesn't happen.
If you could take a look that would be great! Should be a simple fix :)

\- Chaphasilor
___

I believe this is fixed now. Im not a 100% sure if my logic here is sound though.