### PR TITLE
[Redesign] Add setting to ignore OS stop commands

### DIFF
--- a/lib/components/global_snackbar.dart
+++ b/lib/components/global_snackbar.dart
@@ -1,10 +1,10 @@
 import 'dart:async';
 
 import 'package:chopper/chopper.dart';
+import 'package:finamp/l10n/app_localizations.dart';
 import 'package:finamp/services/feedback_helper.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/scheduler.dart';
-import 'package:finamp/l10n/app_localizations.dart';
 import 'package:logging/logging.dart';
 
 @Deprecated("Use GlobalSnackbar.error(dynamic error) instead")
@@ -83,9 +83,6 @@ class GlobalSnackbar {
   static void error(dynamic event) => _enqueue(() => _error(event));
   static void _error(dynamic event) {
     _logger.warning("Displaying error: $event", event);
-    if (event is Error && event.stackTrace != null) {
-      _logger.warning(event.stackTrace);
-    }
     BuildContext context = materialAppNavigatorKey.currentContext!;
     String errorText;
     if (event is Response) {

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -2498,6 +2498,14 @@
   "@autoReloadQueueSubtitle": {
     "description": "Subtitle for the setting that controls if the queue is automatically reloaded when the source changes"
   },
+  "ignoreExternalStopTitle": "Ignore External Stop",
+  "@ignoreExternalStopTitle": {
+    "description": "Title for the setting that controls if external stop commands are ignored."
+  },
+  "ignoreExternalStopSubtitle": "Ignore audio 'stop' commands sent by the OS.  Only in-app gestures will stop playback and clear the queue.",
+  "@ignoreExternalStopSubtitle": {
+    "description": "Subtitle for the setting that controls if external stop commands are ignored."
+  },
   "autoReloadPrompt": "Reload queue to apply new {type, select, network{network settings} transcoding{transcoding settings} other{settings}}",
   "@autoReloadPrompt": {
     "description": "Prompt shown when the queue needs to be reloaded after changing network settings",

--- a/lib/models/finamp_models.dart
+++ b/lib/models/finamp_models.dart
@@ -212,6 +212,7 @@ class DefaultSettings {
   static const playlistTracksSortBy = SortBy.defaultOrder;
   static const playlistTracksSortOrder = SortOrder.ascending;
   static const genreFilterPlaylists = false;
+  static const ignoreExternalStopCommands = false;
 }
 
 @HiveType(typeId: 28)
@@ -327,6 +328,7 @@ class FinampSettings {
     this.playlistTracksSortBy = DefaultSettings.playlistTracksSortBy,
     this.playlistTracksSortOrder = DefaultSettings.playlistTracksSortOrder,
     this.genreFilterPlaylists = DefaultSettings.genreFilterPlaylists,
+    this.ignoreExternalStopCommands = DefaultSettings.ignoreExternalStopCommands,
   });
 
   @HiveField(0, defaultValue: DefaultSettings.isOffline)
@@ -688,6 +690,9 @@ class FinampSettings {
 
   @HiveField(116)
   SleepTimer? sleepTimer;
+
+  @HiveField(117, defaultValue: DefaultSettings.ignoreExternalStopCommands)
+  bool ignoreExternalStopCommands;
 
   static Future<FinampSettings> create() async {
     final downloadLocation = await DownloadLocation.create(

--- a/lib/models/finamp_models.g.dart
+++ b/lib/models/finamp_models.g.dart
@@ -219,6 +219,7 @@ class FinampSettingsAdapter extends TypeAdapter<FinampSettings> {
       playlistTracksSortBy: fields[113] == null ? SortBy.defaultOrder : fields[113] as SortBy,
       playlistTracksSortOrder: fields[114] == null ? SortOrder.ascending : fields[114] as SortOrder,
       genreFilterPlaylists: fields[115] == null ? false : fields[115] as bool,
+      ignoreExternalStopCommands: fields[117] == null ? false : fields[117] as bool,
     )
       ..disableGesture = fields[19] == null ? false : fields[19] as bool
       ..showFastScroller = fields[25] == null ? true : fields[25] as bool
@@ -230,7 +231,7 @@ class FinampSettingsAdapter extends TypeAdapter<FinampSettings> {
   @override
   void write(BinaryWriter writer, FinampSettings obj) {
     writer
-      ..writeByte(110)
+      ..writeByte(111)
       ..writeByte(0)
       ..write(obj.isOffline)
       ..writeByte(1)
@@ -450,7 +451,9 @@ class FinampSettingsAdapter extends TypeAdapter<FinampSettings> {
       ..writeByte(115)
       ..write(obj.genreFilterPlaylists)
       ..writeByte(116)
-      ..write(obj.sleepTimer);
+      ..write(obj.sleepTimer)
+      ..writeByte(117)
+      ..write(obj.ignoreExternalStopCommands);
   }
 
   @override

--- a/lib/screens/audio_service_settings_screen.dart
+++ b/lib/screens/audio_service_settings_screen.dart
@@ -47,6 +47,7 @@ class _AudioServiceSettingsScreenState extends State<AudioServiceSettingsScreen>
           BufferDisableSizeConstraintsSelector(key: _updateChildren),
           const LoadQueueOnStartupSelector(),
           const AutoReloadQueueToggle(),
+          const IgnoreExternalStopToggle(),
         ],
       ),
     );
@@ -186,6 +187,20 @@ class AutoReloadQueueToggle extends ConsumerWidget {
       subtitle: Text(AppLocalizations.of(context)!.autoReloadQueueSubtitle),
       value: ref.watch(finampSettingsProvider.autoReloadQueue),
       onChanged: FinampSetters.setAutoReloadQueue,
+    );
+  }
+}
+
+class IgnoreExternalStopToggle extends ConsumerWidget {
+  const IgnoreExternalStopToggle({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    return SwitchListTile.adaptive(
+      title: Text(AppLocalizations.of(context)!.ignoreExternalStopTitle),
+      subtitle: Text(AppLocalizations.of(context)!.ignoreExternalStopSubtitle),
+      value: ref.watch(finampSettingsProvider.ignoreExternalStopCommands),
+      onChanged: FinampSetters.setIgnoreExternalStopCommands,
     );
   }
 }

--- a/lib/services/censored_log.dart
+++ b/lib/services/censored_log.dart
@@ -9,7 +9,18 @@ import 'finamp_user_helper.dart';
 extension CensoredMessage on LogRecord {
   /// The uncensored log string to be shown to the user
   String get logString =>
-      "[$loggerName/${level.name}] $time: $message${stackTrace == null ? "" : "\n${stackTrace.toString()}"}";
+      "[$loggerName/${level.name}] $time: $message${getStack == null ? "" : "\n${getStack.toString()}"}";
+
+  StackTrace? get getStack {
+    var stack = stackTrace;
+    if (error is Error) {
+      stack ??= (error as Error).stackTrace;
+    }
+    if (object is Error) {
+      stack ??= (object as Error).stackTrace;
+    }
+    return stack;
+  }
 
   String get loginCensoredMessage => containsLogin ? "LOGIN BODY" : message;
 

--- a/lib/services/finamp_settings_helper.g.dart
+++ b/lib/services/finamp_settings_helper.g.dart
@@ -649,6 +649,12 @@ extension FinampSetters on FinampSettingsHelper {
     Hive.box<FinampSettings>("FinampSettings").put("FinampSettings", finampSettingsTemp);
   }
 
+  static void setIgnoreExternalStopCommands(bool newIgnoreExternalStopCommands) {
+    FinampSettings finampSettingsTemp = FinampSettingsHelper.finampSettings;
+    finampSettingsTemp.ignoreExternalStopCommands = newIgnoreExternalStopCommands;
+    Hive.box<FinampSettings>("FinampSettings").put("FinampSettings", finampSettingsTemp);
+  }
+
   static void setBufferDuration(Duration newBufferDuration) {
     FinampSettings finampSettingsTemp = FinampSettingsHelper.finampSettings;
     finampSettingsTemp.bufferDuration = newBufferDuration;
@@ -869,6 +875,8 @@ extension FinampSettingsProviderSelectors on StreamProvider<FinampSettings> {
       finampSettingsProvider.select((value) => value.requireValue.genreFilterPlaylists);
   ProviderListenable<SleepTimer?> get sleepTimer =>
       finampSettingsProvider.select((value) => value.requireValue.sleepTimer);
+  ProviderListenable<bool> get ignoreExternalStopCommands =>
+      finampSettingsProvider.select((value) => value.requireValue.ignoreExternalStopCommands);
   ProviderListenable<DownloadProfile> get downloadTranscodingProfile =>
       finampSettingsProvider.select((value) => value.requireValue.downloadTranscodingProfile);
   ProviderListenable<DownloadLocation> get internalTrackDir =>

--- a/lib/services/music_player_background_task.dart
+++ b/lib/services/music_player_background_task.dart
@@ -550,19 +550,12 @@ class MusicPlayerBackgroundTask extends BaseAudioHandler {
   @override
   Future<void> stop() async {
     try {
-      _audioServiceBackgroundTaskLogger.info("Stopping audio service");
+      _audioServiceBackgroundTaskLogger.info("Audio service received stop command");
+
+      if (FinampSettingsHelper.finampSettings.ignoreExternalStopCommands) return;
 
       final queueService = GetIt.instance<QueueService>();
       await queueService.stopPlayback();
-      // await _player.seek(_player.duration);
-
-      // await handleEndOfQueue();
-
-      // TODO: Do we want to actually cancel the sleep timer if we stop the music?
-      _timer.value?.cancel();
-      _timer.value = null;
-
-      await super.stop();
     } catch (e) {
       _audioServiceBackgroundTaskLogger.severe(e);
       return Future.error(e);
@@ -571,6 +564,10 @@ class MusicPlayerBackgroundTask extends BaseAudioHandler {
 
   Future<void> stopPlayback() async {
     try {
+      // TODO: Do we want to actually cancel the sleep timer if we stop the music?
+      _timer.value?.cancel();
+      _timer.value = null;
+
       await _player.stop();
     } catch (e) {
       _audioServiceBackgroundTaskLogger.severe(e);

--- a/lib/setup_logging.dart
+++ b/lib/setup_logging.dart
@@ -1,11 +1,12 @@
 import 'dart:io';
 
+import 'package:device_info_plus/device_info_plus.dart';
 import 'package:finamp/components/global_snackbar.dart';
+import 'package:finamp/services/censored_log.dart';
 import 'package:flutter/foundation.dart';
 import 'package:get_it/get_it.dart';
 import 'package:logging/logging.dart';
 import 'package:package_info_plus/package_info_plus.dart';
-import 'package:device_info_plus/device_info_plus.dart';
 
 import 'services/finamp_logs_helper.dart';
 
@@ -21,8 +22,8 @@ Future<void> setupLogging() async {
     if (kDebugMode && event.loggerName != "Flutter") {
       debugPrint("[${event.loggerName}/${event.level.name}] ${event.time}: ${event.message}");
     }
-    if (kDebugMode && event.loggerName != "Flutter" && event.stackTrace != null) {
-      debugPrintStack(stackTrace: event.stackTrace);
+    if (kDebugMode && event.loggerName != "Flutter" && event.getStack != null) {
+      debugPrintStack(stackTrace: event.getStack);
     }
     // Make sure asserts are extra visible when debugging
     if (kDebugMode && event.object is AssertionError) {


### PR DESCRIPTION
#1224 seems to be related to the OS sending unexpected 'stop' commands, killing the queue.  I've added a setting to just ignore these commands, requiring you to use the in-app gestures if you want to close the player.  Off by default.  Also:
- Prevent non-playback commands like UserDataChanged from triggering aggressive playback reporting.
- Add a throttle to aggressive playback reporting when controlled - desktop player seems to fire this ~14 times per second.
- Capture stacktraces that were being missed when directly logging Errors without manually passing the stacktrace.