### PR TITLE
Add Queue to Playlist instead of needing a new playlist

### DIFF
--- a/lib/components/AddToPlaylistScreen/add_to_playlist_button.dart
+++ b/lib/components/AddToPlaylistScreen/add_to_playlist_button.dart
@@ -68,7 +68,7 @@ class _AddToPlaylistButtonState extends ConsumerState<AddToPlaylistButton> {
             bool inPlaylist = queueItemInPlaylist(widget.queueItem);
             await showPlaylistActionsMenu(
               context: context,
-              item: widget.item!,
+              items: [widget.item!],
               parentPlaylist: inPlaylist ? widget.queueItem!.source.item : null,
             );
           },

--- a/lib/components/AddToPlaylistScreen/add_to_playlist_list.dart
+++ b/lib/components/AddToPlaylistScreen/add_to_playlist_list.dart
@@ -21,9 +21,9 @@ import 'new_playlist_dialog.dart';
 import '../../menus/playlist_actions_menu.dart';
 
 class AddToPlaylistList extends StatefulWidget {
-  const AddToPlaylistList({super.key, required this.itemToAdd, required this.playlistsFuture});
+  const AddToPlaylistList({super.key, required this.itemsToAdd, required this.playlistsFuture});
 
-  final BaseItemDto itemToAdd;
+  final List<BaseItemDto> itemsToAdd;
   final Future<List<BaseItemDto>> playlistsFuture;
 
   @override
@@ -54,7 +54,7 @@ class _AddToPlaylistListState extends State<AddToPlaylistList> {
               final (playlist, isLoading, playListItemId) = snapshot.data![index];
               return AddToPlaylistTile(
                 playlist: playlist,
-                track: widget.itemToAdd,
+                tracks: widget.itemsToAdd,
                 playlistItemId: playListItemId,
                 isLoading: isLoading,
               );
@@ -91,7 +91,7 @@ class _AddToPlaylistListState extends State<AddToPlaylistList> {
             onPressed: () async {
               var dialogResult = await showDialog<(Future<BaseItemId>, String?)?>(
                 context: context,
-                builder: (context) => NewPlaylistDialog(itemsToAdd: [widget.itemToAdd.id]),
+                builder: (context) => NewPlaylistDialog(itemsToAdd: widget.itemsToAdd.map((item) {return item.id;}).toList()),
               );
               if (dialogResult != null) {
                 var oldFuture = playlistsFuture;
@@ -101,29 +101,31 @@ class _AddToPlaylistListState extends State<AddToPlaylistList> {
                   ];
                   playlistsFuture = oldFuture.then((value) => value + loadingItem);
                 });
-                try {
-                  var newId = await dialogResult.$1;
-                  // Give the server time to calculate an initial playlist image
-                  await Future.delayed(const Duration(seconds: 1));
-                  final jellyfinApiHelper = GetIt.instance<JellyfinApiHelper>();
-                  var playlist = await jellyfinApiHelper.getItemById(newId);
+                for (var track in widget.itemsToAdd) {
+                  try {
+                    var newId = await dialogResult.$1;
+                    // Give the server time to calculate an initial playlist image
+                    await Future.delayed(const Duration(seconds: 1));
+                    final jellyfinApiHelper = GetIt.instance<JellyfinApiHelper>();
+                    var playlist = await jellyfinApiHelper.getItemById(newId);
 
-                  String? trackId;
-                  if (BaseItemDtoType.fromItem(widget.itemToAdd) == BaseItemDtoType.track) {
-                    var playlistItems = await jellyfinApiHelper.getItems(parentItem: playlist, fields: "");
-                    trackId = playlistItems?.firstWhere((element) => element.id == widget.itemToAdd.id).playlistItemId;
-                  } else {
-                    // Provide a fake playlist id for playlists created with a non-track initial item.  It
-                    // will not be used as non-tracks cannot be removed.
-                    trackId = "";
+                    String? trackId;
+                    if (BaseItemDtoType.fromItem(track) == BaseItemDtoType.track) {
+                      var playlistItems = await jellyfinApiHelper.getItems(parentItem: playlist, fields: "");
+                      trackId = playlistItems?.firstWhere((element) => element.id == track.id).playlistItemId;
+                    } else {
+                      // Provide a fake playlist id for playlists created with a non-track initial item.  It
+                      // will not be used as non-tracks cannot be removed.
+                      trackId = "";
+                    }
+                    if (!context.mounted) return;
+                    setState(() {
+                      var newItem = [(playlist, false, trackId)];
+                      playlistsFuture = oldFuture.then((value) => value + newItem);
+                    });
+                  } catch (e) {
+                    GlobalSnackbar.error(e);
                   }
-                  if (!context.mounted) return;
-                  setState(() {
-                    var newItem = [(playlist, false, trackId)];
-                    playlistsFuture = oldFuture.then((value) => value + newItem);
-                  });
-                } catch (e) {
-                  GlobalSnackbar.error(e);
                 }
               }
             },
@@ -139,12 +141,12 @@ class AddToPlaylistTile extends ConsumerStatefulWidget {
     super.key,
     required this.playlist,
     this.playlistItemId,
-    required this.track,
+    required this.tracks,
     this.isLoading = false,
   });
 
   final BaseItemDto playlist;
-  final BaseItemDto track;
+  final List<BaseItemDto> tracks;
   final String? playlistItemId;
   final bool isLoading;
 
@@ -177,7 +179,9 @@ class _AddToPlaylistTileState extends ConsumerState<AddToPlaylistTile> {
         itemIsIncluded = true;
       } else {
         final downloadsService = GetIt.instance<DownloadsService>();
-        itemIsIncluded = downloadsService.checkIfInCollection(widget.playlist, widget.track);
+        for (var track in widget.tracks) {
+          itemIsIncluded = downloadsService.checkIfInCollection(widget.playlist, track);
+        }
       }
     }
   }
@@ -196,10 +200,10 @@ class _AddToPlaylistTileState extends ConsumerState<AddToPlaylistTile> {
           ? TablerIcons.circle_dashed_plus
           : TablerIcons.circle_plus,
       initialState: itemIsIncluded ?? false,
-      onToggle: (bool currentState) async {
-        if (currentState) {
+      onToggle: (bool alreadyInPlaylist) async {
+        if (alreadyInPlaylist) {
           // Only tracks can be removed from playlists
-          if (BaseItemDtoType.fromItem(widget.track) != BaseItemDtoType.track) {
+          if (BaseItemDtoType.fromItem(widget.tracks.first) != BaseItemDtoType.track) {
             return true;
           }
           // If playlistItemId is null, we need to fetch from the server before we can remove
@@ -207,7 +211,7 @@ class _AddToPlaylistTileState extends ConsumerState<AddToPlaylistTile> {
             final jellyfinApiHelper = GetIt.instance<JellyfinApiHelper>();
             var newItems = await jellyfinApiHelper.getItems(parentItem: widget.playlist, fields: "");
 
-            playlistItemId = newItems?.firstWhereOrNull((x) => x.id == widget.track.id)?.playlistItemId;
+            playlistItemId = newItems?.firstWhereOrNull((x) => x.id == widget.tracks.first.id)?.playlistItemId;
             if (playlistItemId == null) {
               // We were already not part of the playlist,. so removal is complete
               setState(() {
@@ -223,7 +227,7 @@ class _AddToPlaylistTileState extends ConsumerState<AddToPlaylistTile> {
           // part of playlist, remove
           bool removed = await removeFromPlaylist(
             context,
-            widget.track,
+            widget.tracks.first,
             widget.playlist,
             playlistItemId!,
             confirm: false,
@@ -236,22 +240,49 @@ class _AddToPlaylistTileState extends ConsumerState<AddToPlaylistTile> {
           }
           return !removed;
         } else {
-          // add to playlist
-          if (BaseItemDtoType.fromItem(widget.track) != BaseItemDtoType.track) {
+          if (widget.tracks.length == 1) {
+            // add to playlist
+            if (BaseItemDtoType.fromItem(widget.tracks.first) != BaseItemDtoType.track) {
+              bool confirmed = false;
+              String itemType = switch (widget.tracks.first.type) {
+                "MusicAlbum" => "album",
+                "MusicArtist" => "artist",
+                "MusicGenre" => "genre",
+                "Playlist" => "playlist",
+                _ => "unknown",
+              };
+              await showDialog(
+                context: context,
+                builder: (context) => ConfirmationPromptDialog(
+                  promptText: AppLocalizations.of(
+                    context,
+                  )!.confirmAddAlbumToPlaylist(itemType, widget.tracks.first.name ?? "Unknown"),
+                  confirmButtonText: AppLocalizations.of(context)!.addButtonLabel,
+                  abortButtonText: MaterialLocalizations.of(context).cancelButtonLabel,
+                  onConfirmed: () => confirmed = true,
+                  onAborted: () {},
+                ),
+              );
+              if (!confirmed || !context.mounted) return false;
+            }
+            bool added = await addItemToPlaylist(context, widget.tracks.first, widget.playlist);
+            if (added) {
+              final jellyfinApiHelper = GetIt.instance<JellyfinApiHelper>();
+              var newItems = await jellyfinApiHelper.getItems(parentItem: widget.playlist, fields: "");
+              setState(() {
+                childCount = newItems?.length ?? 0;
+                playlistItemId = newItems?.firstWhereOrNull((x) => x.id == widget.tracks.first.id)?.playlistItemId;
+                itemIsIncluded = true;
+              });
+              return true; // this is called before the state is updated
+            }
+            return false;
+          } else {
             bool confirmed = false;
-            String itemType = switch (widget.track.type) {
-              "MusicAlbum" => "album",
-              "MusicArtist" => "artist",
-              "MusicGenre" => "genre",
-              "Playlist" => "playlist",
-              _ => "unknown",
-            };
             await showDialog(
               context: context,
               builder: (context) => ConfirmationPromptDialog(
-                promptText: AppLocalizations.of(
-                  context,
-                )!.confirmAddAlbumToPlaylist(itemType, widget.track.name ?? "Unknown"),
+                promptText: "Add X items to playlist?",
                 confirmButtonText: AppLocalizations.of(context)!.addButtonLabel,
                 abortButtonText: MaterialLocalizations.of(context).cancelButtonLabel,
                 onConfirmed: () => confirmed = true,
@@ -259,19 +290,20 @@ class _AddToPlaylistTileState extends ConsumerState<AddToPlaylistTile> {
               ),
             );
             if (!confirmed || !context.mounted) return false;
+
+            bool added = await addItemsToPlaylist(context, widget.tracks, widget.playlist);
+            if (added) {
+              final jellyfinApiHelper = GetIt.instance<JellyfinApiHelper>();
+              var newItems = await jellyfinApiHelper.getItems(parentItem: widget.playlist, fields: "");
+              setState(() {
+                childCount = newItems?.length ?? 0;
+                playlistItemId = newItems?.firstWhereOrNull((x) => x.id == widget.tracks.first.id)?.playlistItemId;
+                itemIsIncluded = true;
+              });
+              return true; // this is called before the state is updated
+            }
+            return false;
           }
-          bool added = await addItemToPlaylist(context, widget.track, widget.playlist);
-          if (added) {
-            final jellyfinApiHelper = GetIt.instance<JellyfinApiHelper>();
-            var newItems = await jellyfinApiHelper.getItems(parentItem: widget.playlist, fields: "");
-            setState(() {
-              childCount = newItems?.length ?? 0;
-              playlistItemId = newItems?.firstWhereOrNull((x) => x.id == widget.track.id)?.playlistItemId;
-              itemIsIncluded = true;
-            });
-            return true; // this is called before the state is updated
-          }
-          return false;
         }
       },
       enabled: !isOffline,

--- a/lib/components/PlayerScreen/queue_source_helper.dart
+++ b/lib/components/PlayerScreen/queue_source_helper.dart
@@ -122,9 +122,9 @@ Future<bool> removeFromPlaylist(
   return false;
 }
 
-Future<bool> addItemToPlaylist(BuildContext context, BaseItemDto item, BaseItemDto parent) async {
+Future<bool> addItemsToPlaylist(BuildContext context, List<BaseItemDto> items, BaseItemDto parent) async {
   //TODO request server to return the new playlist item id
-  await GetIt.instance<JellyfinApiHelper>().addItemstoPlaylist(playlistId: parent.id, ids: [item.id]);
+  await GetIt.instance<JellyfinApiHelper>().addItemstoPlaylist(playlistId: parent.id, ids: items.map((item) {return item.id;}).toList() );
 
   // re-sync playlist to download added item if needed
   final downloadsService = GetIt.instance<DownloadsService>();
@@ -139,6 +139,10 @@ Future<bool> addItemToPlaylist(BuildContext context, BaseItemDto item, BaseItemD
   GlobalSnackbar.message((scaffold) => AppLocalizations.of(context)!.confirmAddedToPlaylist, isConfirmation: true);
   return true;
 }
+Future<bool> addItemToPlaylist(BuildContext context, BaseItemDto item, BaseItemDto parent) async {
+  return addItemsToPlaylist(context, [item], parent);
+}
+
 
 // Removed playlist items will persist in queue with playlist source.  Store removed items
 // to hide remove from playlist prompt on those items.

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -974,9 +974,9 @@
   "@stopAndClearQueue": {
     "description": "Label for a button that stops playback and removes all tracks from the queue."
   },
-  "createPlaylistFromCurrentQueue": "Save Queue as Playlist",
+  "createPlaylistFromCurrentQueue": "Add Queue as Playlist",
   "@createPlaylistFromCurrentQueue": {
-    "description": "Label for a button that creates a new playlist from the current queue."
+    "description": "Label for a button that opens the playlist selection menu to add items from the current queue to a playlist."
   },
   "playingFrom": "Playing from",
   "@playingFrom": {

--- a/lib/menus/components/menuEntries/add_to_playlist_menu_entry.dart
+++ b/lib/menus/components/menuEntries/add_to_playlist_menu_entry.dart
@@ -29,7 +29,7 @@ class AddToPlaylistMenuEntry extends ConsumerWidget implements HideableMenuEntry
           bool inPlaylist = queueItemInPlaylist(queueItem);
           showPlaylistActionsMenu(
             context: context,
-            item: baseItem,
+            items: [baseItem],
             parentPlaylist: inPlaylist ? queueItem!.source.item : null,
           );
         },

--- a/lib/menus/components/menuEntries/create_playlist_from_current_queue.dart
+++ b/lib/menus/components/menuEntries/create_playlist_from_current_queue.dart
@@ -1,6 +1,7 @@
 import 'package:finamp/components/AddToPlaylistScreen/new_playlist_dialog.dart';
 import 'package:finamp/l10n/app_localizations.dart';
 import 'package:finamp/menus/components/menuEntries/menu_entry.dart';
+import 'package:finamp/menus/playlist_actions_menu.dart';
 import 'package:finamp/models/jellyfin_models.dart';
 import 'package:finamp/services/queue_service.dart';
 import 'package:flutter/material.dart';
@@ -19,15 +20,17 @@ class CreatePlaylistFromCurrentQueueMenuEntry extends ConsumerWidget implements 
       icon: TablerIcons.list_tree,
       title: AppLocalizations.of(context)!.createPlaylistFromCurrentQueue,
       onTap: () async {
+        if (context.mounted) Navigator.pop(context);
         final currentQueue = queueService.getQueue();
 
-        if (context.mounted) Navigator.pop(context);
-        var dialogResult = await showDialog<(Future<BaseItemId>, String?)?>(
-          context: context,
-          builder: (context) => NewPlaylistDialog(
-            itemsToAdd: currentQueue.fullQueue.map((item) => item.baseItemId).toList(),
-            initialName: currentQueue.source.name.getLocalized(context),
-          ),
+        await showPlaylistActionsMenu(
+          context: context, 
+          items: currentQueue.fullQueue
+            .where((item) => item.baseItem != null)
+            .map((item) {
+              return item.baseItem!;
+            })
+            .toList()
         );
       },
     );

--- a/lib/menus/playlist_actions_menu.dart
+++ b/lib/menus/playlist_actions_menu.dart
@@ -20,7 +20,7 @@ const playlistActionsMenuRouteName = "/playlist-actions-menu";
 
 Future<void> showPlaylistActionsMenu({
   required BuildContext context,
-  required BaseItemDto item,
+  required List<BaseItemDto> items,
   BaseItemDto? parentPlaylist,
 }) async {
   final jellyfinApiHelper = GetIt.instance<JellyfinApiHelper>();
@@ -31,18 +31,18 @@ Future<void> showPlaylistActionsMenu({
 
   await showThemedBottomSheet(
     context: context,
-    item: item,
+    item: items.length == 1 ? items.first : null,
     routeName: playlistActionsMenuRouteName,
     minDraggableHeight: 0.2,
     buildSlivers: (context) {
       var themeColor = Theme.of(context).colorScheme.primary;
 
       final menuEntries = [
-        MenuItemInfoHeader.condensed(item: item),
-        const SizedBox(height: 16),
-        Consumer(
+        if (items.length == 1) MenuItemInfoHeader.condensed(item: items.first),
+        if (items.length == 1) const SizedBox(height: 16),
+        if (items.length == 1) Consumer(
           builder: (context, ref, child) {
-            bool isFavorite = ref.watch(isFavoriteProvider(item));
+            bool isFavorite = ref.watch(isFavoriteProvider(items.first));
             return PlaylistActionsPlaylistListTile(
               title: AppLocalizations.of(context)!.favorites,
               leading: AspectRatio(
@@ -57,7 +57,7 @@ Future<void> showPlaylistActionsMenu({
               initialState: isFavorite,
               tapFeedback: false,
               onToggle: (bool currentState) async {
-                return ref.read(isFavoriteProvider(item).notifier).updateFavorite(!isFavorite);
+                return ref.read(isFavoriteProvider(items.first).notifier).updateFavorite(!isFavorite);
               },
               enabled: !ref.watch(finampSettingsProvider.isOffline),
             );
@@ -68,7 +68,7 @@ Future<void> showPlaylistActionsMenu({
           initialData: parentPlaylist,
           builder: (context, snapshot) {
             if (snapshot.data != null) {
-              return AddToPlaylistTile(playlist: snapshot.data!, track: item, playlistItemId: item.playlistItemId);
+              return AddToPlaylistTile(playlist: snapshot.data!, tracks: items, playlistItemId: items.length == 1 ? items.first.playlistItemId : null);
             } else {
               return const SizedBox.shrink();
             }
@@ -95,7 +95,7 @@ Future<void> showPlaylistActionsMenu({
           sliver: MenuMask(
             height: PlaylistActionsMenuHeader.defaultHeight,
             child: AddToPlaylistList(
-              itemToAdd: item,
+              itemsToAdd: items,
               playlistsFuture: playlistsFuture.then(
                 (value) => (value?.where((element) => element.id != parentPlaylist?.id).toList() ?? []),
               ),


### PR DESCRIPTION
## Changes
Instead of just creating a new playlist and adding all the items in the queue, it is now possible to add to an existing playlist

### Note
Since the whole adding to playlist system is based around adding one item at a time, I needed to change quite a bit and this may not be the optimal solution. My testing concludes that everything still works as expected at least, though some extra testing cant hurt :)


## Todo before merging
- [ ] Translations

## Related Issues
closes https://github.com/jmshrv/finamp/issues/586