### PR TITLE
[Redesign] Various themeing fixes

### DIFF
--- a/lib/components/AddToPlaylistScreen/add_to_playlist_button.dart
+++ b/lib/components/AddToPlaylistScreen/add_to_playlist_button.dart
@@ -1,20 +1,18 @@
 import 'package:finamp/components/PlayerScreen/queue_source_helper.dart';
 import 'package:finamp/components/global_snackbar.dart';
+import 'package:finamp/l10n/app_localizations.dart';
 import 'package:finamp/models/finamp_models.dart';
 import 'package:finamp/models/jellyfin_models.dart';
 import 'package:finamp/services/favorite_provider.dart';
 import 'package:finamp/services/feedback_helper.dart';
 import 'package:finamp/services/finamp_settings_helper.dart';
-import 'package:finamp/services/queue_service.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/semantics.dart';
-import 'package:finamp/l10n/app_localizations.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:get_it/get_it.dart';
 
 import '../../menus/playlist_actions_menu.dart';
 
-class AddToPlaylistButton extends ConsumerStatefulWidget {
+class AddToPlaylistButton extends ConsumerWidget {
   const AddToPlaylistButton({super.key, required this.item, this.queueItem, this.color, this.size, this.visualDensity});
 
   final BaseItemDto? item;
@@ -24,19 +22,12 @@ class AddToPlaylistButton extends ConsumerStatefulWidget {
   final VisualDensity? visualDensity;
 
   @override
-  ConsumerState<AddToPlaylistButton> createState() => _AddToPlaylistButtonState();
-}
-
-class _AddToPlaylistButtonState extends ConsumerState<AddToPlaylistButton> {
-  final _queueService = GetIt.instance<QueueService>();
-
-  @override
-  Widget build(BuildContext context) {
-    if (widget.item == null) {
+  Widget build(BuildContext context, WidgetRef ref) {
+    if (item == null) {
       return const SizedBox.shrink();
     }
 
-    bool isFav = ref.watch(isFavoriteProvider(widget.item));
+    bool isFav = ref.watch(isFavoriteProvider(item));
     return Semantics.fromProperties(
       properties: SemanticsProperties(
         label: AppLocalizations.of(context)!.addToPlaylistTooltip,
@@ -48,28 +39,28 @@ class _AddToPlaylistButtonState extends ConsumerState<AddToPlaylistButton> {
       child: GestureDetector(
         onLongPress: () async {
           FeedbackHelper.feedback(FeedbackType.selection);
-          ref.read(isFavoriteProvider(widget.item).notifier).updateFavorite(!isFav);
+          ref.read(isFavoriteProvider(item).notifier).updateFavorite(!isFav);
         },
         onSecondaryTap: () async {
           FeedbackHelper.feedback(FeedbackType.selection);
-          ref.read(isFavoriteProvider(widget.item).notifier).updateFavorite(!isFav);
+          ref.read(isFavoriteProvider(item).notifier).updateFavorite(!isFav);
         },
         child: IconButton(
-          icon: Icon(isFav ? Icons.favorite : Icons.favorite_outline, size: widget.size ?? 24.0),
-          color: widget.color ?? IconTheme.of(context).color,
-          disabledColor: (widget.color ?? IconTheme.of(context).color)!.withOpacity(0.3),
-          visualDensity: widget.visualDensity ?? VisualDensity.compact,
+          icon: Icon(isFav ? Icons.favorite : Icons.favorite_outline, size: size ?? 24.0),
+          color: color ?? IconTheme.of(context).color,
+          disabledColor: (color ?? IconTheme.of(context).color)!.withOpacity(0.3),
+          visualDensity: visualDensity ?? VisualDensity.compact,
           // tooltip: AppLocalizations.of(context)!.addToPlaylistTooltip,
           onPressed: () async {
             if (FinampSettingsHelper.finampSettings.isOffline) {
               return GlobalSnackbar.message((context) => AppLocalizations.of(context)!.notAvailableInOfflineMode);
             }
 
-            bool inPlaylist = queueItemInPlaylist(widget.queueItem);
+            bool inPlaylist = queueItemInPlaylist(queueItem);
             await showPlaylistActionsMenu(
               context: context,
-              items: [widget.item!],
-              parentPlaylist: inPlaylist ? widget.queueItem!.source.item : null,
+              items: [item!],
+              parentPlaylist: inPlaylist ? queueItem!.source.item : null,
             );
           },
         ),

--- a/lib/components/LogsScreen/log_tile.dart
+++ b/lib/components/LogsScreen/log_tile.dart
@@ -1,8 +1,8 @@
 import 'package:clipboard/clipboard.dart';
+import 'package:finamp/l10n/app_localizations.dart';
 import 'package:finamp/services/censored_log.dart';
 import 'package:finamp/services/contains_login.dart';
 import 'package:flutter/material.dart';
-import 'package:finamp/l10n/app_localizations.dart';
 import 'package:logging/logging.dart';
 
 import '../global_snackbar.dart';
@@ -30,14 +30,14 @@ class _LogTileState extends State<LogTile> {
         try {
           await FlutterClipboard.copy(widget.logRecord.censoredMessage);
         } catch (e) {
-          errorSnackbar(e, context);
+          GlobalSnackbar.error(e);
         }
       },
       onSecondaryTap: () async {
         try {
           await FlutterClipboard.copy(widget.logRecord.censoredMessage);
         } catch (e) {
-          errorSnackbar(e, context);
+          GlobalSnackbar.error(e);
         }
       },
       child: Card(
@@ -72,9 +72,9 @@ class _LogTileState extends State<LogTile> {
             Text(AppLocalizations.of(context)!.message, style: Theme.of(context).textTheme.titleLarge),
             _LogMessageContent(widget.logRecord.message),
             const SizedBox(height: 16.0),
-            if (widget.logRecord.stackTrace != null)
+            if (widget.logRecord.getStack != null)
               Text(AppLocalizations.of(context)!.stackTrace, style: Theme.of(context).textTheme.titleLarge),
-            if (widget.logRecord.stackTrace != null) _LogMessageContent(widget.logRecord.stackTrace.toString()),
+            if (widget.logRecord.getStack != null) _LogMessageContent(widget.logRecord.getStack.toString()),
           ],
           onExpansionChanged: (value) async {
             if (value && !hasConfirmed && widget.logRecord.containsLogin) {

--- a/lib/components/MusicScreen/item_collection_list_tile.dart
+++ b/lib/components/MusicScreen/item_collection_list_tile.dart
@@ -2,13 +2,13 @@ import 'dart:io';
 
 import 'package:finamp/components/favorite_button.dart';
 import 'package:finamp/components/print_duration.dart';
+import 'package:finamp/l10n/app_localizations.dart';
 import 'package:finamp/services/current_album_image_provider.dart';
+import 'package:finamp/services/datetime_helper.dart';
 import 'package:finamp/services/finamp_settings_helper.dart';
 import 'package:finamp/services/finamp_user_helper.dart';
-import 'package:finamp/services/datetime_helper.dart';
 import 'package:finamp/services/theme_provider.dart';
 import 'package:flutter/material.dart';
-import 'package:finamp/l10n/app_localizations.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_tabler_icons/flutter_tabler_icons.dart';
 import 'package:get_it/get_it.dart';
@@ -202,31 +202,35 @@ class ItemCollectionListTile extends ConsumerWidget {
     final unthemedListTile = Builder(
       // get updated context after the theme is applied
       builder: (context) {
-        return ListTile(
-          textColor: Theme.of(context).textTheme.bodyLarge?.color,
-          tileColor: Theme.of(context).colorScheme.surfaceContainer,
-          contentPadding: EdgeInsets.symmetric(horizontal: 16.0, vertical: !showSubtitle ? 8.0 : 0.0),
-          onTap: onTap,
-          leading: AlbumImage(item: item),
-          title: titleText,
-          subtitle: (showSubtitle) ? subtitleText : null,
-          trailing: Row(
-            mainAxisSize: MainAxisSize.min,
-            mainAxisAlignment: MainAxisAlignment.end,
-            children: [
-              if ((itemType == BaseItemDtoType.artist
-                      ? jellyfinApiHelper.selectedMixArtists
-                      : (itemType == BaseItemDtoType.genre)
-                      ? jellyfinApiHelper.selectedMixGenres
-                      : jellyfinApiHelper.selectedMixAlbums)
-                  .contains(item))
-                const Icon(Icons.explore),
-              FavoriteButton(
-                item: item,
-                onlyIfFav: true,
-                showFavoriteIconOnlyWhenFilterDisabled: showFavoriteIconOnlyWhenFilterDisabled,
-              ),
-            ],
+        return Padding(
+          padding: const EdgeInsets.only(left: 6.0, right: 6.0),
+          child: ListTile(
+            textColor: Theme.of(context).textTheme.bodyLarge?.color,
+            tileColor: Theme.of(context).colorScheme.surfaceContainer,
+            contentPadding: EdgeInsets.symmetric(horizontal: 10.0, vertical: !showSubtitle ? 8.0 : 0.0),
+            onTap: onTap,
+            leading: AlbumImage(item: item),
+            title: titleText,
+            subtitle: (showSubtitle) ? subtitleText : null,
+            shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(8.0)),
+            trailing: Row(
+              mainAxisSize: MainAxisSize.min,
+              mainAxisAlignment: MainAxisAlignment.end,
+              children: [
+                if ((itemType == BaseItemDtoType.artist
+                        ? jellyfinApiHelper.selectedMixArtists
+                        : (itemType == BaseItemDtoType.genre)
+                        ? jellyfinApiHelper.selectedMixGenres
+                        : jellyfinApiHelper.selectedMixAlbums)
+                    .contains(item))
+                  const Icon(Icons.explore),
+                FavoriteButton(
+                  item: item,
+                  onlyIfFav: true,
+                  showFavoriteIconOnlyWhenFilterDisabled: showFavoriteIconOnlyWhenFilterDisabled,
+                ),
+              ],
+            ),
           ),
         );
       },
@@ -235,9 +239,7 @@ class ItemCollectionListTile extends ConsumerWidget {
     return isCurrentlyPlaying && highlightCurrentItem
         ? ItemTheme(
             item: item,
-            themeTransitionDuration: MediaQuery.of(context).disableAnimations
-                ? Duration.zero
-                : const Duration(milliseconds: 500),
+            themeTransitionDuration: const Duration(milliseconds: 500),
             themeOverride: (imageTheme) {
               return imageTheme.copyWith(
                 colorScheme: imageTheme.colorScheme.copyWith(

--- a/lib/models/finamp_models.dart
+++ b/lib/models/finamp_models.dart
@@ -9,7 +9,6 @@ import 'package:background_downloader/background_downloader.dart';
 import 'package:collection/collection.dart';
 import 'package:finamp/components/global_snackbar.dart';
 import 'package:finamp/l10n/app_localizations.dart';
-import 'package:finamp/services/discord_rpc.dart';
 import 'package:finamp/services/finamp_user_helper.dart';
 import 'package:flutter/material.dart';
 import 'package:get_it/get_it.dart';
@@ -1812,7 +1811,7 @@ enum QueueItemQueueType {
 
 @HiveType(typeId: 54)
 class QueueItemSource {
-  QueueItemSource.rawId({
+  const QueueItemSource.rawId({
     required this.type,
     required this.name,
     required this.id,
@@ -1865,19 +1864,19 @@ class QueueItemSource {
   }) : id = id.raw;
 
   @HiveField(0)
-  QueueItemSourceType type;
+  final QueueItemSourceType type;
 
   @HiveField(1)
-  QueueItemSourceName name;
+  final QueueItemSourceName name;
 
   @HiveField(2)
-  String id;
+  final String id;
 
   @HiveField(3)
-  BaseItemDto? item;
+  final BaseItemDto? item;
 
   @HiveField(4)
-  double? contextNormalizationGain;
+  final double? contextNormalizationGain;
 }
 
 @HiveType(typeId: 55)

--- a/lib/screens/album_screen.dart
+++ b/lib/screens/album_screen.dart
@@ -30,7 +30,7 @@ class _AlbumScreenState extends ConsumerState<AlbumScreen> {
 
   @override
   Widget build(BuildContext context) {
-    final BaseItemDto parent = widget.parent ?? ModalRoute.of(context)!.settings.arguments as BaseItemDto;
+    final BaseItemDto parent = widget.parent ?? ModalRoute.settingsOf(context)!.arguments as BaseItemDto;
 
     return Scaffold(
       extendBody: true,

--- a/lib/screens/artist_screen.dart
+++ b/lib/screens/artist_screen.dart
@@ -32,7 +32,7 @@ class _ArtistScreenState extends ConsumerState<ArtistScreen> {
 
   @override
   Widget build(BuildContext context) {
-    final BaseItemDto artist = widget.widgetArtist ?? ModalRoute.of(context)!.settings.arguments as BaseItemDto;
+    final BaseItemDto artist = widget.widgetArtist ?? ModalRoute.settingsOf(context)!.arguments as BaseItemDto;
 
     return Scaffold(
       extendBody: true,

--- a/lib/screens/blurred_player_screen_background.dart
+++ b/lib/screens/blurred_player_screen_background.dart
@@ -38,7 +38,7 @@ class BlurredPlayerScreenBackground extends ConsumerWidget {
 
     return Positioned.fill(
       child: AnimatedSwitcher(
-        duration: getThemeTransitionDuration(context),
+        duration: getThemeTransitionDuration(context, null),
         switchOutCurve: const Threshold(0.0),
         child: imageProvider == null
             ? placeholderBuilder(null)

--- a/lib/screens/genre_screen.dart
+++ b/lib/screens/genre_screen.dart
@@ -1,5 +1,5 @@
-import 'package:finamp/services/genre_screen_provider.dart';
 import 'package:finamp/services/finamp_user_helper.dart';
+import 'package:finamp/services/genre_screen_provider.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:get_it/get_it.dart';
@@ -33,7 +33,7 @@ class _GenreScreenState extends ConsumerState<GenreScreen> {
 
   @override
   Widget build(BuildContext context) {
-    final BaseItemDto genre = widget.widgetGenre ?? ModalRoute.of(context)!.settings.arguments as BaseItemDto;
+    final BaseItemDto genre = widget.widgetGenre ?? ModalRoute.settingsOf(context)!.arguments as BaseItemDto;
 
     return Scaffold(
       extendBody: true,

--- a/lib/services/environment_metadata.dart
+++ b/lib/services/environment_metadata.dart
@@ -2,14 +2,16 @@
 // for logging, analytics, and diagnostics.
 
 import 'dart:io' show Platform;
+
 import 'package:device_info_plus/device_info_plus.dart';
 import 'package:finamp/models/jellyfin_models.dart';
 import 'package:finamp/services/jellyfin_api_helper.dart';
-import 'package:logging/logging.dart';
-import 'package:package_info_plus/package_info_plus.dart';
 import 'package:get_it/get_it.dart';
 import 'package:json_annotation/json_annotation.dart';
+import 'package:logging/logging.dart';
+import 'package:package_info_plus/package_info_plus.dart';
 import 'package:shared_preferences/shared_preferences.dart';
+
 import 'finamp_user_helper.dart';
 
 part 'environment_metadata.g.dart';
@@ -224,7 +226,7 @@ class EnvironmentMetadata {
 
   String get pretty =>
       "=== METADATA ===\n"
-      "Device Info: ${deviceInfo.pretty}\n"
-      "App Info: ${appInfo.pretty}\n"
-      "Server Info: ${serverInfo?.pretty ?? "Not available"}";
+      "${deviceInfo.pretty}\n"
+      "${appInfo.pretty}\n"
+      "${serverInfo?.pretty ?? "Server Info: Not available"}";
 }

--- a/lib/services/finamp_logs_helper.dart
+++ b/lib/services/finamp_logs_helper.dart
@@ -34,7 +34,7 @@ class FinampLogsHelper {
     if (_logFileWriter != null) {
       // This fails if we log an event before setting up userHelper
       var message = log.censoredMessage;
-      if (log.stackTrace == null) {
+      if (log.getStack == null) {
         // Truncate long messages from chopper, but leave long stack traces
         message = message.substring(0, min(1024 * 5, message.length));
       }


### PR DESCRIPTION
Various fixes, mostly to the currently playing album highlighting.
- Fix theme transitions not being properly skipped while widgets are in background.
- Switch some widgets with unneeded states to stateless.
- Give album list items rounded corners.
- Fix musicscreentabview rebuilding on unrelated settings changes.
- Fix original queue source album being highlighted after queue restore when the currently playing item is not necessarily from that album.