### PR TITLE
Use album gain outside of album contexts

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -116,7 +116,10 @@ lib/                                -- the codebase also known as src in other p
 4. Create a new method for interacting with the endpoint in `jellyfin_api_helper.dart`. Again, just copy-paste what you need.
 5. Call the new method through `JellyfinApiHelper` to make your request
 
+### Adding i18n strings
 
+1. In [app_en.arb](lib/l10n/app_en.arb), add default english string as well as string description following examples in the file
+2. Run `flutter gen-l10n` or VSCode command "Generate Localizations" if you have Flutter plugin installed
 
 ## The Redesign
 

--- a/flake.nix
+++ b/flake.nix
@@ -55,6 +55,10 @@
             ANDROID_SDK_ROOT = "${androidSdk}/libexec/android-sdk";
             ANDROID_HOME = "${androidSdk}/libexec/android-sdk";
             GRADLE_OPTS = "-Dorg.gradle.project.android.aapt2FromMavenOverride=${androidSdk}/libexec/android-sdk/build-tools/${buildToolsVersion}/aapt2";
+            FLUTTER_ROOT = "${flutter}";
+            # finamp can't find libmpv on its own, even with `nix-shell -p mpv-unwrapped`
+            # still requires `cd build/linux/x64/release/bundle/lib/`
+            LD_LIBRARY_PATH = "${lib.makeLibraryPath [ pkgs.mpv-unwrapped ]}";
             buildInputs = [
               flutter
               androidSdk

--- a/lib/components/PlayerScreen/feature_chips.dart
+++ b/lib/components/PlayerScreen/feature_chips.dart
@@ -153,7 +153,7 @@ class FeatureState {
 
       if (feature == FinampFeatureChipType.normalizationGain &&
           FinampSettingsHelper.finampSettings.volumeNormalizationActive) {
-        double? effectiveGainChange = getEffectiveGainChange(currentTrack!.item, currentTrack!.baseItem);
+        double? effectiveGainChange = getGainForCurrentPlayback(currentTrack!.item, currentTrack!.baseItem);
         if (effectiveGainChange != null) {
           features.add(
             FeatureProperties(

--- a/lib/components/VolumeNormalizationSettingsScreen/volume_normalization_mode_selector.dart
+++ b/lib/components/VolumeNormalizationSettingsScreen/volume_normalization_mode_selector.dart
@@ -14,8 +14,8 @@ extension LocalizedName on VolumeNormalizationMode {
         return AppLocalizations.of(context)!.volumeNormalizationModeHybrid;
       case VolumeNormalizationMode.trackBased:
         return AppLocalizations.of(context)!.volumeNormalizationModeTrackBased;
-      // case VolumeNormalizationMode.albumBased:
-      //   return AppLocalizations.of(context)!.volumeNormalizationModeAlbumBased;
+      case VolumeNormalizationMode.albumBased:
+        return AppLocalizations.of(context)!.volumeNormalizationModeAlbumBased;
       case VolumeNormalizationMode.albumOnly:
         return AppLocalizations.of(context)!.volumeNormalizationModeAlbumOnly;
     }

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -1474,13 +1474,13 @@
   "@volumeNormalizationModeSelectorSubtitle": {
     "description": "Subtitle for the dropdown that selects the replay gain mode"
   },
-  "volumeNormalizationModeSelectorDescription": "Hybrid (Track + Album):\nTrack gain is used for regular playback, but if an album is playing (either because it''s the main playback queue source, or because it was added to the queue at some point), the album gain is used instead.\n\nTrack-based:\nTrack gain is always used, regardless of whether an album is playing or not.\n\nAlbums Only:\nVolume Normalization is only applied while playing albums (using the album gain), but not for individual tracks.",
+  "volumeNormalizationModeSelectorDescription": "Dynamic:\nWhen playing multiple tracks from the same album in a row, album gain is used (i.e. when playing an album, or tracks from the same album in a playlist). Otherwise, track gain is used.\n\nTrack-based:\nTrack gain is always used, regardless of whether an album is playing or not.\n\nAlbum-based:\nAlbum gain is always used, but if it's not available (i.e. for singles), track gain is used instead.\n\nAlbums Only:\nVolume normalization is only applied while playing albums (using the album gain), but not for individual tracks.",
   "@volumeNormalizationModeSelectorDescription": {
     "description": "Description for the dropdown that selects the replay gain mode, shown in a dialog that opens when the user presses the info icon next to the dropdown"
   },
-  "volumeNormalizationModeHybrid": "Hybrid (Track + Album)",
+  "volumeNormalizationModeHybrid": "Dynamic",
   "@volumeNormalizationModeHybrid": {
-    "description": "'Hybrid' option for the replay gain mode dropdown. In hybrid mode, the track gain is used for regular playback, but if an album is playing (either because it's the main playback queue source, or because it was added to the queue at some point), the album gain is used instead."
+    "description": "'Dynamic' option for the replay gain mode dropdown. In dynamic mode, the track gain is used for regular playback, but if an album is playing (either because it's the main playback queue source, or because it was added to the queue at some point), or successive tracks from a same album are in the queue, the album gain is used instead."
   },
   "volumeNormalizationModeTrackBased": "Track-based",
   "@volumeNormalizationModeTrackBased": {

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -370,6 +370,7 @@ Future<void> _setupPlaybackServices() async {
   GetIt.instance.registerSingleton<MusicPlayerBackgroundTask>(audioHandler);
   var queueService = QueueService();
   GetIt.instance.registerSingleton(queueService);
+  audioHandler.onQueueServiceAvailable(); // breaking circular dependency
   GetIt.instance.registerSingleton(PlaybackHistoryService());
   GetIt.instance.registerSingleton(AudioServiceHelper());
 

--- a/lib/models/finamp_models.dart
+++ b/lib/models/finamp_models.dart
@@ -2169,6 +2169,9 @@ enum VolumeNormalizationMode {
   /// Only normalize if playing albums
   @HiveField(2)
   albumOnly,
+
+  @HiveField(3)
+  albumBased,
 }
 
 @HiveType(typeId: 64)

--- a/lib/models/finamp_models.g.dart
+++ b/lib/models/finamp_models.g.dart
@@ -1881,6 +1881,8 @@ class VolumeNormalizationModeAdapter
         return VolumeNormalizationMode.trackBased;
       case 2:
         return VolumeNormalizationMode.albumOnly;
+      case 3:
+        return VolumeNormalizationMode.albumBased;
       default:
         return VolumeNormalizationMode.hybrid;
     }
@@ -1895,6 +1897,8 @@ class VolumeNormalizationModeAdapter
         writer.writeByte(1);
       case VolumeNormalizationMode.albumOnly:
         writer.writeByte(2);
+      case VolumeNormalizationMode.albumBased:
+        writer.writeByte(3);
     }
   }
 

--- a/lib/services/current_track_metadata_provider.dart
+++ b/lib/services/current_track_metadata_provider.dart
@@ -12,16 +12,13 @@ final currentTrackMetadataProvider = AutoDisposeProvider<AsyncValue<MetadataProv
   for (final itemToPrecache in precacheItems) {
     BaseItemDto? base = itemToPrecache.baseItem;
     if (base != null) {
-      // only fetch lyrics for the current track
-      final request = MetadataRequest(item: base, includeLyrics: true);
-      ref.listen(metadataProvider(request), (_, __) {});
+      ref.listen(metadataProvider(base), (_, __) {});
     }
   }
 
   final currentTrack = ref.watch(currentTrackProvider).value;
   if (currentTrack?.baseItem != null) {
-    final request = MetadataRequest(item: currentTrack!.baseItem!, includeLyrics: true);
-    return ref.watch(metadataProvider(request));
+    return ref.watch(metadataProvider(currentTrack!.baseItem!));
   }
   return const AsyncValue.data(null);
 });

--- a/lib/services/current_track_metadata_provider.dart
+++ b/lib/services/current_track_metadata_provider.dart
@@ -16,7 +16,6 @@ final currentTrackMetadataProvider = AutoDisposeProvider<AsyncValue<MetadataProv
       // only fetch lyrics for the current track
       final request = MetadataRequest(
         item: base,
-        queueItem: itemToPrecache,
         includeLyrics: true,
         checkIfSpeedControlNeeded:
             ref.watch(finampSettingsProvider.playbackSpeedVisibility) == PlaybackSpeedVisibility.automatic,
@@ -29,7 +28,6 @@ final currentTrackMetadataProvider = AutoDisposeProvider<AsyncValue<MetadataProv
   if (currentTrack?.baseItem != null) {
     final request = MetadataRequest(
       item: currentTrack!.baseItem!,
-      queueItem: currentTrack,
       includeLyrics: true,
       checkIfSpeedControlNeeded:
           ref.watch(finampSettingsProvider.playbackSpeedVisibility) == PlaybackSpeedVisibility.automatic,

--- a/lib/services/current_track_metadata_provider.dart
+++ b/lib/services/current_track_metadata_provider.dart
@@ -1,6 +1,5 @@
 import 'package:finamp/models/finamp_models.dart';
 import 'package:finamp/models/jellyfin_models.dart';
-import 'package:finamp/services/finamp_settings_helper.dart';
 import 'package:finamp/services/queue_service.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:get_it/get_it.dart';
@@ -14,24 +13,14 @@ final currentTrackMetadataProvider = AutoDisposeProvider<AsyncValue<MetadataProv
     BaseItemDto? base = itemToPrecache.baseItem;
     if (base != null) {
       // only fetch lyrics for the current track
-      final request = MetadataRequest(
-        item: base,
-        includeLyrics: true,
-        checkIfSpeedControlNeeded:
-            ref.watch(finampSettingsProvider.playbackSpeedVisibility) == PlaybackSpeedVisibility.automatic,
-      );
+      final request = MetadataRequest(item: base, includeLyrics: true);
       ref.listen(metadataProvider(request), (_, __) {});
     }
   }
 
   final currentTrack = ref.watch(currentTrackProvider).value;
   if (currentTrack?.baseItem != null) {
-    final request = MetadataRequest(
-      item: currentTrack!.baseItem!,
-      includeLyrics: true,
-      checkIfSpeedControlNeeded:
-          ref.watch(finampSettingsProvider.playbackSpeedVisibility) == PlaybackSpeedVisibility.automatic,
-    );
+    final request = MetadataRequest(item: currentTrack!.baseItem!, includeLyrics: true);
     return ref.watch(metadataProvider(request));
   }
   return const AsyncValue.data(null);

--- a/lib/services/metadata_provider.dart
+++ b/lib/services/metadata_provider.dart
@@ -43,12 +43,14 @@ class MetadataProvider {
   LyricDto? lyrics;
   bool isDownloaded;
   bool qualifiesForPlaybackSpeedControl;
+  double? parentNormalizationGain;
 
   MetadataProvider({
     required this.mediaSourceInfo,
     this.lyrics,
     this.isDownloaded = false,
     this.qualifiesForPlaybackSpeedControl = false,
+    this.parentNormalizationGain,
   });
 
   bool get hasLyrics => mediaSourceInfo.mediaStreams.any((e) => e.type == "Lyric");
@@ -167,8 +169,7 @@ metadataProvider = FutureProvider.autoDispose.family<MetadataProvider?, Metadata
   }
 
   BaseItemDto? parent;
-  if (request.item.parentId != null &&
-      (request.checkIfSpeedControlNeeded && !metadata.qualifiesForPlaybackSpeedControl)) {
+  if (request.item.parentId != null) {
     if (!FinampSettingsHelper.finampSettings.isOffline) {
       try {
         parent = await jellyfinApiHelper.getItemById(request.item.parentId!);
@@ -200,6 +201,10 @@ metadataProvider = FutureProvider.autoDispose.family<MetadataProvider?, Metadata
       parent != null &&
       (parent.runTimeTicks ?? 0) > MetadataProvider.speedControlLongAlbumDuration.inMicroseconds * 10) {
     metadata.qualifiesForPlaybackSpeedControl = true;
+  }
+
+  if (parent != null) {
+    metadata.parentNormalizationGain = parent.normalizationGain;
   }
 
   if (request.includeLyrics && metadata.hasLyrics) {

--- a/lib/services/metadata_provider.dart
+++ b/lib/services/metadata_provider.dart
@@ -51,183 +51,190 @@ class MetadataProvider {
   bool get hasLyrics => mediaSourceInfo.mediaStreams.any((e) => e.type == "Lyric");
 }
 
-final AutoDisposeFutureProviderFamily<MetadataProvider?, MetadataRequest>
-metadataProvider = FutureProvider.autoDispose.family<MetadataProvider?, MetadataRequest>((ref, request) async {
-  // watch settings to trigger re-fetching metadata when offline mode changes
-  ref.watch(finampSettingsProvider.isOffline);
+final AutoDisposeFutureProviderFamily<MetadataProvider?, MetadataRequest> metadataProvider = FutureProvider.autoDispose
+    .family<MetadataProvider?, MetadataRequest>((ref, request) async {
+      // watch settings to trigger re-fetching metadata when offline mode changes
+      ref.watch(finampSettingsProvider.isOffline);
 
-  final jellyfinApiHelper = GetIt.instance<JellyfinApiHelper>();
-  final downloadsService = GetIt.instance<DownloadsService>();
+      Future<BaseItemDto?>? parentFuture;
+      if (request.item.parentId != null) {
+        parentFuture = ref.watch(albumProvider(request.item.parentId!).future);
+      }
 
-  metadataProviderLogger.fine("Fetching metadata for '${request.item.name}' (${request.item.id})");
+      final jellyfinApiHelper = GetIt.instance<JellyfinApiHelper>();
+      final downloadsService = GetIt.instance<DownloadsService>();
 
-  MediaSourceInfo? playbackInfo;
-  MediaSourceInfo? localPlaybackInfo;
+      metadataProviderLogger.fine("Fetching metadata for '${request.item.name}' (${request.item.id})");
 
-  final downloadStub = await downloadsService.getTrackInfo(id: request.item.id);
-  if (downloadStub != null) {
-    final downloadItem = await ref.watch(downloadsService.itemProvider(downloadStub).future);
-    if (downloadItem != null && downloadItem.state.isComplete) {
-      metadataProviderLogger.fine("Got offline metadata for '${request.item.name}'");
-      var profile = downloadItem.fileTranscodingProfile;
-      // We could explicitly get a mediaSource of type Default, but just grabbing
-      // the first seems to generally work?
-      var codec = profile?.codec != FinampTranscodingCodec.original
-          ? profile?.codec.name
-          : downloadItem.baseItem!.mediaSources?.first.container;
-      var bitrate = profile?.codec != FinampTranscodingCodec.original
-          ? profile?.stereoBitrate
-          : downloadItem.baseItem!.mediaSources?.first.bitrate;
+      MediaSourceInfo? playbackInfo;
+      MediaSourceInfo? localPlaybackInfo;
 
-      // We cannot create accurate MediaStreams for a transcoded item,so
-      // just return the lyrics stream, as those are not affected and will not
-      // be shown if the mediaStream is not present
-      List<MediaStream> mediaStream = profile?.codec != FinampTranscodingCodec.original
-          ? downloadItem.baseItem!.mediaStreams?.where((x) => x.type == "Lyric").toList() ?? []
-          : downloadItem.baseItem!.mediaStreams ?? [];
+      final downloadStub = await downloadsService.getTrackInfo(id: request.item.id);
+      if (downloadStub != null) {
+        final downloadItem = await ref.watch(downloadsService.itemProvider(downloadStub).future);
+        if (downloadItem != null && downloadItem.state.isComplete) {
+          metadataProviderLogger.fine("Got offline metadata for '${request.item.name}'");
+          var profile = downloadItem.fileTranscodingProfile;
+          // We could explicitly get a mediaSource of type Default, but just grabbing
+          // the first seems to generally work?
+          var codec = profile?.codec != FinampTranscodingCodec.original
+              ? profile?.codec.name
+              : downloadItem.baseItem!.mediaSources?.first.container;
+          var bitrate = profile?.codec != FinampTranscodingCodec.original
+              ? profile?.stereoBitrate
+              : downloadItem.baseItem!.mediaSources?.first.bitrate;
 
-      localPlaybackInfo = MediaSourceInfo(
-        id: downloadItem.baseItem!.id,
-        protocol: "File",
-        type: "Default",
-        isRemote: false,
-        supportsTranscoding: false,
-        supportsDirectStream: false,
-        supportsDirectPlay: true,
-        isInfiniteStream: false,
-        requiresOpening: false,
-        requiresClosing: false,
-        requiresLooping: false,
-        supportsProbing: false,
-        mediaStreams: mediaStream,
-        readAtNativeFramerate: false,
-        ignoreDts: false,
-        ignoreIndex: false,
-        genPtsInput: false,
-        bitrate: bitrate,
-        container: codec,
-        name: downloadItem.baseItem!.mediaSources?.first.name,
-        size: await downloadsService.getFileSize(downloadStub),
+          // We cannot create accurate MediaStreams for a transcoded item,so
+          // just return the lyrics stream, as those are not affected and will not
+          // be shown if the mediaStream is not present
+          List<MediaStream> mediaStream = profile?.codec != FinampTranscodingCodec.original
+              ? downloadItem.baseItem!.mediaStreams?.where((x) => x.type == "Lyric").toList() ?? []
+              : downloadItem.baseItem!.mediaStreams ?? [];
+
+          localPlaybackInfo = MediaSourceInfo(
+            id: downloadItem.baseItem!.id,
+            protocol: "File",
+            type: "Default",
+            isRemote: false,
+            supportsTranscoding: false,
+            supportsDirectStream: false,
+            supportsDirectPlay: true,
+            isInfiniteStream: false,
+            requiresOpening: false,
+            requiresClosing: false,
+            requiresLooping: false,
+            supportsProbing: false,
+            mediaStreams: mediaStream,
+            readAtNativeFramerate: false,
+            ignoreDts: false,
+            ignoreIndex: false,
+            genPtsInput: false,
+            bitrate: bitrate,
+            container: codec,
+            name: downloadItem.baseItem!.mediaSources?.first.name,
+            size: await downloadsService.getFileSize(downloadStub),
+          );
+        }
+      }
+
+      //!!! only use offline metadata if the app is in offline mode
+      // Finamp should always use the server metadata when online, if possible
+      if (FinampSettingsHelper.finampSettings.isOffline) {
+        playbackInfo = localPlaybackInfo;
+      } else {
+        // fetch from server in online mode
+        metadataProviderLogger.fine(
+          "Fetching metadata for '${request.item.name}' (${request.item.id}) from server due to missing attributes",
+        );
+        try {
+          playbackInfo = (await jellyfinApiHelper.getPlaybackInfo(request.item.id))?.first;
+        } catch (e) {
+          metadataProviderLogger.severe("Failed to fetch metadata for '${request.item.name}' (${request.item.id})", e);
+          return null;
+        }
+
+        // update **PARTS** of playbackInfo with localPlaybackInfo if available
+        if (localPlaybackInfo != null && playbackInfo != null) {
+          playbackInfo.protocol = localPlaybackInfo.protocol;
+          playbackInfo.bitrate = localPlaybackInfo.bitrate;
+          // Use lyrics mediastream from online item, but take all other streams
+          // from downloaded item
+          playbackInfo.mediaStreams = playbackInfo.mediaStreams.where((x) => x.type == "Lyric").toList();
+          playbackInfo.mediaStreams.addAll(localPlaybackInfo.mediaStreams.where((x) => x.type != "Lyric"));
+          playbackInfo.container = localPlaybackInfo.container;
+          playbackInfo.size = localPlaybackInfo.size;
+        }
+      }
+
+      if (playbackInfo == null) {
+        metadataProviderLogger.warning("Couldn't load metadata for '${request.item.name}' (${request.item.id})");
+        return null;
+      }
+
+      BaseItemDto? parent;
+      if (parentFuture != null) {
+        parent = await parentFuture;
+      }
+
+      final metadata = MetadataProvider(
+        mediaSourceInfo: playbackInfo,
+        isDownloaded: localPlaybackInfo != null,
+        parentNormalizationGain: parent?.normalizationGain,
       );
-    }
-  }
 
-  //!!! only use offline metadata if the app is in offline mode
-  // Finamp should always use the server metadata when online, if possible
-  if (FinampSettingsHelper.finampSettings.isOffline) {
-    playbackInfo = localPlaybackInfo;
-  } else {
-    // fetch from server in online mode
-    metadataProviderLogger.fine(
-      "Fetching metadata for '${request.item.name}' (${request.item.id}) from server due to missing attributes",
-    );
-    try {
-      playbackInfo = (await jellyfinApiHelper.getPlaybackInfo(request.item.id))?.first;
-    } catch (e) {
-      metadataProviderLogger.severe("Failed to fetch metadata for '${request.item.name}' (${request.item.id})", e);
+      for (final genre in request.item.genres ?? []) {
+        if (MetadataProvider.speedControlGenres.contains(genre.toLowerCase())) {
+          metadata.qualifiesForPlaybackSpeedControl = true;
+          break;
+        }
+      }
+      if (!metadata.qualifiesForPlaybackSpeedControl &&
+          (metadata.mediaSourceInfo.runTimeTicks ?? 0) >
+              MetadataProvider.speedControlLongTrackDuration.inMicroseconds * 10) {
+        // we might want playback speed control for long tracks (like podcasts or audiobook chapters)
+        metadata.qualifiesForPlaybackSpeedControl = true;
+      }
+
+      // check if item qualifies for having playback speed control available
+      if (!metadata.qualifiesForPlaybackSpeedControl &&
+          parent != null &&
+          (parent.runTimeTicks ?? 0) > MetadataProvider.speedControlLongAlbumDuration.inMicroseconds * 10) {
+        metadata.qualifiesForPlaybackSpeedControl = true;
+      }
+
+      if (request.includeLyrics && metadata.hasLyrics) {
+        //!!! only use offline metadata if the app is in offline mode
+        // Finamp should always use the server metadata when online, if possible
+        if (FinampSettingsHelper.finampSettings.isOffline) {
+          DownloadedLyrics? downloadedLyrics;
+          downloadedLyrics = await downloadsService.getLyricsDownload(baseItem: request.item);
+          if (downloadedLyrics != null) {
+            metadata.lyrics = downloadedLyrics.lyricDto;
+            metadataProviderLogger.fine("Got offline lyrics for '${request.item.name}'");
+          } else {
+            metadataProviderLogger.fine("No offline lyrics for '${request.item.name}'");
+          }
+        } else {
+          metadataProviderLogger.fine("Fetching lyrics for '${request.item.name}' (${request.item.id})");
+          try {
+            final lyrics = await jellyfinApiHelper.getLyrics(itemId: request.item.id);
+            metadata.lyrics = lyrics;
+          } catch (e) {
+            metadataProviderLogger.warning(
+              "Failed to fetch lyrics for '${request.item.name}' (${request.item.id}). Metadata might be stale",
+              e,
+            );
+          }
+        }
+      }
+
+      metadataProviderLogger.fine(
+        "Fetched metadata for '${request.item.name}' (${request.item.id}): ${metadata.lyrics} ${metadata.hasLyrics}",
+      );
+
+      return metadata;
+    });
+
+final AutoDisposeFutureProviderFamily<BaseItemDto?, BaseItemId> albumProvider = FutureProvider.autoDispose
+    .family<BaseItemDto?, BaseItemId>((ref, parentId) async {
+      final jellyfinApiHelper = GetIt.instance<JellyfinApiHelper>();
+      final downloadsService = GetIt.instance<DownloadsService>();
+
+      if (ref.watch(finampSettingsProvider.isOffline)) {
+        final parentInfo = await downloadsService.getCollectionInfo(id: parentId);
+        if (parentInfo == null) {
+          metadataProviderLogger.warning("Couldn't find parent collection '$parentId' in offline mode");
+        } else if (parentInfo.baseItem == null) {
+          metadataProviderLogger.warning("Offline metadata for '$parentId' does not include jellyfin BaseItemDto");
+        } else {
+          return parentInfo.baseItem;
+        }
+      } else {
+        try {
+          return await jellyfinApiHelper.getItemById(parentId);
+        } catch (e) {
+          metadataProviderLogger.warning("Failed to get parent item '$parentId'", e);
+        }
+      }
       return null;
-    }
-
-    // update **PARTS** of playbackInfo with localPlaybackInfo if available
-    if (localPlaybackInfo != null && playbackInfo != null) {
-      playbackInfo.protocol = localPlaybackInfo.protocol;
-      playbackInfo.bitrate = localPlaybackInfo.bitrate;
-      // Use lyrics mediastream from online item, but take all other streams
-      // from downloaded item
-      playbackInfo.mediaStreams = playbackInfo.mediaStreams.where((x) => x.type == "Lyric").toList();
-      playbackInfo.mediaStreams.addAll(localPlaybackInfo.mediaStreams.where((x) => x.type != "Lyric"));
-      playbackInfo.container = localPlaybackInfo.container;
-      playbackInfo.size = localPlaybackInfo.size;
-    }
-  }
-
-  if (playbackInfo == null) {
-    metadataProviderLogger.warning("Couldn't load metadata for '${request.item.name}' (${request.item.id})");
-    return null;
-  }
-
-  final metadata = MetadataProvider(mediaSourceInfo: playbackInfo, isDownloaded: localPlaybackInfo != null);
-
-  for (final genre in request.item.genres ?? []) {
-    if (MetadataProvider.speedControlGenres.contains(genre.toLowerCase())) {
-      metadata.qualifiesForPlaybackSpeedControl = true;
-      break;
-    }
-  }
-  if (!metadata.qualifiesForPlaybackSpeedControl &&
-      (metadata.mediaSourceInfo.runTimeTicks ?? 0) >
-          MetadataProvider.speedControlLongTrackDuration.inMicroseconds * 10) {
-    // we might want playback speed control for long tracks (like podcasts or audiobook chapters)
-    metadata.qualifiesForPlaybackSpeedControl = true;
-  }
-
-  BaseItemDto? parent;
-  if (request.item.parentId != null) {
-    if (!FinampSettingsHelper.finampSettings.isOffline) {
-      try {
-        parent = await jellyfinApiHelper.getItemById(request.item.parentId!);
-      } catch (e) {
-        metadataProviderLogger.warning(
-          "Failed to get parent item ('${request.item.parentId}') for '${request.item.name}' (${request.item.id})",
-          e,
-        );
-      }
-    } else {
-      final parentInfo = await downloadsService.getCollectionInfo(id: request.item.parentId!);
-      if (parentInfo == null) {
-        metadataProviderLogger.warning(
-          "Couldn't find parent collection '${request.item.parentId}' for track '${request.item.id}' in offline mode",
-        );
-      } else if (parentInfo.baseItem == null) {
-        metadataProviderLogger.warning(
-          "Offline metadata for '${request.item.parentId}' (parent of '${request.item.id}') does not include jellyfin BaseItemDto",
-        );
-      } else {
-        parent = parentInfo.baseItem;
-      }
-    }
-  }
-
-  // check if item qualifies for having playback speed control available
-  if (!metadata.qualifiesForPlaybackSpeedControl &&
-      parent != null &&
-      (parent.runTimeTicks ?? 0) > MetadataProvider.speedControlLongAlbumDuration.inMicroseconds * 10) {
-    metadata.qualifiesForPlaybackSpeedControl = true;
-  }
-
-  if (parent != null) {
-    metadata.parentNormalizationGain = parent.normalizationGain;
-  }
-
-  if (request.includeLyrics && metadata.hasLyrics) {
-    //!!! only use offline metadata if the app is in offline mode
-    // Finamp should always use the server metadata when online, if possible
-    if (FinampSettingsHelper.finampSettings.isOffline) {
-      DownloadedLyrics? downloadedLyrics;
-      downloadedLyrics = await downloadsService.getLyricsDownload(baseItem: request.item);
-      if (downloadedLyrics != null) {
-        metadata.lyrics = downloadedLyrics.lyricDto;
-        metadataProviderLogger.fine("Got offline lyrics for '${request.item.name}'");
-      } else {
-        metadataProviderLogger.fine("No offline lyrics for '${request.item.name}'");
-      }
-    } else {
-      metadataProviderLogger.fine("Fetching lyrics for '${request.item.name}' (${request.item.id})");
-      try {
-        final lyrics = await jellyfinApiHelper.getLyrics(itemId: request.item.id);
-        metadata.lyrics = lyrics;
-      } catch (e) {
-        metadataProviderLogger.warning(
-          "Failed to fetch lyrics for '${request.item.name}' (${request.item.id}). Metadata might be stale",
-          e,
-        );
-      }
-    }
-  }
-
-  metadataProviderLogger.fine(
-    "Fetched metadata for '${request.item.name}' (${request.item.id}): ${metadata.lyrics} ${metadata.hasLyrics}",
-  );
-
-  return metadata;
-});
+    });

--- a/lib/services/metadata_provider.dart
+++ b/lib/services/metadata_provider.dart
@@ -11,15 +11,10 @@ import 'jellyfin_api_helper.dart';
 final metadataProviderLogger = Logger("MetadataProvider");
 
 class MetadataRequest {
-  const MetadataRequest({
-    required this.item,
-    this.queueItem,
-    this.includeLyrics = false,
-    this.checkIfSpeedControlNeeded = false,
-  }) : super();
+  const MetadataRequest({required this.item, this.includeLyrics = false, this.checkIfSpeedControlNeeded = false})
+    : super();
 
   final BaseItemDto item;
-  final FinampQueueItem? queueItem;
 
   final bool includeLyrics;
   final bool checkIfSpeedControlNeeded;
@@ -29,12 +24,11 @@ class MetadataRequest {
     return other is MetadataRequest &&
         other.includeLyrics == includeLyrics &&
         other.checkIfSpeedControlNeeded == checkIfSpeedControlNeeded &&
-        other.item.id == item.id &&
-        other.queueItem?.id == queueItem?.id;
+        other.item.id == item.id;
   }
 
   @override
-  int get hashCode => Object.hash(item.id, queueItem?.id, includeLyrics, checkIfSpeedControlNeeded);
+  int get hashCode => Object.hash(item.id, includeLyrics, checkIfSpeedControlNeeded);
 }
 
 /// A storage container for metadata about a track.  The codec information will reflect

--- a/lib/services/metadata_provider.dart
+++ b/lib/services/metadata_provider.dart
@@ -53,9 +53,6 @@ class MetadataProvider {
 
 final AutoDisposeFutureProviderFamily<MetadataProvider?, MetadataRequest> metadataProvider = FutureProvider.autoDispose
     .family<MetadataProvider?, MetadataRequest>((ref, request) async {
-      // watch settings to trigger re-fetching metadata when offline mode changes
-      ref.watch(finampSettingsProvider.isOffline);
-
       Future<BaseItemDto?>? parentFuture;
       if (request.item.parentId != null) {
         parentFuture = ref.watch(albumProvider(request.item.parentId!).future);
@@ -119,7 +116,7 @@ final AutoDisposeFutureProviderFamily<MetadataProvider?, MetadataRequest> metada
 
       //!!! only use offline metadata if the app is in offline mode
       // Finamp should always use the server metadata when online, if possible
-      if (FinampSettingsHelper.finampSettings.isOffline) {
+      if (ref.watch(finampSettingsProvider.isOffline)) {
         playbackInfo = localPlaybackInfo;
       } else {
         // fetch from server in online mode
@@ -185,7 +182,7 @@ final AutoDisposeFutureProviderFamily<MetadataProvider?, MetadataRequest> metada
       if (request.includeLyrics && metadata.hasLyrics) {
         //!!! only use offline metadata if the app is in offline mode
         // Finamp should always use the server metadata when online, if possible
-        if (FinampSettingsHelper.finampSettings.isOffline) {
+        if (ref.watch(finampSettingsProvider.isOffline)) {
           DownloadedLyrics? downloadedLyrics;
           downloadedLyrics = await downloadsService.getLyricsDownload(baseItem: request.item);
           if (downloadedLyrics != null) {

--- a/lib/services/music_player_background_task.dart
+++ b/lib/services/music_player_background_task.dart
@@ -300,13 +300,14 @@ class MusicPlayerBackgroundTask extends BaseAudioHandler {
     // Propagate all events from the audio player to AudioService clients.
     int? replayQueueIndex;
     _player.playbackEventStream.listen((event) async {
-      if (!(_player.sequenceState?.sequence.isEmpty ?? true)) {
+      final playerSequence = _player.sequenceState?.sequence;
+      if (playerSequence != null && playerSequence.isNotEmpty) {
         if (event.currentIndex != replayQueueIndex) {
           replayQueueIndex = event.currentIndex;
           if (replayQueueIndex != null) {
             var queueItem =
                 // event.currentIndex is based on the original sequence, not the effectiveSequence
-                _player.sequenceState?.sequence[replayQueueIndex!].tag as FinampQueueItem?;
+                playerSequence[replayQueueIndex!].tag as FinampQueueItem?;
             if (queueItem != null) {
               _applyVolumeNormalization(queueItem.item);
             }

--- a/lib/services/music_player_background_task.dart
+++ b/lib/services/music_player_background_task.dart
@@ -11,6 +11,7 @@ import 'package:finamp/models/jellyfin_models.dart' as jellyfin_models;
 import 'package:finamp/services/favorite_provider.dart';
 import 'package:finamp/services/jellyfin_api_helper.dart';
 import 'package:finamp/services/queue_service.dart';
+import 'package:finamp/services/current_track_metadata_provider.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
@@ -24,6 +25,7 @@ import 'package:rxdart/rxdart.dart';
 import 'android_auto_helper.dart';
 import 'finamp_settings_helper.dart';
 import 'locale_helper.dart';
+import 'metadata_provider.dart';
 
 enum FadeDirection { fadeIn, fadeOut, none }
 
@@ -941,13 +943,12 @@ class MusicPlayerBackgroundTask extends BaseAudioHandler {
     if (FinampSettingsHelper.finampSettings.volumeNormalizationActive && currentTrack != null) {
       final baseItem = jellyfin_models.BaseItemDto.fromJson(currentTrack.extras?["itemJson"] as Map<String, dynamic>);
 
-      double? effectiveGainChange = getEffectiveGainChange(currentTrack, baseItem);
+      double? effectiveGainChange = getGainForCurrentPlayback(currentTrack, baseItem);
 
       _volumeNormalizationLogger.info(
         "normalization gain for '${baseItem.name}': $effectiveGainChange (track gain change: ${baseItem.normalizationGain})",
       );
       if (effectiveGainChange != null) {
-        _volumeNormalizationLogger.info("Gain change: $effectiveGainChange");
         if (Platform.isAndroid) {
           _loudnessEnhancerEffect?.setTargetGain(
             effectiveGainChange / 10.0,
@@ -1083,20 +1084,48 @@ class MusicPlayerBackgroundTask extends BaseAudioHandler {
   double get volume => _player.volume;
   bool get paused => !_player.playing;
   Duration get playbackPosition => _player.position;
+
+  void onQueueServiceAvailable() {
+    // Moved here because currentTrackMetadataProvider depends on queueService
+    // If metadataProvider is sloooooow, this allows it to catch up
+    GetIt.instance<ProviderContainer>().listen(currentTrackMetadataProvider, (previous, next) {
+      if (FinampSettingsHelper.finampSettings.volumeNormalizationMode != VolumeNormalizationMode.albumBased &&
+          FinampSettingsHelper.finampSettings.volumeNormalizationMode != VolumeNormalizationMode.hybrid) {
+        return;
+      }
+      if (previous?.valueOrNull?.parentNormalizationGain != next.valueOrNull?.parentNormalizationGain) {
+        _applyVolumeNormalization(mediaItem.valueOrNull);
+      }
+    });
+  }
 }
 
-double? getEffectiveGainChange(MediaItem currentTrack, jellyfin_models.BaseItemDto? item) {
+double? getGainForCurrentPlayback(MediaItem currentTrack, jellyfin_models.BaseItemDto? item) {
   final baseItem =
       item ?? jellyfin_models.BaseItemDto.fromJson(currentTrack.extras?["itemJson"] as Map<String, dynamic>);
+
   double? effectiveGainChange;
   switch (FinampSettingsHelper.finampSettings.volumeNormalizationMode) {
-    case VolumeNormalizationMode.hybrid:
-      // case VolumeNormalizationMode.albumBased: // we use the context normalization gain for album-based because we don't have the album item here
-      // use context normalization gain if available, otherwise use track normalization gain
-      effectiveGainChange = currentTrack.extras?["contextNormalizationGain"] as double? ?? baseItem.normalizationGain;
+    case VolumeNormalizationMode.hybrid when GetIt.instance<QueueService>().getQueue().isCurrentlyPlayingTracksFromSameAlbum():
+    case VolumeNormalizationMode.albumBased:
+      final providerContainer = GetIt.instance<ProviderContainer>();
+      // final parentNormalizationGain = providerContainer.read(currentTrackMetadataProvider).valueOrNull?.parentNormalizationGain;
+      // includeLyrics is always true - fetch the metadataRequest directly.
+      // Requires that provided arguments are the only fields of request,
+      // along with `includeLyrics` always being true in currentTrackMetadataProvider
+      // Otherwise, use code commented above
+      final parentNormalizationGain = providerContainer
+          .read(metadataProvider(MetadataRequest(item: baseItem, includeLyrics: true)))
+          .valueOrNull
+          ?.parentNormalizationGain;
+
+      effectiveGainChange =
+          parentNormalizationGain ??
+          (currentTrack.extras?["contextNormalizationGain"] as double?) ??
+          baseItem.normalizationGain;
       break;
+    case VolumeNormalizationMode.hybrid:
     case VolumeNormalizationMode.trackBased:
-      // only ever use track normalization gain
       effectiveGainChange = baseItem.normalizationGain;
       break;
     case VolumeNormalizationMode.albumOnly:

--- a/lib/services/music_player_background_task.dart
+++ b/lib/services/music_player_background_task.dart
@@ -343,6 +343,15 @@ class MusicPlayerBackgroundTask extends BaseAudioHandler {
       }
     });
 
+    // This is called each time queue (or at least previous and next items in it)
+    // This unintended behavior is actually used to recalculate the `Dynamic` 4
+    // normalization gain mode.
+    // if user adds a track from the same album next to queue or makes previous
+    // and next track in the queue not from the same album anymore (e.g. by
+    // removing them from queue), volume gain is recalculated instantly so that
+    // it is not changed on track change (where gapless playback will regress to
+    // audible volume change).
+    // This is possible because this callback is called on each queue change
     mediaItem.listen((currentTrack) {
       sleepTimer?.onTrackCompleted();
 

--- a/lib/services/music_player_background_task.dart
+++ b/lib/services/music_player_background_task.dart
@@ -1115,7 +1115,7 @@ double? getGainForCurrentPlayback(MediaItem currentTrack, jellyfin_models.BaseIt
       // along with `includeLyrics` always being true in currentTrackMetadataProvider
       // Otherwise, use code commented above
       final parentNormalizationGain = providerContainer
-          .read(metadataProvider(MetadataRequest(item: baseItem, includeLyrics: true)))
+          .read(metadataProvider(baseItem))
           .valueOrNull
           ?.parentNormalizationGain;
 

--- a/lib/services/queue_service.dart
+++ b/lib/services/queue_service.dart
@@ -1345,3 +1345,14 @@ class NextUpShuffleOrder extends ShuffleOrder {
     indices.clear();
   }
 }
+
+extension SequentialTracks on FinampQueueInfo {
+  bool isCurrentlyPlayingTracksFromSameAlbum() {
+    final currentTrackAlbum = currentTrack?.baseItem?.parentId;
+    if (currentTrackAlbum == null) return false;
+    final previousTrackAlbum = previousTracks.lastOrNull?.baseItem?.parentId;
+    final nextTrackAlbum = (nextUp.firstOrNull ?? queue.firstOrNull)?.baseItem?.parentId;
+
+    return previousTrackAlbum == currentTrackAlbum || currentTrackAlbum == nextTrackAlbum;
+  }
+}


### PR DESCRIPTION
## Changes

This PR uses album gain separately fetched from jellyfin server via `currentTrackMetadataProvider`.

<details>
<summary>Previous text</summary>

This fixes https://github.com/jmshrv/finamp/issues/1102.. and adds a bunch of new bugs (don't know any but it is inevitable, I know)

I had a bunch of ideas how to fix that, however I found [this issue in jellyfin](https://github.com/jellyfin/jellyfin/issues/14346) (can be linked as upstream to #1102 btw), where [it is told](https://github.com/jellyfin/jellyfin/issues/14346#issuecomment-2988016426) that jellyfin averages track gains to get album gain. Knowing that, my implementation averages known part of album, removing the need to do any network requests or changing jellyfin API.

<sup>(however the latter would be very good but I know dotnet (0 hours) even less than Dart (3-4 hours before I abandoned it))</sup>

The algorithm: take tracks from the same album before and after currently playing track (so that resulting list is subset of tracks of their album), then average their gain to get "album" gain.

Due to my lack of experience in Dart language, I think this PR is more a PoC than a reliable fix. Currently it has production-working asserts (I *probably* tested it on production using `flutter build linux`).

Tested on album Myth by Two Steps from Hell (inside a playlist ofc), first two tracks in my case have like 10db difference and those tracks are the cause of my issue ;-)

And the first commit is to enhance code clarity and improve compiler assurance on soundness (primarily via extracting pointer to queue list for DRY).
</details>

## Todo before merging

- [x] Make a new `Album-based gain` setting
- [x] Handle sequental album tracks in hybrid gain (so that `contextNormalizationGain` is obsolete)
  - [ ] Remove contextNormalizationGain?
- [x] Handle offline mode
- ~~Add "Album-based with fallback to track-based" gain without handling sequental tracks (my own testing feedback :P for some reason singles don't have album gain).~~  
  ~~I think it is worth making current "Album-based gain" the "Album-only gain" (because it is, well, album-only) and add fallback to track gain for "Album-based"~~ We decided to add fallback for album-based gain. The remaining is related to "remove contextNormalizationGain" item
- [x] Create an "album provider" so that albums are cached in memory and not requested for every track in queue

## Related Issues

Fixes https://github.com/jmshrv/finamp/issues/1102

P.s. additional thanks to the author of flake.nix - won't link PR 1299 not to spam but you helped me so much. Before I thought I better base my changes on release tag for usage of `nixpkgs`'s derivation.
P.s.s. those averages can also be calculated at queue modification time for performance at the energy cost (as most of the time those averages won't be used on large playlists)