### PR TITLE
[Redesign] Fix outdated album sync

### DIFF
--- a/lib/components/PlayerScreen/album_chip.dart
+++ b/lib/components/PlayerScreen/album_chip.dart
@@ -73,7 +73,7 @@ class _EmptyAlbumChip extends StatelessWidget {
 }
 
 class ReleaseDate extends StatelessWidget {
-  const ReleaseDate({this.baseItem, this.backgroundColor, this.color});
+  const ReleaseDate({super.key, this.baseItem, this.backgroundColor, this.color});
 
   final BaseItemDto? baseItem;
   final Color? backgroundColor;
@@ -123,15 +123,21 @@ class _AlbumChipContent extends StatelessWidget {
         borderRadius: _borderRadius,
         child: InkWell(
           borderRadius: _borderRadius,
-          onTap: FinampSettingsHelper.finampSettings.isOffline
-              ? () => isarDownloader
-                    .getCollectionInfo(id: item.albumId!)
-                    .then(
-                      (album) => Navigator.of(context).pushNamed(AlbumScreen.routeName, arguments: album!.baseItem!),
-                    )
-              : () => jellyfinApiHelper
-                    .getItemById(item.albumId!)
-                    .then((album) => Navigator.of(context).pushNamed(AlbumScreen.routeName, arguments: album)),
+          onTap: item.albumId != null
+              ? () async {
+                  if (FinampSettingsHelper.finampSettings.isOffline) {
+                    var stub = await isarDownloader.getCollectionInfo(id: item.albumId!);
+                    if (stub?.baseItem != null && context.mounted) {
+                      await Navigator.of(context).pushNamed(AlbumScreen.routeName, arguments: stub!.baseItem!);
+                    }
+                  } else {
+                    var album = await jellyfinApiHelper.getItemById(item.albumId!);
+                    if (context.mounted) {
+                      await Navigator.of(context).pushNamed(AlbumScreen.routeName, arguments: album);
+                    }
+                  }
+                }
+              : null,
           child: Padding(
             padding: const EdgeInsets.symmetric(vertical: 2, horizontal: 4),
             child: Text(

--- a/lib/components/PlayerScreen/artist_chip.dart
+++ b/lib/components/PlayerScreen/artist_chip.dart
@@ -21,12 +21,12 @@ const _height = 24.0; // I'm sure this magic number will work on all devices
 final _defaultBackgroundColour = Colors.white.withOpacity(0.1);
 
 @riverpod
-Future<BaseItemDto> artistItem(Ref ref, BaseItemId id) async {
+Future<BaseItemDto?> artistItem(Ref ref, BaseItemId id) async {
   final jellyfinApiHelper = GetIt.instance<JellyfinApiHelper>();
   final isarDownloader = GetIt.instance<DownloadsService>();
   final bool isOffline = ref.watch(finampSettingsProvider.isOffline);
   return isOffline
-      ? isarDownloader.getCollectionInfo(id: id).then((value) => value!.baseItem!)
+      ? isarDownloader.getCollectionInfo(id: id).then((value) => value?.baseItem)
       : jellyfinApiHelper.getItemById(id);
 }
 

--- a/lib/components/PlayerScreen/artist_chip.g.dart
+++ b/lib/components/PlayerScreen/artist_chip.g.dart
@@ -11,7 +11,7 @@ part of 'artist_chip.dart';
 // RiverpodGenerator
 // **************************************************************************
 
-String _$artistItemHash() => r'f4d09228b904b8b050fd55960ceab1a3a3823e5f';
+String _$artistItemHash() => r'542d9312760e4643c82889c82891ac4a960e87d2';
 
 /// Copied from Dart SDK
 class _SystemHash {
@@ -39,7 +39,7 @@ class _SystemHash {
 const artistItemProvider = ArtistItemFamily();
 
 /// See also [artistItem].
-class ArtistItemFamily extends Family<AsyncValue<BaseItemDto>> {
+class ArtistItemFamily extends Family<AsyncValue<BaseItemDto?>> {
   /// See also [artistItem].
   const ArtistItemFamily();
 
@@ -71,7 +71,7 @@ class ArtistItemFamily extends Family<AsyncValue<BaseItemDto>> {
 }
 
 /// See also [artistItem].
-class ArtistItemProvider extends AutoDisposeFutureProvider<BaseItemDto> {
+class ArtistItemProvider extends AutoDisposeFutureProvider<BaseItemDto?> {
   /// See also [artistItem].
   ArtistItemProvider(BaseItemId id)
     : this._internal(
@@ -100,7 +100,7 @@ class ArtistItemProvider extends AutoDisposeFutureProvider<BaseItemDto> {
 
   @override
   Override overrideWith(
-    FutureOr<BaseItemDto> Function(ArtistItemRef provider) create,
+    FutureOr<BaseItemDto?> Function(ArtistItemRef provider) create,
   ) {
     return ProviderOverride(
       origin: this,
@@ -117,7 +117,7 @@ class ArtistItemProvider extends AutoDisposeFutureProvider<BaseItemDto> {
   }
 
   @override
-  AutoDisposeFutureProviderElement<BaseItemDto> createElement() {
+  AutoDisposeFutureProviderElement<BaseItemDto?> createElement() {
     return _ArtistItemProviderElement(this);
   }
 
@@ -137,13 +137,13 @@ class ArtistItemProvider extends AutoDisposeFutureProvider<BaseItemDto> {
 
 @Deprecated('Will be removed in 3.0. Use Ref instead')
 // ignore: unused_element
-mixin ArtistItemRef on AutoDisposeFutureProviderRef<BaseItemDto> {
+mixin ArtistItemRef on AutoDisposeFutureProviderRef<BaseItemDto?> {
   /// The parameter `id` of this provider.
   BaseItemId get id;
 }
 
 class _ArtistItemProviderElement
-    extends AutoDisposeFutureProviderElement<BaseItemDto>
+    extends AutoDisposeFutureProviderElement<BaseItemDto?>
     with ArtistItemRef {
   _ArtistItemProviderElement(super.provider);
 

--- a/lib/components/now_playing_bar.dart
+++ b/lib/components/now_playing_bar.dart
@@ -1,5 +1,4 @@
 import 'dart:async';
-import 'dart:math';
 
 import 'package:audio_service/audio_service.dart';
 import 'package:finamp/color_schemes.g.dart';
@@ -251,6 +250,10 @@ class NowPlayingBar extends StatelessWidget {
                                   Stack(
                                     alignment: Alignment.center,
                                     children: [
+                                      if (ref.watch(finampSettingsProvider.showProgressOnNowPlayingBar))
+                                        Positioned.fill(
+                                          child: ColoredBox(color: IconTheme.of(context).color!.withOpacity(0.75)),
+                                        ),
                                       AlbumImage(
                                         placeholderBuilder: (_) => const SizedBox.shrink(),
                                         imageListenable: currentAlbumImageProvider,
@@ -287,39 +290,33 @@ class NowPlayingBar extends StatelessWidget {
                                     child: Stack(
                                       children: [
                                         if (ref.watch(finampSettingsProvider.showProgressOnNowPlayingBar))
-                                          Positioned(
-                                            left: 0,
-                                            top: 0,
+                                          Positioned.fill(
                                             child: StreamBuilder<Duration>(
                                               stream: AudioService.position,
                                               initialData: audioHandler.playbackState.value.position,
                                               builder: (context, snapshot) {
                                                 if (snapshot.hasData) {
                                                   playbackPosition = snapshot.data;
-                                                  final screenSize = MediaQuery.of(context).size;
-                                                  return Container(
-                                                    // rather hacky workaround, using LayoutBuilder would be nice but I couldn't get it to work...
-                                                    width: max(
-                                                      0,
-                                                      (screenSize.width - 3 * horizontalPadding - albumImageSize) *
-                                                          (playbackPosition!.inMilliseconds /
-                                                              (mediaState.mediaItem?.duration ??
-                                                                      const Duration(seconds: 0))
-                                                                  .inMilliseconds),
-                                                    ),
-                                                    height: albumImageSize,
-                                                    decoration: ShapeDecoration(
-                                                      color: IconTheme.of(context).color!.withOpacity(0.75),
-                                                      shape: const RoundedRectangleBorder(
-                                                        borderRadius: BorderRadius.only(
-                                                          topRight: Radius.circular(12),
-                                                          bottomRight: Radius.circular(12),
+                                                  var itemLength = mediaState.mediaItem?.duration;
+                                                  return FractionallySizedBox(
+                                                    alignment: AlignmentDirectional.centerStart,
+                                                    widthFactor: itemLength == null
+                                                        ? 0
+                                                        : playbackPosition!.inMilliseconds / itemLength.inMilliseconds,
+                                                    child: DecoratedBox(
+                                                      decoration: ShapeDecoration(
+                                                        color: IconTheme.of(context).color!.withOpacity(0.75),
+                                                        shape: const RoundedRectangleBorder(
+                                                          borderRadius: BorderRadius.only(
+                                                            topRight: Radius.circular(12),
+                                                            bottomRight: Radius.circular(12),
+                                                          ),
                                                         ),
                                                       ),
                                                     ),
                                                   );
                                                 } else {
-                                                  return Container();
+                                                  return SizedBox.shrink();
                                                 }
                                               },
                                             ),


### PR DESCRIPTION
The sync download button that appears on items with outdated downloads doesn't actually fix outdated albums because the quicksync setting causes them to be skipped.  This has been fixed by forcing a full sync when explicitly resyncing these types.  Also:
- Fix null exceptions in album/artist chips when switching to offline mode when a non-downloaded item is playing.
- Fix restore queue failing to present the retry button when errors are thrown.
- Show played seek bar color behind non-square albums on now-playing bar to match adjacent section of seek bar.