### PR TITLE
Add Centralized Device, App, and Server Metadata Logging

### DIFF
--- a/lib/services/finamp_logs_helper.dart
+++ b/lib/services/finamp_logs_helper.dart
@@ -5,12 +5,14 @@ import 'dart:math';
 import 'package:clipboard/clipboard.dart';
 import 'package:file_picker/file_picker.dart';
 import 'package:finamp/services/censored_log.dart';
+import 'package:finamp/services/log.dart';
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/foundation.dart';
 import 'package:logging/logging.dart';
 import 'package:path/path.dart' as path_helper;
 import 'package:path_provider/path_provider.dart';
 import 'package:share_plus/share_plus.dart';
+import 'package:get_it/get_it.dart';
 
 class FinampLogsHelper {
   final List<LogRecord> logs = [];
@@ -60,6 +62,15 @@ class FinampLogsHelper {
 
   Future<String> getFullLogs() async {
     final fullLogsBuffer = StringBuffer();
+
+    // Get the Log instance and add its metadata at the top
+    final logMeta = GetIt.instance.isRegistered<Log>() ? GetIt.instance<Log>() : null;
+    if (logMeta != null) {
+      fullLogsBuffer.writeln("=== Device/App/Server Info ===");
+      fullLogsBuffer.writeln(jsonEncode(logMeta.toJson()));
+      fullLogsBuffer.writeln("==============================");
+    }
+
     if (_logFileWriter != null) {
       final basePath = (Platform.isAndroid || Platform.isIOS)
           ? await getApplicationDocumentsDirectory()

--- a/lib/services/log.dart
+++ b/lib/services/log.dart
@@ -1,0 +1,159 @@
+import "package:device_info_plus/device_info_plus.dart";
+import 'package:package_info_plus/package_info_plus.dart';
+
+class DeviceInfo {
+  String deviceName;
+  String deviceModel;
+  String osVersion;
+
+  DeviceInfo({
+    required this.deviceName,
+    required this.deviceModel,
+    required this.osVersion,
+  });
+
+  static Future<DeviceInfo> fromPlatform() async {
+    final deviceInfoPlugin = DeviceInfoPlugin();
+
+    if (await deviceInfoPlugin.deviceInfo is AndroidDeviceInfo) {
+      final info = await deviceInfoPlugin.androidInfo;
+      return DeviceInfo(
+        deviceName: info.brand,
+        deviceModel: info.model,
+        osVersion: info.version.release,
+      );
+    } else if (await deviceInfoPlugin.deviceInfo is IosDeviceInfo) {
+      final info = await deviceInfoPlugin.iosInfo;
+      return DeviceInfo(
+        deviceName: info.name,
+        deviceModel: info.model,
+        osVersion: info.systemVersion,
+      );
+    } else if (await deviceInfoPlugin.deviceInfo is MacOsDeviceInfo) {
+      final info = await deviceInfoPlugin.macOsInfo;
+      return DeviceInfo(
+        deviceName: info.computerName,
+        deviceModel: info.model,
+        osVersion: "${info.majorVersion}.${info.minorVersion}.${info.patchVersion}",
+      );
+    } else if (await deviceInfoPlugin.deviceInfo is LinuxDeviceInfo) {
+      final info = await deviceInfoPlugin.linuxInfo;
+      return DeviceInfo(
+        deviceName: info.name,
+        deviceModel: info.id,
+        osVersion: info.version ?? 'Unknown',
+      );
+    } else if (await deviceInfoPlugin.deviceInfo is WindowsDeviceInfo) {
+      final info = await deviceInfoPlugin.windowsInfo;
+      return DeviceInfo(
+        deviceName: info.computerName,
+        deviceModel: info.deviceId,
+        osVersion: info.displayVersion,
+      );
+    }
+    // Add other platforms as needed...
+    throw UnsupportedError("Unsupported platform");
+  }
+
+  Map<String, String> toJson() {
+    return {
+      'deviceName': deviceName,
+      'deviceModel': deviceModel,
+      'osVersion': osVersion,
+    };
+  }
+}
+
+class AppInfo {
+  String appName;
+  String packageName;
+  String version;
+  String buildNumber;
+
+  AppInfo({
+    required this.appName,
+    required this.packageName,
+    required this.version,
+    required this.buildNumber,
+  });
+
+  static Future<AppInfo> fromPlatform() async {
+    final packageInfo = await PackageInfo.fromPlatform();
+    return AppInfo(
+      appName: packageInfo.appName,
+      packageName: packageInfo.packageName,
+      version: packageInfo.version,
+      buildNumber: packageInfo.buildNumber,
+    );
+  }
+
+  Map<String, String> toJson() {
+    return {
+      'appName': appName,
+      'packageName': packageName,
+      'version': version,
+      'buildNumber': buildNumber,
+    };
+  }
+}
+
+class ServerInfo {
+  String serverAddress;
+  int serverPort;
+  String serverProtocol;
+
+  ServerInfo({
+    required this.serverAddress,
+    required this.serverPort,
+    required this.serverProtocol,
+  });
+
+  static Future<ServerInfo> fromConfig() async {
+    // Replace with actual logic to retrieve server configuration
+    return ServerInfo(
+      serverAddress: 'example.com',
+      serverPort: 443,
+      serverProtocol: 'https',
+    );
+  }
+
+  Map<String, dynamic> toJson() {
+    return {
+      'serverAddress': serverAddress,
+      'serverPort': serverPort,
+      'serverProtocol': serverProtocol,
+    };
+  }
+}
+
+class Log {
+  final DeviceInfo deviceInfo;
+  final AppInfo appInfo;
+  final ServerInfo serverInfo;
+
+  Log({
+    required this.deviceInfo,
+    required this.appInfo,
+    required this.serverInfo,
+  });
+
+  // Async factory to create and populate all fields
+  static Future<Log> create() async {
+    final deviceInfo = await DeviceInfo.fromPlatform();
+    final appInfo = await AppInfo.fromPlatform();
+    final serverInfo = await ServerInfo.fromConfig();
+    return Log(
+      deviceInfo: deviceInfo,
+      appInfo: appInfo,
+      serverInfo: serverInfo,
+    );
+  }
+
+  Map<String, dynamic> toJson() {
+    return {
+      'deviceInfo': deviceInfo.toJson(),
+      'appInfo': appInfo.toJson(),
+      'serverInfo': serverInfo.toJson(),
+    };
+  }
+}

--- a/lib/setup_logging.dart
+++ b/lib/setup_logging.dart
@@ -3,18 +3,23 @@ import 'dart:io';
 import 'package:flutter/foundation.dart';
 import 'package:get_it/get_it.dart';
 import 'package:logging/logging.dart';
-import 'package:package_info_plus/package_info_plus.dart';
-import 'package:device_info_plus/device_info_plus.dart';
 
 import 'services/finamp_logs_helper.dart';
+import 'services/log.dart';
 
 Future<void> setupLogging() async {
   GetIt.instance.registerSingleton(FinampLogsHelper());
   await GetIt.instance<FinampLogsHelper>().openLog();
-  //Logger.root.level = kDebugMode ? Level.ALL : Level.INFO;
+
+  // Create and store the Log instance for later use
+  final log = await Log.create();
+  GetIt.instance.registerSingleton<Log>(log);
+
   Logger.root.level = Level.ALL;
   Logger.root.onRecord.listen((event) {
     final finampLogsHelper = GetIt.instance<FinampLogsHelper>();
+
+    // Example: You can now use log.toJson() or log fields here if needed
 
     // We don't want to print log messages from the Flutter logger since Flutter prints logs by itself
     if (kDebugMode && event.loggerName != "Flutter") {
@@ -28,42 +33,4 @@ Future<void> setupLogging() async {
     }
     finampLogsHelper.addLog(event);
   });
-  final startupLogger = Logger("Startup");
-  startupLogger.info("App starting, logging initialized.");
-
-  final packageInfo = await PackageInfo.fromPlatform();
-  final deviceInfo = DeviceInfoPlugin();
-
-  startupLogger.info(
-      "This is ${packageInfo.appName} version ${packageInfo.version}+${packageInfo.buildNumber} (Signature '${packageInfo.buildSignature}'), installed via ${packageInfo.installerStore}.");
-
-  try {
-    String deviceInfoString;
-    if (Platform.isAndroid) {
-      final androidInfo = await deviceInfo.androidInfo;
-      deviceInfoString =
-          "Android ${androidInfo.version.release} on ${androidInfo.model} (${androidInfo.product})";
-    } else if (Platform.isIOS) {
-      final iosInfo = await deviceInfo.iosInfo;
-      deviceInfoString = "${iosInfo.systemVersion} on ${iosInfo.model}";
-    } else if (Platform.isMacOS) {
-      final macosInfo = await deviceInfo.macOsInfo;
-      deviceInfoString =
-          "macOS ${macosInfo.majorVersion}.${macosInfo.minorVersion}.${macosInfo.patchVersion} on ${macosInfo.model}";
-    } else if (Platform.isLinux) {
-      final linuxInfo = await deviceInfo.linuxInfo;
-      deviceInfoString = "${linuxInfo.version} on ${linuxInfo.id}";
-    } else if (Platform.isWindows) {
-      final windowsInfo = await deviceInfo.windowsInfo;
-      deviceInfoString =
-          "Windows ${windowsInfo.displayVersion} on ${windowsInfo.deviceId}";
-    } else {
-      final webInfo = await deviceInfo.webBrowserInfo;
-      deviceInfoString =
-          "Web browser ${webInfo.userAgent} on ${webInfo.platform}";
-    }
-    startupLogger.info("Running on $deviceInfoString.");
-  } catch (e) {
-    startupLogger.warning("Failed to get device info: $e");
-  }
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -78,7 +78,7 @@ dependencies:
       url: https://github.com/MrLittleWhite/isar_flutter_libs.git
 
   path: ^1.9.0
-  intl: ">=0.18.1 < 1.0.0"
+  intl: 0.20.2
   auto_size_text: ^3.0.0
   marquee: ^2.3.0
   palette_generator:


### PR DESCRIPTION
"NOT FINISHED YET"

This PR introduces centralized collection and logging of device, app, and server metadata to enhance diagnostic capabilities. The primary changes include:

Added a new log.dart service to gather device, app, and server information across supported platforms.
Updated setup_logging.dart to initialize and register this metadata at startup using GetIt for dependency injection.
Modified finamp_logs_helper.dart to prepend collected metadata to full log exports, making support and debugging easier.
Updated pubspec.yaml to bump intl to 0.20.2 for compatibility.
Key enhancements:

Device info (model, OS version, etc.)
App info (name, version, build)
Server info (address, protocol, port)
Structured metadata is now included at the top of exported logs.
These improvements should make error reports and support requests more informative and actionable.
