### PR TITLE
[Redesign] Album Image Zoom Fixes

### DIFF
--- a/lib/components/AlbumScreen/album_screen_content_flexible_space_bar.dart
+++ b/lib/components/AlbumScreen/album_screen_content_flexible_space_bar.dart
@@ -1,10 +1,10 @@
 import 'package:finamp/components/Buttons/cta_medium.dart';
 import 'package:finamp/components/global_snackbar.dart';
+import 'package:finamp/l10n/app_localizations.dart';
 import 'package:finamp/models/finamp_models.dart';
 import 'package:finamp/services/feedback_helper.dart';
 import 'package:finamp/services/queue_service.dart';
 import 'package:flutter/material.dart';
-import 'package:finamp/l10n/app_localizations.dart';
 import 'package:flutter_tabler_icons/flutter_tabler_icons.dart';
 import 'package:get_it/get_it.dart';
 
@@ -232,8 +232,7 @@ class AlbumScreenContentFlexibleSpaceBar extends StatelessWidget {
                   children: [
                     SizedBox(
                       height: 125,
-                      child: TapToZoomImage(
-                          albumImage: AlbumImage(item: parentItem)),
+                      child: AlbumImage(item: parentItem, tapToZoom: true),
                     ),
                     const Padding(
                       padding: EdgeInsets.symmetric(horizontal: 4),

--- a/lib/components/AlbumScreen/track_menu.dart
+++ b/lib/components/AlbumScreen/track_menu.dart
@@ -849,11 +849,11 @@ class _TrackInfoState extends ConsumerState<TrackInfo> {
             children: [
               AspectRatio(
                 aspectRatio: 1.0,
-                child: TapToZoomImage(
-                    albumImage: AlbumImage(
+                child: AlbumImage(
                   item: widget.item,
                   borderRadius: BorderRadius.zero,
-                )),
+                  tapToZoom: true,
+                ),
               ),
               Expanded(
                 child: Container(

--- a/lib/components/ArtistScreen/artist_screen_content_flexible_space_bar.dart
+++ b/lib/components/ArtistScreen/artist_screen_content_flexible_space_bar.dart
@@ -3,11 +3,11 @@ import 'dart:async';
 import 'package:collection/collection.dart';
 import 'package:finamp/components/Buttons/cta_medium.dart';
 import 'package:finamp/components/global_snackbar.dart';
+import 'package:finamp/l10n/app_localizations.dart';
 import 'package:finamp/models/finamp_models.dart';
 import 'package:finamp/services/feedback_helper.dart';
 import 'package:finamp/services/queue_service.dart';
 import 'package:flutter/material.dart';
-import 'package:finamp/l10n/app_localizations.dart';
 import 'package:flutter_tabler_icons/flutter_tabler_icons.dart';
 import 'package:get_it/get_it.dart';
 
@@ -44,7 +44,6 @@ class ArtistScreenContentFlexibleSpaceBar extends StatelessWidget {
   final int albumCount;
   final BaseItemDto? genreFilter;
   final void Function(BaseItemDto?)? updateGenreFilter;
-
 
   @override
   Widget build(BuildContext context) {
@@ -153,8 +152,8 @@ class ArtistScreenContentFlexibleSpaceBar extends StatelessWidget {
             item: parentItem,
           ));
       GlobalSnackbar.message(
-          (scaffold) => AppLocalizations.of(scaffold)!
-              .confirmPlayNext("artist"),
+          (scaffold) =>
+              AppLocalizations.of(scaffold)!.confirmPlayNext("artist"),
           isConfirmation: true);
     }
 
@@ -171,8 +170,8 @@ class ArtistScreenContentFlexibleSpaceBar extends StatelessWidget {
             item: parentItem,
           ));
       GlobalSnackbar.message(
-          (scaffold) => AppLocalizations.of(scaffold)!
-              .confirmAddToNextUp("artist"),
+          (scaffold) =>
+              AppLocalizations.of(scaffold)!.confirmAddToNextUp("artist"),
           isConfirmation: true);
     }
 
@@ -189,8 +188,8 @@ class ArtistScreenContentFlexibleSpaceBar extends StatelessWidget {
             item: parentItem,
           ));
       GlobalSnackbar.message(
-          (scaffold) => AppLocalizations.of(scaffold)!
-              .confirmAddToQueue("artist"),
+          (scaffold) =>
+              AppLocalizations.of(scaffold)!.confirmAddToQueue("artist"),
           isConfirmation: true);
     }
 
@@ -301,8 +300,10 @@ class ArtistScreenContentFlexibleSpaceBar extends StatelessWidget {
                   children: [
                     SizedBox(
                       height: 125,
-                      child: TapToZoomImage(
-                          albumImage: AlbumImage(item: parentItem)),
+                      child: AlbumImage(
+                        item: parentItem,
+                        tapToZoom: true,
+                      ),
                     ),
                     const Padding(
                       padding: EdgeInsets.symmetric(horizontal: 4),
@@ -337,8 +338,8 @@ class ArtistScreenContentFlexibleSpaceBar extends StatelessWidget {
                                 text: AppLocalizations.of(context)!
                                     .playButtonLabel,
                                 icon: TablerIcons.player_play,
-                                onPressed: () => allTracks.then((items) =>
-                                    playAllFromArtist(items ?? [])),
+                                onPressed: () => allTracks.then(
+                                    (items) => playAllFromArtist(items ?? [])),
                                 // set the minimum width as 25% of the screen width,
                                 minWidth:
                                     MediaQuery.of(context).size.width * 0.25,
@@ -346,8 +347,8 @@ class ArtistScreenContentFlexibleSpaceBar extends StatelessWidget {
                               PopupMenuButton<ArtistMenuItems>(
                                 enableFeedback: true,
                                 // icon: const Icon(TablerIcons.dots_vertical),
-                                onOpened: () => FeedbackHelper.feedback(
-                                    FeedbackType.light),
+                                onOpened: () =>
+                                    FeedbackHelper.feedback(FeedbackType.light),
                                 itemBuilder: (context) {
                                   final queueService =
                                       GetIt.instance<QueueService>();
@@ -388,8 +389,7 @@ class ArtistScreenContentFlexibleSpaceBar extends StatelessWidget {
                                     ),
                                   ];
                                 },
-                                onSelected:
-                                    (ArtistMenuItems selection) async {
+                                onSelected: (ArtistMenuItems selection) async {
                                   switch (selection) {
                                     case ArtistMenuItems.playNext:
                                       unawaited(allTracks.then((items) =>
@@ -428,8 +428,7 @@ class ArtistScreenContentFlexibleSpaceBar extends StatelessWidget {
                                           shuffleAlbumsFromArtistNext(
                                               items ?? [])));
                                       break;
-                                    case ArtistMenuItems
-                                          .shuffleAlbumsToNextUp:
+                                    case ArtistMenuItems.shuffleAlbumsToNextUp:
                                       unawaited(allTracks.then((items) =>
                                           shuffleAlbumsFromArtistToNextUp(
                                               items ?? [])));
@@ -461,8 +460,8 @@ class ArtistScreenContentFlexibleSpaceBar extends StatelessWidget {
                               PopupMenuButton<ArtistMenuItems>(
                                 enableFeedback: true,
                                 // icon: const Icon(TablerIcons.dots_vertical),
-                                onOpened: () => FeedbackHelper.feedback(
-                                    FeedbackType.light),
+                                onOpened: () =>
+                                    FeedbackHelper.feedback(FeedbackType.light),
                                 itemBuilder: (context) {
                                   final queueService =
                                       GetIt.instance<QueueService>();
@@ -527,8 +526,8 @@ class ArtistScreenContentFlexibleSpaceBar extends StatelessWidget {
                                         ),
                                       ),
                                     PopupMenuItem<ArtistMenuItems>(
-                                      value: ArtistMenuItems
-                                          .shuffleAlbumsToNextUp,
+                                      value:
+                                          ArtistMenuItems.shuffleAlbumsToNextUp,
                                       child: ListTile(
                                         leading: const Icon(TablerIcons
                                             .corner_right_down_double),
@@ -538,8 +537,8 @@ class ArtistScreenContentFlexibleSpaceBar extends StatelessWidget {
                                       ),
                                     ),
                                     PopupMenuItem<ArtistMenuItems>(
-                                      value: ArtistMenuItems
-                                          .shuffleAlbumsToQueue,
+                                      value:
+                                          ArtistMenuItems.shuffleAlbumsToQueue,
                                       child: ListTile(
                                         leading:
                                             const Icon(TablerIcons.playlist),
@@ -550,8 +549,7 @@ class ArtistScreenContentFlexibleSpaceBar extends StatelessWidget {
                                     ),
                                   ];
                                 },
-                                onSelected:
-                                    (ArtistMenuItems selection) async {
+                                onSelected: (ArtistMenuItems selection) async {
                                   switch (selection) {
                                     case ArtistMenuItems.playNext:
                                       unawaited(allTracks.then((items) =>
@@ -590,8 +588,7 @@ class ArtistScreenContentFlexibleSpaceBar extends StatelessWidget {
                                           shuffleAlbumsFromArtistNext(
                                               items ?? [])));
                                       break;
-                                    case ArtistMenuItems
-                                          .shuffleAlbumsToNextUp:
+                                    case ArtistMenuItems.shuffleAlbumsToNextUp:
                                       unawaited(allTracks.then((items) =>
                                           shuffleAlbumsFromArtistToNextUp(
                                               items ?? [])));

--- a/lib/components/album_image.dart
+++ b/lib/components/album_image.dart
@@ -155,34 +155,30 @@ class _AlbumImageState extends ConsumerState<AlbumImage> {
             tapToZoom: false,
             onZoomRoute: true,
           );
+          // Show album as clickable on desktop
           return MouseRegion(
             cursor: SystemMouseCursors.click,
             child: GestureDetector(
-              onTap: () => Navigator.of(context).push(
-                  PageRouteBuilder<_ZoomedImage>(
-                      opaque: false,
-                      barrierDismissible: true,
-                      transitionDuration:
-                          MediaQuery.of(context).disableAnimations
-                              ? Duration.zero
-                              : const Duration(milliseconds: 500),
-                      pageBuilder: (BuildContext context,
-                          Animation<double> animation1,
-                          Animation<double> animation2) {
-                        return _ZoomedImage(albumImage: largeImage, id: zoomID);
-                      })),
-              child: LayoutBuilder(builder: (context, constraints) {
-                return Hero(
+                onTap: () => Navigator.of(context).push(PageRouteBuilder<
+                        _ZoomedImage>(
+                    opaque: false,
+                    barrierDismissible: true,
+                    transitionDuration: MediaQuery.of(context).disableAnimations
+                        ? Duration.zero
+                        : const Duration(milliseconds: 500),
+                    pageBuilder: (BuildContext context,
+                        Animation<double> animation1,
+                        Animation<double> animation2) {
+                      return _ZoomedImage(albumImage: largeImage, id: zoomID);
+                    })),
+                child: Hero(
                     tag: zoomID,
                     createRectTween: (begin, end) =>
                         RectTween(begin: begin, end: end),
                     child: image,
                     placeholderBuilder: (context, heroSize, child) => image,
-                    flightShuttleBuilder:
-                        (overlayContext, _, __, fromContext, ____) =>
-                            largeImage);
-              }),
-            ),
+                    flightShuttleBuilder: (_, __, ___, ____, _____) =>
+                        largeImage)),
           );
         }
 
@@ -294,7 +290,6 @@ class _ZoomedImage extends StatelessWidget {
   final String id;
 
   const _ZoomedImage({
-    super.key,
     required this.albumImage,
     required this.id,
   });
@@ -309,7 +304,7 @@ class _ZoomedImage extends StatelessWidget {
               color: Colors.black.withOpacity(0.5),
               child: BackdropFilter(
                 filter: ImageFilter.blur(sigmaX: 5.0, sigmaY: 5.0),
-                child: Container(),
+                child: SizedBox.expand(),
               ),
             ),
           ),

--- a/lib/components/album_image.dart
+++ b/lib/components/album_image.dart
@@ -5,12 +5,12 @@ import 'dart:ui';
 import 'package:finamp/components/PlayerScreen/player_split_screen_scaffold.dart';
 import 'package:finamp/models/finamp_models.dart';
 import 'package:finamp/services/finamp_settings_helper.dart';
-import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_blurhash/flutter_blurhash.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_tabler_icons/flutter_tabler_icons.dart';
 import 'package:octo_image/octo_image.dart';
+import 'package:uuid/v4.dart';
 
 import '../models/jellyfin_models.dart';
 import '../services/album_image_provider.dart';
@@ -22,7 +22,7 @@ typedef ImageProviderCallback = void Function(ImageProvider theme);
 /// Aspect ratio 1 with a circular border radius of 4. If you don't want these
 /// customisations, use [BareAlbumImage] or get an [ImageProvider] directly
 /// through [AlbumImageProvider.init].
-class AlbumImage extends ConsumerWidget {
+class AlbumImage extends ConsumerStatefulWidget {
   const AlbumImage({
     super.key,
     this.item,
@@ -32,6 +32,8 @@ class AlbumImage extends ConsumerWidget {
     this.disabled = false,
     this.autoScale = true,
     this.decoration,
+    this.tapToZoom = false,
+    this.onZoomRoute = false,
   });
 
   /// The item to get an image for.
@@ -48,6 +50,10 @@ class AlbumImage extends ConsumerWidget {
   /// Whether to automatically scale the image to the size of the widget.
   final bool autoScale;
 
+  final bool tapToZoom;
+
+  final bool onZoomRoute;
+
   /// The decoration to use for the album image. This is defined in AlbumImage
   /// instead of being used as a separate widget so that non-square images don't
   /// look incorrect due to AlbumImage having an aspect ratio of 1:1
@@ -56,95 +62,151 @@ class AlbumImage extends ConsumerWidget {
   static final defaultBorderRadius = BorderRadius.circular(4);
 
   @override
-  Widget build(BuildContext context, WidgetRef ref) {
-    final borderRadius = this.borderRadius ?? defaultBorderRadius;
-    assert(item == null || imageListenable == null);
-    if ((item == null || item!.imageId == null) && imageListenable == null) {
+  ConsumerState<AlbumImage> createState() => _AlbumImageState();
+}
+
+class _AlbumImageState extends ConsumerState<AlbumImage> {
+  final String zoomID = UuidV4().generate();
+
+  @override
+  Widget build(BuildContext context) {
+    final borderRadius = widget.borderRadius ?? AlbumImage.defaultBorderRadius;
+    assert(widget.item == null || widget.imageListenable == null);
+    assert(!(widget.disabled && widget.tapToZoom));
+    if ((widget.item == null || widget.item!.imageId == null) &&
+        widget.imageListenable == null) {
       return ClipRRect(
         borderRadius: borderRadius,
         child: AspectRatio(
           aspectRatio: 1,
           child: Container(
-            decoration: decoration,
+            decoration: widget.decoration,
             child: const _AlbumImageErrorPlaceholder(),
           ),
         ),
       );
     }
 
+    final content = ClipRRect(
+      borderRadius: borderRadius,
+      child: LayoutBuilder(builder: (context, constraints) {
+        var listenable = widget.imageListenable;
+        bool imageScaled = false;
+        if (listenable == null) {
+          // If the current themeing context has a usable image for this item,
+          // use that instead of generating a new request
+          if (ref.watch(localThemeInfoProvider.select((request) =>
+              (request?.largeThemeImage ?? false) &&
+              request?.item == widget.item))) {
+            listenable = localImageProvider;
+          } else {
+            int? physicalWidth;
+            int? physicalHeight;
+            if (widget.autoScale) {
+              imageScaled = true;
+              // LayoutBuilder (and other pixel-related stuff in Flutter) returns logical pixels instead of physical pixels.
+              // While this is great for doing layout stuff, we want to get images that are the right size in pixels.
+              // Logical pixels aren't the same as the physical pixels on the device, they're quite a bit bigger.
+              // If we use logical pixels for the image request, we'll get a smaller image than we want.
+              // Because of this, we convert the logical pixels to physical pixels by multiplying by the device's DPI.
+              final MediaQueryData mediaQuery = MediaQuery.of(context);
+              physicalWidth =
+                  (constraints.maxWidth * mediaQuery.devicePixelRatio).toInt();
+              physicalHeight =
+                  (constraints.maxHeight * mediaQuery.devicePixelRatio).toInt();
+              // If using grid music screen view without fixed size tiles, and if the view is resizable due
+              // to being on desktop and using split screen, then clamp album size to reduce server requests when resizing.
+              if ((!(Platform.isIOS || Platform.isAndroid) ||
+                      usingPlayerSplitScreen) &&
+                  !FinampSettingsHelper.finampSettings.useFixedSizeGridTiles &&
+                  FinampSettingsHelper.finampSettings.contentViewType ==
+                      ContentViewType.grid) {
+                physicalWidth =
+                    exp((log(physicalWidth) * 3).ceil() / 3).toInt();
+                physicalHeight =
+                    exp((log(physicalHeight) * 3).ceil() / 3).toInt();
+              }
+            }
+
+            listenable = albumImageProvider(AlbumImageRequest(
+              item: widget.item!,
+              maxWidth: physicalWidth,
+              maxHeight: physicalHeight,
+            )).select((value) => ThemeImage(value, widget.item?.blurHash));
+          }
+        }
+
+        var image = Container(
+          decoration: widget.decoration,
+          child: BareAlbumImage(
+            imageListenable: listenable,
+            placeholderBuilder: widget.placeholderBuilder,
+            onZoomRoute: widget.onZoomRoute,
+          ),
+        );
+
+        if (widget.tapToZoom) {
+          final largeImage = AlbumImage(
+            item: imageScaled ? widget.item : null,
+            imageListenable: imageScaled ? null : listenable,
+            borderRadius: borderRadius,
+            placeholderBuilder: (_) => image,
+            autoScale: false,
+            tapToZoom: false,
+            onZoomRoute: true,
+          );
+          return MouseRegion(
+            cursor: SystemMouseCursors.click,
+            child: GestureDetector(
+              onTap: () => Navigator.of(context).push(
+                  PageRouteBuilder<_ZoomedImage>(
+                      opaque: false,
+                      barrierDismissible: true,
+                      transitionDuration:
+                          MediaQuery.of(context).disableAnimations
+                              ? Duration.zero
+                              : const Duration(milliseconds: 500),
+                      pageBuilder: (BuildContext context,
+                          Animation<double> animation1,
+                          Animation<double> animation2) {
+                        return _ZoomedImage(albumImage: largeImage, id: zoomID);
+                      })),
+              child: LayoutBuilder(builder: (context, constraints) {
+                return Hero(
+                    tag: zoomID,
+                    createRectTween: (begin, end) =>
+                        RectTween(begin: begin, end: end),
+                    child: image,
+                    placeholderBuilder: (context, heroSize, child) => image,
+                    flightShuttleBuilder:
+                        (overlayContext, _, __, fromContext, ____) =>
+                            largeImage);
+              }),
+            ),
+          );
+        }
+
+        return widget.disabled
+            ? Opacity(
+                opacity: 0.75,
+                child: ColorFiltered(
+                    colorFilter:
+                        const ColorFilter.mode(Colors.black, BlendMode.color),
+                    child: image))
+            : image;
+      }),
+    );
+
     return Semantics(
       // label: item?.name != null ? AppLocalizations.of(context)!.artworkTooltip(item!.name!) : AppLocalizations.of(context)!.artwork, // removed to reduce screen reader verbosity
       excludeSemantics: true,
       child: AspectRatio(
         aspectRatio: 1.0,
-        child: Align(
-          child: ClipRRect(
-            borderRadius: borderRadius,
-            child: LayoutBuilder(builder: (context, constraints) {
-              int? physicalWidth;
-              int? physicalHeight;
-              if (autoScale) {
-                // LayoutBuilder (and other pixel-related stuff in Flutter) returns logical pixels instead of physical pixels.
-                // While this is great for doing layout stuff, we want to get images that are the right size in pixels.
-                // Logical pixels aren't the same as the physical pixels on the device, they're quite a bit bigger.
-                // If we use logical pixels for the image request, we'll get a smaller image than we want.
-                // Because of this, we convert the logical pixels to physical pixels by multiplying by the device's DPI.
-                final MediaQueryData mediaQuery = MediaQuery.of(context);
-                physicalWidth =
-                    (constraints.maxWidth * mediaQuery.devicePixelRatio)
-                        .toInt();
-                physicalHeight =
-                    (constraints.maxHeight * mediaQuery.devicePixelRatio)
-                        .toInt();
-                // If using grid music screen view without fixed size tiles, and if the view is resizable due
-                // to being on desktop and using split screen, then clamp album size to reduce server requests when resizing.
-                if ((!(Platform.isIOS || Platform.isAndroid) ||
-                        usingPlayerSplitScreen) &&
-                    !FinampSettingsHelper
-                        .finampSettings.useFixedSizeGridTiles &&
-                    FinampSettingsHelper.finampSettings.contentViewType ==
-                        ContentViewType.grid) {
-                  physicalWidth =
-                      exp((log(physicalWidth) * 3).ceil() / 3).toInt();
-                  physicalHeight =
-                      exp((log(physicalHeight) * 3).ceil() / 3).toInt();
-                }
-              }
-
-              var listenable = imageListenable;
-              if (listenable == null) {
-                // If the current themeing context has a usable image for this item,
-                // use that instead of generating a new request
-                if (ref.watch(localThemeInfoProvider.select((request) =>
-                    (request?.largeThemeImage ?? false) &&
-                    request?.item == item))) {
-                  listenable = localImageProvider;
-                } else {
-                  listenable = albumImageProvider(AlbumImageRequest(
-                    item: item!,
-                    maxWidth: physicalWidth,
-                    maxHeight: physicalHeight,
-                  )).select((value) => ThemeImage(value, item?.blurHash));
-                }
-              }
-
-              var image = Container(
-                decoration: decoration,
-                child: BareAlbumImage(
-                    imageListenable: listenable,
-                    placeholderBuilder: placeholderBuilder),
-              );
-              return disabled
-                  ? Opacity(
-                      opacity: 0.75,
-                      child: ColorFiltered(
-                          colorFilter: const ColorFilter.mode(
-                              Colors.black, BlendMode.color),
-                          child: image))
-                  : image;
-            }),
-          ),
-        ),
+        child: widget.onZoomRoute
+            ? content
+            : Align(
+                child: content,
+              ),
       ),
     );
   }
@@ -158,12 +220,14 @@ class BareAlbumImage extends ConsumerWidget {
     this.imageProviderCallback,
     this.errorBuilder = defaultErrorBuilder,
     this.placeholderBuilder,
+    required this.onZoomRoute,
   });
 
   final ProviderListenable<ThemeImage> imageListenable;
   final WidgetBuilder? placeholderBuilder;
   final OctoErrorBuilder errorBuilder;
   final ImageProviderCallback? imageProviderCallback;
+  final bool onZoomRoute;
 
   static Widget defaultPlaceholderBuilder(BuildContext context) {
     return Container(color: Theme.of(context).cardColor);
@@ -194,21 +258,19 @@ class BareAlbumImage extends ConsumerWidget {
       if (imageProviderCallback != null) {
         imageProviderCallback!(image);
       }
-      return LayoutBuilder(builder: (context, constraints) {
-        return OctoImage(
-          image: image,
-          filterQuality: FilterQuality.medium,
-          fadeOutDuration: MediaQuery.of(context).disableAnimations
-              ? Duration.zero
-              : const Duration(milliseconds: 300),
-          fadeInDuration: MediaQuery.of(context).disableAnimations
-              ? Duration.zero
-              : const Duration(milliseconds: 300),
-          fit: BoxFit.contain,
-          placeholderBuilder: localPlaceholder,
-          errorBuilder: errorBuilder,
-        );
-      });
+      return OctoImage(
+        image: image,
+        filterQuality: FilterQuality.medium,
+        fadeOutDuration: MediaQuery.of(context).disableAnimations || onZoomRoute
+            ? Duration.zero
+            : const Duration(milliseconds: 300),
+        fadeInDuration: MediaQuery.of(context).disableAnimations || onZoomRoute
+            ? Duration.zero
+            : const Duration(milliseconds: 300),
+        fit: BoxFit.contain,
+        placeholderBuilder: localPlaceholder,
+        errorBuilder: errorBuilder,
+      );
     }
 
     return Builder(builder: localPlaceholder);
@@ -227,96 +289,48 @@ class _AlbumImageErrorPlaceholder extends StatelessWidget {
   }
 }
 
-class TapToZoomImage extends StatefulWidget {
-  final AlbumImage albumImage;
-  final bool isDisabled;
+class _ZoomedImage extends StatelessWidget {
+  final Widget albumImage;
+  final String id;
 
-  const TapToZoomImage({
+  const _ZoomedImage({
     super.key,
     required this.albumImage,
-    this.isDisabled = false,
-  });
-
-  @override
-  _TapToZoomImageState createState() => _TapToZoomImageState();
-}
-
-final zoomedImageHeroTag = "zoomed-image";
-
-class _TapToZoomImageState extends State<TapToZoomImage> {
-  @override
-  Widget build(BuildContext context) {
-    if (widget.isDisabled) {
-      return widget.albumImage;
-    }
-
-    return MouseRegion(
-      cursor: SystemMouseCursors.click,
-      child: GestureDetector(
-        onTap: () => Navigator.of(context).push(PageRouteBuilder<ZoomedImage>(
-            opaque: false,
-            barrierDismissible: true,
-            transitionDuration: MediaQuery.of(context).disableAnimations
-                ? Duration.zero
-                : const Duration(milliseconds: 500),
-            pageBuilder: (BuildContext context, Animation<double> animation1,
-                Animation<double> animation2) {
-              return ZoomedImage(albumImage: widget.albumImage);
-            })),
-        child: Hero(
-          tag: zoomedImageHeroTag,
-          child: widget.albumImage,
-          placeholderBuilder: (context, heroSize, child) => widget.albumImage,
-        ),
-      ),
-    );
-  }
-}
-
-class ZoomedImage extends StatelessWidget {
-  final AlbumImage albumImage;
-
-  const ZoomedImage({
-    super.key,
-    required this.albumImage,
+    required this.id,
   });
 
   @override
   Widget build(BuildContext context) {
-    return SafeArea( 
-      child: Stack(
-        children: [
-          Positioned.fill(
-            child: IgnorePointer(
-              child: Container(
-                color: Colors.black.withOpacity(0.5),
-                child: BackdropFilter(
-                  filter: ImageFilter.blur(sigmaX: 5.0, sigmaY: 5.0),
-                  child: Container(),
-                ),
+    return Stack(
+      children: [
+        Positioned.fill(
+          child: IgnorePointer(
+            child: Container(
+              color: Colors.black.withOpacity(0.5),
+              child: BackdropFilter(
+                filter: ImageFilter.blur(sigmaX: 5.0, sigmaY: 5.0),
+                child: Container(),
               ),
             ),
           ),
-          Center(
-              child: Dismissible(
-            key: const Key("zoomed-image-dismiss"),
-            direction: DismissDirection.vertical,
-            onDismissed: (direction) {
-              Navigator.of(context).pop();
-            },
-            child: InteractiveViewer(
-              constrained: true,
-              panEnabled: true,
-              clipBehavior: Clip.none,
-              child: Hero(
-                tag: zoomedImageHeroTag,
-                child: albumImage,
-              ),
+        ),
+        Center(
+          child: InteractiveViewer(
+            constrained: true,
+            panEnabled: true,
+            clipBehavior: Clip.none,
+            child: Hero(
+              tag: id,
+              createRectTween: (begin, end) =>
+                  RectTween(begin: begin, end: end),
+              child: albumImage,
             ),
-          )),
-          Positioned(
-            top: 4,
-            right: 8,
+          ),
+        ),
+        Positioned(
+          top: 4,
+          right: 8,
+          child: SafeArea(
             child: IconButton(
               icon: const Icon(TablerIcons.x),
               color: Colors.white,
@@ -326,8 +340,8 @@ class ZoomedImage extends StatelessWidget {
               },
             ),
           ),
-        ],
-      ),
+        ),
+      ],
     );
   }
 }


### PR DESCRIPTION
Cleans up a couple of issues I noticed with the image zoom feature, primarily that a new resized image will be requested from the server for every frame in the transition animation.  Also:
- Use existing small image as placeholder for zoomed image during transition and while zoomed.
- Don't animate between images on unrelated routes.
- Linear transition animation.
- Always use maximum image resolution when zoomed.
- Removed dismiss gesture because it interfered with zooming and you can already both click outside the image or use the system back gesture.