### PR TITLE
Fix crash in MediaItemContentProvider when the pipe breaks

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -25,7 +25,7 @@ if (flutterVersionName == null) {
 def keystoreProperties = new Properties()
 def keystorePropertiesFile = rootProject.file('key.properties')
 if (keystorePropertiesFile.exists()) {
-   keystoreProperties.load(new FileInputStream(keystorePropertiesFile))
+    keystoreProperties.load(new FileInputStream(keystorePropertiesFile))
 }
 
 android {
@@ -95,4 +95,5 @@ dependencies {
     implementation 'androidx.appcompat:appcompat:1.3.1'
     implementation 'androidx.mediarouter:mediarouter:1.7.0'
     implementation "androidx.core:core-splashscreen:1.0.0"
+    implementation "org.jetbrains.kotlinx:kotlinx-coroutines-core:1.8.1"
 }

--- a/android/app/src/main/kotlin/com/unicornsonlsd/finamp/MediaItemContentProvider.kt
+++ b/android/app/src/main/kotlin/com/unicornsonlsd/finamp/MediaItemContentProvider.kt
@@ -4,33 +4,58 @@ import android.content.ContentProvider
 import android.content.ContentValues
 import android.database.Cursor
 import android.net.Uri
+import android.os.Bundle
 import android.os.ParcelFileDescriptor
+import android.util.Log
 import android.util.LruCache
+import androidx.core.net.toUri
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
 import java.io.File
+import java.io.FileNotFoundException
 import java.io.FileOutputStream
+import java.io.IOException
 import java.net.URL
 
 class MediaItemContentProvider : ContentProvider() {
 
-    private lateinit var memoryCache : LruCache<String, ByteArray>
+    private val coroutineScope = CoroutineScope(Dispatchers.Default)
+
+    private lateinit var memoryCache: LruCache<String, ByteArray>
 
     override fun openFile(uri: Uri, mode: String): ParcelFileDescriptor? {
-        if (uri.encodedFragment != null) {
-            // we store the original scheme://host in fragment since it should be unused
-            val origin = Uri.parse(uri.encodedFragment)
-            val fixedUri = uri.buildUpon().fragment(null).scheme(origin.scheme).encodedAuthority(origin.encodedAuthority).toString()
+        val fragment = uri.encodedFragment
+        if (fragment != null) {
+            // We store the original scheme://host in fragment since it should be unused
+            val origin = fragment.toUri()
+            val fixedUri = uri.buildUpon()
+                .fragment(null)
+                .scheme(origin.scheme)
+                .encodedAuthority(origin.encodedAuthority)
+                .toString()
 
-            // check if we already cached the image
+            // Check if we already cached the image
             val bytes = memoryCache.get(fixedUri)
             if (bytes != null) {
-                return openPipeHelper(uri, "application/octet-stream", null, bytes) {output, _, _, _, b ->
+                return openSafePipeHelper(
+                    uri,
+                    "application/octet-stream",
+                    null,
+                    bytes,
+                ) { output, _, _, _, b ->
                     FileOutputStream(output.fileDescriptor).write(b)
                 }
             }
 
             val response = URL(fixedUri).readBytes()
             memoryCache.put(fixedUri, response)
-            return openPipeHelper(uri, "application/octet-stream", null, response) {output, _, _, _, b ->
+            return openSafePipeHelper(
+                uri,
+                "application/octet-stream",
+                null,
+                response,
+            ) { output, _, _, _, b ->
                 FileOutputStream(output.fileDescriptor).write(b)
             }
         }
@@ -47,7 +72,7 @@ class MediaItemContentProvider : ContentProvider() {
 
         // Use 1/8th of the available memory for this memory cache.
         val cacheSize = maxMemory / 8
-        memoryCache  = object : LruCache<String, ByteArray>(cacheSize) {
+        memoryCache = object : LruCache<String, ByteArray>(cacheSize) {
 
             override fun sizeOf(key: String, value: ByteArray): Int {
                 // The cache size will be measured in kilobytes rather than
@@ -59,7 +84,13 @@ class MediaItemContentProvider : ContentProvider() {
         return true
     }
 
-    override fun query(uri: Uri, projection: Array<out String>?, selection: String?, selectionArgs: Array<out String>?, sortOrder: String?): Cursor? {
+    override fun query(
+        uri: Uri,
+        projection: Array<out String>?,
+        selection: String?,
+        selectionArgs: Array<out String>?,
+        sortOrder: String?,
+    ): Cursor? {
         return null
     }
 
@@ -75,7 +106,52 @@ class MediaItemContentProvider : ContentProvider() {
         return 0
     }
 
-    override fun update(uri: Uri, values: ContentValues?, selection: String?, selectionArgs: Array<out String>?): Int {
+    override fun update(
+        uri: Uri,
+        values: ContentValues?,
+        selection: String?,
+        selectionArgs: Array<out String>?,
+    ): Int {
         return 0
+    }
+
+    /**
+     * Own implementation of [openPipeHelper].
+     *
+     * Differs from the framework implementation in that it has an additional try/catch block
+     * around the writeDataToPipe call.
+     *
+     * This is to catch the EPIPE (Broken pipe) error that can occur
+     * when writing large files (like GIF cover arts) to the pipe.
+     */
+    private fun <T> openSafePipeHelper(
+        uri: Uri,
+        mimeType: String,
+        opts: Bundle? = null,
+        args: T?,
+        func: PipeDataWriter<T>,
+    ): ParcelFileDescriptor = try {
+        val (read, write) = ParcelFileDescriptor.createPipe()
+
+        coroutineScope.launch(Dispatchers.IO) {
+            try {
+                func.writeDataToPipe(write, uri, mimeType, opts, args)
+            } catch (e: IOException) {
+                Log.e(TAG, "Failure writing to pipe", e)
+            }
+            try {
+                write.close()
+            } catch (e: IOException) {
+                Log.w(TAG, "Failure closing pipe", e)
+            }
+        }
+
+        read
+    } catch (e: IOException) {
+        throw FileNotFoundException("failure making pipe")
+    }
+
+    companion object {
+        private const val TAG = "MediaItemCP"
     }
 }


### PR DESCRIPTION
This can happen when loading especially large files like GIF cover arts. Unfortunately, the crash happens within (very old) framework code, so we have to copy the called function and write our own version that simply catches the exception.

Fixes #1185.