### PR TITLE
Add support for custom `finamp://` URL scheme registration & handling

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -36,6 +36,18 @@
                  gap between the end of Android's launch screen and the painting of
                  Flutter's first frame. -->
       <meta-data android:name="io.flutter.embedding.android.SplashScreenDrawable" android:resource="@drawable/launch_background" />
+
+      <!-- Enables automatic handling of deep links and app links. -->
+      <meta-data android:name="flutter_deeplinking_enabled" android:value="false" />
+      <intent-filter>
+          <action android:name="android.intent.action.VIEW" />
+          <category android:name="android.intent.category.DEFAULT" />
+          <category android:name="android.intent.category.BROWSABLE" />
+          <!-- Add optional android:host to distinguish your app
+                from others in case of conflicting scheme name -->
+          <data android:scheme="finamp" />
+      </intent-filter>
+
       <intent-filter>
         <action android:name="android.intent.action.MAIN"/>
         <category android:name="android.intent.category.APP_MUSIC"/>

--- a/assets/finamp.desktop.m4
+++ b/assets/finamp.desktop.m4
@@ -8,3 +8,4 @@ Exec=__INSTALL_PATH__/finamp
 Terminal=false
 Categories=AudioVideo;Audio;Player;Music;
 Comment=An open source Jellyfin music player
+MimeType=x-scheme-handler/finamp; # necessary so that the flutter app can open custom urls of type finamp://...

--- a/linux/finamp_application.cc
+++ b/linux/finamp_application.cc
@@ -17,6 +17,15 @@ G_DEFINE_TYPE(FinampApplication, finamp_application, GTK_TYPE_APPLICATION)
 // Implements GApplication::activate.
 static void finamp_application_activate(GApplication* application) {
   FinampApplication* self = FINAMP_APPLICATION(application);
+
+  // handle link handling
+  GList* windows = gtk_application_get_windows(GTK_APPLICATION(application));
+  if (windows) {
+    gtk_window_present(GTK_WINDOW(windows->data));
+    // If there is already a window, we just present it and do not create a new one.
+    return;
+  }
+
   GtkWindow* window =
       GTK_WINDOW(gtk_application_window_new(GTK_APPLICATION(application)));
 
@@ -77,7 +86,7 @@ static gboolean finamp_application_local_command_line(GApplication* application,
   g_application_activate(application);
   *exit_status = 0;
 
-  return TRUE;
+  return FALSE; // We handled the command line arguments, so we return FALSE to indicate that we don't want the default handling.
 }
 
 // Implements GObject::dispose.
@@ -98,6 +107,6 @@ static void finamp_application_init(FinampApplication* self) {}
 FinampApplication* finamp_application_new() {
   return FINAMP_APPLICATION(g_object_new(finamp_application_get_type(),
                                      "application-id", APPLICATION_ID,
-                                     "flags", G_APPLICATION_NON_UNIQUE,
+                                     "flags", G_APPLICATION_HANDLES_COMMAND_LINE | G_APPLICATION_HANDLES_OPEN,
                                      nullptr));
 }

--- a/linux/flutter/generated_plugin_registrant.cc
+++ b/linux/flutter/generated_plugin_registrant.cc
@@ -6,6 +6,7 @@
 
 #include "generated_plugin_registrant.h"
 
+#include <gtk/gtk_plugin.h>
 #include <isar_flutter_libs/isar_flutter_libs_plugin.h>
 #include <media_kit_libs_linux/media_kit_libs_linux_plugin.h>
 #include <screen_retriever_linux/screen_retriever_linux_plugin.h>
@@ -13,6 +14,9 @@
 #include <window_manager/window_manager_plugin.h>
 
 void fl_register_plugins(FlPluginRegistry* registry) {
+  g_autoptr(FlPluginRegistrar) gtk_registrar =
+      fl_plugin_registry_get_registrar_for_plugin(registry, "GtkPlugin");
+  gtk_plugin_register_with_registrar(gtk_registrar);
   g_autoptr(FlPluginRegistrar) isar_flutter_libs_registrar =
       fl_plugin_registry_get_registrar_for_plugin(registry, "IsarFlutterLibsPlugin");
   isar_flutter_libs_plugin_register_with_registrar(isar_flutter_libs_registrar);

--- a/linux/flutter/generated_plugins.cmake
+++ b/linux/flutter/generated_plugins.cmake
@@ -3,6 +3,7 @@
 #
 
 list(APPEND FLUTTER_PLUGIN_LIST
+  gtk
   isar_flutter_libs
   media_kit_libs_linux
   screen_retriever_linux

--- a/macos/Runner/Info.plist
+++ b/macos/Runner/Info.plist
@@ -43,5 +43,18 @@
 		<key>NSAllowsArbitraryLoads</key>
 		<true/>
 	</dict>
+	<key>CFBundleURLTypes</key>
+	<array>
+		<dict>
+			<key>CFBundleURLName</key>
+			<!-- abstract name for this URL type (you can leave it blank) -->
+			<string>finamp_scheme</string>
+			<key>CFBundleURLSchemes</key>
+			<array>
+				<!-- your schemes -->
+				<string>finamp</string>
+			</array>
+		</dict>
+	</array>
 </dict>
 </plist>

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -25,6 +25,38 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.13.0"
+  app_links:
+    dependency: "direct main"
+    description:
+      name: app_links
+      sha256: "85ed8fc1d25a76475914fff28cc994653bd900bc2c26e4b57a49e097febb54ba"
+      url: "https://pub.dev"
+    source: hosted
+    version: "6.4.0"
+  app_links_linux:
+    dependency: transitive
+    description:
+      name: app_links_linux
+      sha256: f5f7173a78609f3dfd4c2ff2c95bd559ab43c80a87dc6a095921d96c05688c81
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.3"
+  app_links_platform_interface:
+    dependency: transitive
+    description:
+      name: app_links_platform_interface
+      sha256: "05f5379577c513b534a29ddea68176a4d4802c46180ee8e2e966257158772a3f"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.0.2"
+  app_links_web:
+    dependency: transitive
+    description:
+      name: app_links_web
+      sha256: af060ed76183f9e2b87510a9480e56a5352b6c249778d07bd2c95fc35632a555
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.4"
   app_set_id:
     dependency: "direct main"
     description:
@@ -678,6 +710,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.3.2"
+  gtk:
+    dependency: transitive
+    description:
+      name: gtk
+      sha256: e8ce9ca4b1df106e4d72dad201d345ea1a036cc12c360f1a7d5a758f78ffa42c
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.1.0"
   hashcodes:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -115,6 +115,7 @@ dependencies:
   visibility_detector: ^0.4.0+2
   gaimon: ^1.4.0
   http: ^1.4.0
+  app_links: ^6.4.0
 
 dev_dependencies:
   flutter_test:
@@ -222,3 +223,4 @@ msix_config:
   certificate_password: finamp
   # Building during msix:create is currently bugged, so build manually beforehand.
   build_windows: false
+  protocol_activation: finamp # the protocols to activate the app

--- a/windows/runner/main.cpp
+++ b/windows/runner/main.cpp
@@ -2,11 +2,53 @@
 #include <flutter/flutter_view_controller.h>
 #include <windows.h>
 
+#include "app_links/app_links_plugin_c_api.h"
 #include "flutter_window.h"
 #include "utils.h"
 
+bool SendAppLinkToInstance(const std::wstring& title) {
+  // Find our exact window
+  HWND hwnd = ::FindWindow(L"FLUTTER_RUNNER_WIN32_WINDOW", title.c_str());
+
+  if (hwnd) {
+    // Dispatch new link to current window
+    SendAppLink(hwnd);
+
+    // (Optional) Restore our window to front in same state
+    WINDOWPLACEMENT place = { sizeof(WINDOWPLACEMENT) };
+    GetWindowPlacement(hwnd, &place);
+
+    switch(place.showCmd) {
+      case SW_SHOWMAXIMIZED:
+          ShowWindow(hwnd, SW_SHOWMAXIMIZED);
+          break;
+      case SW_SHOWMINIMIZED:
+          ShowWindow(hwnd, SW_RESTORE);
+          break;
+      default:
+          ShowWindow(hwnd, SW_NORMAL);
+          break;
+    }
+
+    SetWindowPos(0, HWND_TOP, 0, 0, 0, 0, SWP_SHOWWINDOW | SWP_NOSIZE | SWP_NOMOVE);
+    SetForegroundWindow(hwnd);
+    // END (Optional) Restore
+
+    // Window has been found, don't create another one.
+    return true;
+  }
+
+  return false;
+}
+
 int APIENTRY wWinMain(_In_ HINSTANCE instance, _In_opt_ HINSTANCE prev,
                       _In_ wchar_t *command_line, _In_ int show_command) {
+
+  // You may ignore the result if you need to create another window.
+  if (SendAppLinkToInstance(L"Finamp")) {
+    return EXIT_SUCCESS;
+  }
+                        
   // Attach to console when present (e.g., 'flutter run') or create a
   // new console when running with a debugger.
   if (!::AttachConsole(ATTACH_PARENT_PROCESS) && ::IsDebuggerPresent()) {


### PR DESCRIPTION
<!-- Just a reminder that text in these brackets is not visible in the rendered output.
You also do **not** need to use this template. You can remove and modify anything however you like!
Its just a suggestion :)
-->

## Changes
<!-- Please describe what this Pull request adds or changes. Possibly with images -->
- Finamp will open / move to foreground when a URL with the `finamp://` scheme is opened
- URLs starting with `finamp://internal/` can be used to open registered screens based on the remaining path
  - i.e. `finamp://internal/settings/layout` will open the "Layout & Theme" settings screen (directly, going back will return to the previous screen and *not* to the top-level settings screen)

## Todo before merging
<!-- Add custom todos if deemed necessary to give others an overview on how far this PR is progressing -->

<!-- Did you add UI text? 
No? Just check or remove the box
Yes? Make sure you replace hardcoded strings with translations -->
- [x] ~~Translations~~
<!-- Did you add settings to the settings screen?
No? Just check or remove the box 
Yes? Make sure they are resettable using the button on the respective page! (see finamp_settings_helper.dart)-->
- [x] ~~Reset Settings~~
<!-- Did you run into problems?
No? Just check or remove the box
Yes? Look at the CONTRIBUTING.md, maybe you can add something to help others! -->
- [x] ~~Extended CONTRIBUTING.md~~
- [ ] Configure scheme support for iOS

## Related Issues

- closes #1281 
