### PR TITLE
[Redesign] Improve error handling

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -113,7 +113,7 @@ void main() async {
     _mainLog.info("Setup offline listen tracking");
     await _setupDownloadsHelper();
     _mainLog.info("Setup downloads service");
-    _setupProviders();
+    await _setupProviders();
     _mainLog.info("Setup providers");
     await _setupOSIntegration();
     _mainLog.info("Setup os integrations");
@@ -139,6 +139,12 @@ void main() async {
       }
       FlutterError.presentError(details);
       flutterLogger.severe(error, error, details.stack);
+    };
+
+    PlatformDispatcher.instance.onError = (error,stack){
+      flutterLogger.severe(error, error, stack);
+      // We have not handled printing to console, flutter should still do that.
+      return false;
     };
 
     DartPluginRegistrant.ensureInitialized();
@@ -281,10 +287,12 @@ Future<void> setupHive() async {
   GetIt.instance.registerSingleton(isar);
 }
 
-void _setupProviders() {
-  var container = ProviderContainer();
+Future<void> _setupProviders() async {
+  var container = ProviderContainer(observers: [FinampProviderObserver()]);
   GetIt.instance.registerSingleton<ProviderContainer>(container);
+  // Make sure that finampSettingsProvider always has a value available
   container.listen(finampSettingsProvider, (_, __) {});
+  await container.read(finampSettingsProvider.future);
 
   DataSourceService.create();
   AutoOffline.startWatching();
@@ -877,5 +885,17 @@ class NoTransitionPageTransitionsBuilder extends PageTransitionsBuilder {
     Widget child,
   ) {
     return child;
+  }
+}
+
+class FinampProviderObserver extends ProviderObserver{
+  @override
+  void providerDidFail(
+      ProviderBase<Object?> provider,
+      Object error,
+      StackTrace stackTrace,
+      ProviderContainer container,
+      ) {
+    GlobalSnackbar.error(error);
   }
 }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -141,7 +141,7 @@ void main() async {
       flutterLogger.severe(error, error, details.stack);
     };
 
-    PlatformDispatcher.instance.onError = (error,stack){
+    PlatformDispatcher.instance.onError = (error, stack) {
       flutterLogger.severe(error, error, stack);
       // We have not handled printing to console, flutter should still do that.
       return false;
@@ -888,14 +888,14 @@ class NoTransitionPageTransitionsBuilder extends PageTransitionsBuilder {
   }
 }
 
-class FinampProviderObserver extends ProviderObserver{
+class FinampProviderObserver extends ProviderObserver {
   @override
   void providerDidFail(
-      ProviderBase<Object?> provider,
-      Object error,
-      StackTrace stackTrace,
-      ProviderContainer container,
-      ) {
+    ProviderBase<Object?> provider,
+    Object error,
+    StackTrace stackTrace,
+    ProviderContainer container,
+  ) {
     GlobalSnackbar.error(error);
   }
 }

--- a/lib/services/jellyfin_api_helper.dart
+++ b/lib/services/jellyfin_api_helper.dart
@@ -7,6 +7,7 @@ import 'package:chopper/chopper.dart';
 import 'package:collection/collection.dart';
 import 'package:finamp/components/global_snackbar.dart';
 import 'package:finamp/services/http_aggregate_logging_interceptor.dart';
+import 'package:flutter/scheduler.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:get_it/get_it.dart';
@@ -229,7 +230,7 @@ class JellyfinApiHelper {
       return QueryResult_BaseItemDto(
           totalRecordCount: 0, startIndex: 0, items: []);
     }
-    assert(!FinampSettingsHelper.finampSettings.isOffline);
+    assert(_verifyCallable());
     assert(itemIds == null || parentItem == null);
     fields ??=
         defaultFields; // explicitly set the default fields, if we pass `null` to [JellyfinAPI.getItems] it will **not** apply the default fields, since the argument *is* provided.
@@ -418,7 +419,7 @@ class JellyfinApiHelper {
       // use.
       return [];
     }
-    assert(!FinampSettingsHelper.finampSettings.isOffline);
+    assert(_verifyCallable());
     fields ??=
         defaultFields; // explicitly set the default fields, if we pass `null` to [JellyfinAPI.getItems] it will **not** apply the default fields, since the argument *is* provided.
 
@@ -458,7 +459,7 @@ class JellyfinApiHelper {
     int? limit,
     String? fields,
   }) async {
-    assert(!FinampSettingsHelper.finampSettings.isOffline);
+    assert(_verifyCallable());
 
     fields ??= defaultFields;
 
@@ -629,7 +630,7 @@ class JellyfinApiHelper {
   /// Gets the playback info for an item, such as format and bitrate. Usually, I'd require a BaseItemDto as an argument
   /// but since this will be run inside of [MusicPlayerBackgroundTask], I've just set the raw id as an argument.
   Future<List<MediaSourceInfo>?> getPlaybackInfo(BaseItemId itemId) async {
-    assert(!FinampSettingsHelper.finampSettings.isOffline);
+    assert(_verifyCallable());
     var response = await jellyfinApi.getPlaybackInfo(
       id: itemId,
       userId: _finampUserHelper.currentUser!.id,
@@ -700,7 +701,7 @@ class JellyfinApiHelper {
 
   /// Gets an item from a user's library.
   Future<BaseItemDto> getItemById(BaseItemId itemId) async {
-    assert(!FinampSettingsHelper.finampSettings.isOffline);
+    assert(_verifyCallable());
     final response = await jellyfinApi.getItemById(
       userId: _finampUserHelper.currentUser!.id,
       itemId: itemId,
@@ -715,7 +716,7 @@ class JellyfinApiHelper {
   /// Gets an item from a user's library, batching with other request coming in around the same time.
   Future<BaseItemDto?> getItemByIdBatched(BaseItemId itemId,
       [String? fields]) async {
-    assert(!FinampSettingsHelper.finampSettings.isOffline);
+    assert(_verifyCallable());
     fields ??=
         defaultFields; // explicitly set the default fields, if we pass `null` to [JellyfinAPI.getItems] it will **not** apply the default fields, since the argument *is* provided.
     _getItemByIdBatchedRequests.add(itemId);
@@ -817,7 +818,7 @@ class JellyfinApiHelper {
 
   /// Marks an item as a favorite.
   Future<UserItemDataDto> addFavorite(BaseItemId itemId) async {
-    assert(!FinampSettingsHelper.finampSettings.isOffline);
+    assert(_verifyCallable());
     final response = await jellyfinApi.addFavorite(
         userId: _finampUserHelper.currentUser!.id, itemId: itemId);
 
@@ -832,7 +833,7 @@ class JellyfinApiHelper {
 
   /// Unmarks item as a favorite.
   Future<UserItemDataDto> removeFavorite(BaseItemId itemId) async {
-    assert(!FinampSettingsHelper.finampSettings.isOffline);
+    assert(_verifyCallable());
     final response = await jellyfinApi.removeFavorite(
         userId: _finampUserHelper.currentUser!.id, itemId: itemId);
 
@@ -1187,4 +1188,17 @@ class JellyfinApiHelper {
       return false;
     });
   });
+}
+
+/// Verify that we are in an appropriate location to make API calls.
+/// This should only be called inside assert() to prevent running in release mode.
+bool _verifyCallable() {
+  if(FinampSettingsHelper.finampSettings.isOffline) return false;
+  // Verify that all calls to jellyfin occur either in background async calls,
+  // initState methods, or providers.
+  if(SchedulerBinding.instance.schedulerPhase == SchedulerPhase.idle) return true;
+  var stack=StackTrace.current
+      .toString();
+  if(stack.contains('ProviderContainer.readProviderElement')||stack.contains('initState')) return true;
+  return false;
 }

--- a/lib/services/jellyfin_api_helper.dart
+++ b/lib/services/jellyfin_api_helper.dart
@@ -1193,12 +1193,19 @@ class JellyfinApiHelper {
 /// Verify that we are in an appropriate location to make API calls.
 /// This should only be called inside assert() to prevent running in release mode.
 bool _verifyCallable() {
-  if(FinampSettingsHelper.finampSettings.isOffline) return false;
+  if (FinampSettingsHelper.finampSettings.isOffline) {
+    return false;
+  }
   // Verify that all calls to jellyfin occur either in background async calls,
   // initState methods, or providers.
-  if(SchedulerBinding.instance.schedulerPhase == SchedulerPhase.idle) return true;
-  var stack=StackTrace.current
-      .toString();
-  if(stack.contains('ProviderContainer.readProviderElement')||stack.contains('initState')) return true;
+  if (SchedulerBinding.instance.schedulerPhase == SchedulerPhase.idle) {
+    return true;
+  }
+  var stack = StackTrace.current.toString();
+  if (stack.contains('ProviderContainer.readProviderElement') ||
+      stack.contains('initState') ||
+      stack.contains('didChangeDependencies')) {
+    return true;
+  }
   return false;
 }

--- a/lib/setup_logging.dart
+++ b/lib/setup_logging.dart
@@ -1,5 +1,6 @@
 import 'dart:io';
 
+import 'package:finamp/components/global_snackbar.dart';
 import 'package:flutter/foundation.dart';
 import 'package:get_it/get_it.dart';
 import 'package:logging/logging.dart';
@@ -25,6 +26,10 @@ Future<void> setupLogging() async {
         event.loggerName != "Flutter" &&
         event.stackTrace != null) {
       debugPrintStack(stackTrace: event.stackTrace);
+    }
+    // Make sure asserts are extra visible when debugging
+    if(kDebugMode && event.object is AssertionError){
+      GlobalSnackbar.message((_)=>event.object.toString());
     }
     finampLogsHelper.addLog(event);
   });

--- a/lib/setup_logging.dart
+++ b/lib/setup_logging.dart
@@ -28,8 +28,8 @@ Future<void> setupLogging() async {
       debugPrintStack(stackTrace: event.stackTrace);
     }
     // Make sure asserts are extra visible when debugging
-    if(kDebugMode && event.object is AssertionError){
-      GlobalSnackbar.message((_)=>event.object.toString());
+    if (kDebugMode && event.object is AssertionError) {
+      GlobalSnackbar.message((_) => event.object.toString());
     }
     finampLogsHelper.addLog(event);
   });


### PR DESCRIPTION
Stop riverpod from eating errors inside providers.  Prevent error during AutoOffline.startWatching from the settings provider not being fully initialized.  Properly log errors that occur outside of flutter stack frames.  Always create snackbar for assert failures to reduce the chance that they're missed while debugging.  Throw assert error if jellyfin api calls occur during widget build().