### PR TITLE
[Redesign] Use system title bar on wayland

### DIFF
--- a/linux/my_application.cc
+++ b/linux/my_application.cc
@@ -25,8 +25,7 @@ static void my_application_activate(GApplication* application) {
   // desktop).
   // If running on X and not using GNOME then just use a traditional title bar
   // in case the window manager does more exotic layout, e.g. tiling.
-  // If running on Wayland assume the header bar will work (may need changing
-  // if future cases occur).
+  // If running on Wayland always use a title bar because I don't know how to check the WM
   gboolean use_header_bar = TRUE;
 #ifdef GDK_WINDOWING_X11
   GdkScreen* screen = gtk_window_get_screen(window);
@@ -35,6 +34,8 @@ static void my_application_activate(GApplication* application) {
     if (g_strcmp0(wm_name, "GNOME Shell") != 0) {
       use_header_bar = FALSE;
     }
+  }else{
+      use_header_bar = FALSE;
   }
 #endif
   if (use_header_bar) {

--- a/linux/my_application.cc
+++ b/linux/my_application.cc
@@ -26,16 +26,14 @@ static void my_application_activate(GApplication* application) {
   // If running on X and not using GNOME then just use a traditional title bar
   // in case the window manager does more exotic layout, e.g. tiling.
   // If running on Wayland always use a title bar because I don't know how to check the WM
-  gboolean use_header_bar = TRUE;
+  gboolean use_header_bar = FALSE;
 #ifdef GDK_WINDOWING_X11
   GdkScreen* screen = gtk_window_get_screen(window);
   if (GDK_IS_X11_SCREEN(screen)) {
     const gchar* wm_name = gdk_x11_screen_get_window_manager_name(screen);
-    if (g_strcmp0(wm_name, "GNOME Shell") != 0) {
-      use_header_bar = FALSE;
+    if (g_strcmp0(wm_name, "GNOME Shell") == 0) {
+      use_header_bar = TRUE;
     }
-  }else{
-      use_header_bar = FALSE;
   }
 #endif
   if (use_header_bar) {


### PR DESCRIPTION
This makes Finamp use the system title bar when on wayland.  It seems to work on KDE, someone should test what this looks like on GNOME because it sounds like they have some unusual behaviour related to window decorations on wayland.