### PR TITLE
Add support for Android user-installed certificates

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -23,6 +23,7 @@
     android:allowBackup="true"
     android:fullBackupContent="@xml/backup_rules_legacy"
     android:dataExtractionRules="@xml/backup_rules"
+    android:networkSecurityConfig="@xml/network_security_config"
   >
     <activity android:name=".MainActivity" android:launchMode="singleTop" android:theme="@style/LaunchTheme" android:configChanges="orientation|keyboardHidden|keyboard|screenSize|smallestScreenSize|locale|layoutDirection|fontScale|screenLayout|density|uiMode" android:hardwareAccelerated="true" android:windowSoftInputMode="adjustResize" android:exported="true">
       <!-- Specifies an Android theme to apply to this Activity as soon as

--- a/android/app/src/main/res/xml/network_security_config.xml
+++ b/android/app/src/main/res/xml/network_security_config.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<network-security-config>
+  <base-config>
+    <trust-anchors>
+      <certificates src="system"/>
+      <certificates src="user"/>
+    </trust-anchors>
+  </base-config>
+</network-security-config>

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -46,6 +46,7 @@ import 'package:flutter_localizations/flutter_localizations.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_svg/svg.dart';
 import 'package:flutter_tabler_icons/flutter_tabler_icons.dart';
+import 'package:flutter_user_certificates_android/flutter_user_certificates_android.dart';
 import 'package:get_it/get_it.dart';
 import 'package:hive_ce_flutter/hive_flutter.dart';
 import 'package:intl/date_symbol_data_local.dart';
@@ -105,6 +106,8 @@ void main() async {
     _migrateDownloadLocations();
     _migrateSortOptions();
     _mainLog.info("Completed applicable migrations");
+    await _trustAndroidUserCerts();
+    _mainLog.info("Trusted Android user certs");
     await _setupFinampUserHelper();
     _mainLog.info("Setup user helper");
     await _setupJellyfinApiData();
@@ -418,6 +421,13 @@ void _migrateSortOptions() {
   if (changed) {
     FinampSettingsHelper.overwriteFinampSettings(finampSettings);
   }
+}
+
+Future<void> _trustAndroidUserCerts() async {
+  // Extend the default security context to trust Android user certificates.
+  // This is a workaround for <https://github.com/dart-lang/sdk/issues/50435>.
+  WidgetsFlutterBinding.ensureInitialized();
+  await FlutterUserCertificatesAndroid().trustAndroidUserCertificates(SecurityContext.defaultContext);
 }
 
 Future<void> _setupFinampUserHelper() async {

--- a/lib/services/jellyfin_api_helper.dart
+++ b/lib/services/jellyfin_api_helper.dart
@@ -10,6 +10,7 @@ import 'package:finamp/services/http_aggregate_logging_interceptor.dart';
 import 'package:flutter/scheduler.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_user_certificates_android/flutter_user_certificates_android.dart';
 import 'package:get_it/get_it.dart';
 import 'package:http/io_client.dart' as http;
 import 'package:isar/isar.dart';
@@ -59,6 +60,11 @@ class JellyfinApiHelper {
   static Future<void> _processRequestsBackground((SendPort, RootIsolateToken) input) async {
     BackgroundIsolateBinaryMessenger.ensureInitialized(input.$2);
     ReceivePort requestPort = ReceivePort();
+
+    // Extend the default security context to trust Android user certificates.
+    // This is a workaround for <https://github.com/dart-lang/sdk/issues/50435>.
+    await FlutterUserCertificatesAndroid().trustAndroidUserCertificates(SecurityContext.defaultContext);
+
     input.$1.send(requestPort.sendPort);
     final dir = (Platform.isAndroid || Platform.isIOS)
         ? await getApplicationDocumentsDirectory()

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -617,6 +617,15 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.0.5"
+  flutter_user_certificates_android:
+    dependency: "direct main"
+    description:
+      path: "."
+      ref: add-trusting
+      resolved-ref: e122aad81ddbd9bf22623f125389498570de2a25
+      url: "https://github.com/jfly/flutter_user_certificates_android.git"
+    source: git
+    version: "0.0.1"
   flutter_web_plugins:
     dependency: transitive
     description: flutter

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -61,6 +61,13 @@ dependencies:
   uuid: ^4.5.1
   infinite_scroll_pagination: ^4.0.0
   flutter_sticky_header: ^0.8.0
+  # TODO: switch to regular `flutter_user_certificates_android` when this PR is
+  # merged:
+  # <https://github.com/johnstef99/flutter_user_certificates_android/pull/2>.
+  flutter_user_certificates_android:
+    git:
+      url: https://github.com/jfly/flutter_user_certificates_android.git
+      ref: "add-trusting"
   device_info_plus: ^11.3.3
   app_set_id: ^1.2.1
   package_info_plus: ^8.3.0


### PR DESCRIPTION
This fixes https://github.com/jmshrv/finamp/issues/106

Frustratingly, Dart/Flutter ignores user-installed certificates. Working around this requires rooting your Android device to install certificates as "system" certs, which isn't an option for all people.

This is a known issue with Dart, see
https://github.com/dart-lang/sdk/issues/50435 and
https://github.com/flutter/flutter/issues/56607 for details.

This depends on my fork of
`johnstef99/flutter_user_certificates_android`, which I've sent a PR for here
<https://github.com/johnstef99/flutter_user_certificates_android/pull/2>. If y'all don't like the supply chain implications of that, I'm happy to inline the implementation here instead.

I opted not to make this configurable as I don't see the value. People using finamp are sophisticated self-hosters, and should understand the risks of configuring their OS to trust certificates.

## Related Issues

fixes #106 